### PR TITLE
chore: bump @opencollection/types and @opencollection/schema to 0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9319,7 +9319,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@monaco-editor/react": "^4.7.0",
-        "@opencollection/types": "0.9.1",
+        "@opencollection/types": "0.9.2",
         "@prantlf/jsonlint": "^16.0.0",
         "@reduxjs/toolkit": "^2.10.1",
         "@tailwindcss/vite": "^4.0.9",
@@ -9381,7 +9381,7 @@
     },
     "packages/oc-schema": {
       "name": "@opencollection/schema",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT"
     },
     "packages/oc-schema-explorer": {
@@ -9389,7 +9389,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
-        "@opencollection/schema": "0.9.1",
+        "@opencollection/schema": "0.9.2",
         "lucide-react": "^0.539.0",
         "monaco-editor": "^0.47.0",
         "react": "^18.2.0",
@@ -10679,7 +10679,7 @@
     },
     "packages/oc-types": {
       "name": "@opencollection/types",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.0"

--- a/packages/oc-docs/package.json
+++ b/packages/oc-docs/package.json
@@ -58,7 +58,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@monaco-editor/react": "^4.7.0",
-    "@opencollection/types": "0.9.1",
+    "@opencollection/types": "0.9.2",
     "@prantlf/jsonlint": "^16.0.0",
     "@reduxjs/toolkit": "^2.10.1",
     "@tailwindcss/vite": "^4.0.9",

--- a/packages/oc-schema-explorer/package.json
+++ b/packages/oc-schema-explorer/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
-    "@opencollection/schema": "0.9.1",
+    "@opencollection/schema": "0.9.2",
     "lucide-react": "^0.539.0",
     "monaco-editor": "^0.47.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- Bumps `@opencollection/types` and `@opencollection/schema` from `0.9.1` to `0.9.2`.
- Updates the consumer packages (`oc-docs`, `oc-schema-explorer`) and `package-lock.json` to pick up the new versions across the workspace.

## Test plan
- [ ] `npm install` completes cleanly
- [ ] `oc-docs` builds and runs
- [ ] `oc-schema-explorer` builds and runs
