### PR TITLE
feat(oc-types): add per-environment external secrets types

### DIFF
--- a/packages/oc-schema/src/opencollection.schema.json
+++ b/packages/oc-schema/src/opencollection.schema.json
@@ -2425,6 +2425,9 @@
             ]
           }
         },
+        "externalSecrets": {
+          "$ref": "#/$defs/ExternalSecrets"
+        },
         "clientCertificates": {
           "type": "array",
           "description": "Array of client certificates for mutual TLS authentication",
@@ -2502,6 +2505,114 @@
         }
       },
       "required": ["secret"],
+      "additionalProperties": false
+    },
+    "ExternalSecrets": {
+      "type": "object",
+      "description": "A block of external secrets resolved from a secret provider for an environment",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "hashicorp-vault-cloud",
+            "hashicorp-vault-server",
+            "aws-secrets-manager",
+            "azure-key-vault"
+          ],
+          "description": "The secret provider that resolves these external secrets"
+        },
+        "variables": {
+          "type": "array",
+          "description": "Array of external secret variables resolved from the provider",
+          "items": {
+            "$ref": "#/$defs/ExternalSecretVariable"
+          }
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "ExternalSecretVariable": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/HashicorpVaultExternalSecret"
+        },
+        {
+          "$ref": "#/$defs/AwsSecretsManagerExternalSecret"
+        },
+        {
+          "$ref": "#/$defs/AzureKeyVaultExternalSecret"
+        }
+      ],
+      "description": "An external secret variable, shaped per the secret provider that resolves it"
+    },
+    "HashicorpVaultExternalSecret": {
+      "type": "object",
+      "description": "An external secret resolved from HashiCorp Vault",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The variable name"
+        },
+        "description": {
+          "$ref": "#/$defs/Description"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether the external secret is disabled"
+        },
+        "path": {
+          "type": "string",
+          "description": "The path of the secret within HashiCorp Vault"
+        }
+      },
+      "required": ["name", "path"],
+      "additionalProperties": false
+    },
+    "AwsSecretsManagerExternalSecret": {
+      "type": "object",
+      "description": "An external secret resolved from AWS Secrets Manager",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The variable name"
+        },
+        "description": {
+          "$ref": "#/$defs/Description"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether the external secret is disabled"
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The name of the secret within AWS Secrets Manager"
+        }
+      },
+      "required": ["name", "secretName"],
+      "additionalProperties": false
+    },
+    "AzureKeyVaultExternalSecret": {
+      "type": "object",
+      "description": "An external secret resolved from Azure Key Vault",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The variable name"
+        },
+        "description": {
+          "$ref": "#/$defs/Description"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether the external secret is disabled"
+        },
+        "vaultName": {
+          "type": "string",
+          "description": "The name of the Azure Key Vault that holds the secret"
+        }
+      },
+      "required": ["name", "vaultName"],
       "additionalProperties": false
     },
     "VariableValue": {

--- a/packages/oc-spec-site/src/components/Content.jsx
+++ b/packages/oc-spec-site/src/components/Content.jsx
@@ -12,6 +12,7 @@ import AuthType from './sections/AuthType'
 import RequestBody from './sections/RequestBody'
 import BodyType from './sections/BodyType'
 import Variables from './sections/Variables'
+import ExternalSecrets from './sections/ExternalSecrets'
 import Assertions from './sections/Assertions'
 import ScriptsLifecycle from './sections/ScriptsLifecycle'
 import PropertyTable from './PropertyTable'
@@ -85,6 +86,8 @@ function Content({ section, schema }) {
         return <BodyType bodyType={section} schema={schema} />
       case 'variables':
         return <Variables schema={schema} />
+      case 'external-secrets':
+        return <ExternalSecrets schema={schema} />
       case 'assertions':
         return <Assertions schema={schema} />
       case 'scripts-lifecycle':

--- a/packages/oc-spec-site/src/components/Sidebar.jsx
+++ b/packages/oc-spec-site/src/components/Sidebar.jsx
@@ -87,6 +87,7 @@ const navItems = [
     ]
   },
   { id: 'variables', label: 'Variables' },
+  { id: 'external-secrets', label: 'External Secrets' },
   { id: 'assertions', label: 'Assertions' },
   { id: 'scripts-lifecycle', label: 'Scripts & Lifecycle' },
 ]

--- a/packages/oc-spec-site/src/components/sections/Environments.jsx
+++ b/packages/oc-spec-site/src/components/sections/Environments.jsx
@@ -8,7 +8,7 @@ function Environments({ schema }) {
   const theme = useTheme();
   const { typography, spacing } = theme;
   const environment = schema.$defs.Environment;
-  
+
   const example = {
     name: "Production",
     description: "Production environment configuration",
@@ -22,14 +22,14 @@ function Environments({ schema }) {
     <section>
       <h2 className={typography.heading.h2}>Environments</h2>
       <p className={`${typography.body.default} ${spacing.element}`}>Environments allow you to define different sets of variables for different contexts (development, staging, production, etc.).</p>
-      
+
       <h3 className={`${typography.heading.h3} ${spacing.paragraph}`}>Environment Properties</h3>
-      <PropertyTable 
+      <PropertyTable
         properties={environment.properties}
         order={Object.keys(environment.properties)}
         required={environment.required}
       />
-      
+
       <h3 className={`${typography.heading.h3} ${spacing.paragraph}`}>Example</h3>
       <CodeBlock code={convertToYaml(example)} language="yaml" />
     </section>

--- a/packages/oc-spec-site/src/components/sections/ExternalSecrets.jsx
+++ b/packages/oc-spec-site/src/components/sections/ExternalSecrets.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import PropertyTable from '../PropertyTable'
+import CodeBlock from '../CodeBlock'
+import { useTheme } from '../../theme/ThemeProvider'
+import { convertToYaml } from '../../utils/yamlConverter'
+
+function ExternalSecrets({ schema }) {
+  const theme = useTheme();
+  const { typography, spacing } = theme;
+  const externalSecrets = schema.$defs.ExternalSecrets;
+  const secretProviders = externalSecrets.properties.type.enum;
+
+  const secretVariants = [
+    { label: 'HashiCorp Vault', def: schema.$defs.HashicorpVaultExternalSecret },
+    { label: 'AWS Secrets Manager', def: schema.$defs.AwsSecretsManagerExternalSecret },
+    { label: 'Azure Key Vault', def: schema.$defs.AzureKeyVaultExternalSecret }
+  ];
+
+  const example = {
+    type: "hashicorp-vault-server",
+    variables: [
+      {
+        name: "apiKey",
+        path: "secret/data/production/api-key",
+        description: "API key resolved from HashiCorp Vault"
+      }
+    ]
+  };
+
+  return (
+    <section>
+      <h2 className={typography.heading.h2}>External Secrets</h2>
+      <p className={`${typography.body.default} ${spacing.element}`}>External secrets let an environment reference secrets that are resolved at runtime from a secret provider, instead of storing their values inline. Each environment can declare a single <code>externalSecrets</code> block with a provider <code>type</code> and its <code>variables</code>.</p>
+
+      <h3 className={`${typography.heading.h3} ${spacing.paragraph}`}>Properties</h3>
+      <PropertyTable
+        properties={externalSecrets.properties}
+        order={Object.keys(externalSecrets.properties)}
+        required={externalSecrets.required}
+      />
+
+      <h3 className={`${typography.heading.h3} ${spacing.paragraph}`}>Supported Providers</h3>
+      <p className={`${typography.body.default} ${spacing.element}`}>The <code>type</code> field selects the provider that resolves the secrets.</p>
+      <div className={`flex flex-wrap gap-2 ${spacing.element}`}>
+        {secretProviders.map(provider => (
+          <span key={provider} className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-gray-100 text-gray-800">{provider}</span>
+        ))}
+      </div>
+
+      <h3 className={`${typography.heading.h3} ${spacing.paragraph}`}>External Secret Variables</h3>
+      <p className={`${typography.body.default} ${spacing.element}`}>Each entry in <code>variables</code> is shaped by the provider that resolves it. Every variant shares a <code>name</code>, optional <code>description</code>, and <code>disabled</code> flag, plus a provider-specific reference to the secret.</p>
+
+      {secretVariants.map(({ label, def }) => (
+        <div key={label}>
+          <h4 className="text-base font-semibold mb-2">{label}</h4>
+          <PropertyTable
+            properties={def.properties}
+            order={Object.keys(def.properties)}
+            required={def.required}
+          />
+        </div>
+      ))}
+
+      <h3 className={`${typography.heading.h3} ${spacing.paragraph}`}>Example</h3>
+      <CodeBlock code={convertToYaml(example)} language="yaml" />
+    </section>
+  )
+}
+
+export default ExternalSecrets

--- a/packages/oc-spec-site/src/schema.json
+++ b/packages/oc-spec-site/src/schema.json
@@ -2232,6 +2232,9 @@
             ]
           }
         },
+        "externalSecrets": {
+          "$ref": "#/$defs/ExternalSecrets"
+        },
         "clientCertificates": {
           "type": "array",
           "description": "Array of client certificates for mutual TLS authentication",
@@ -2309,6 +2312,114 @@
         }
       },
       "required": ["secret"],
+      "additionalProperties": false
+    },
+    "ExternalSecrets": {
+      "type": "object",
+      "description": "A block of external secrets resolved from a secret provider for an environment",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "hashicorp-vault-cloud",
+            "hashicorp-vault-server",
+            "aws-secrets-manager",
+            "azure-key-vault"
+          ],
+          "description": "The secret provider that resolves these external secrets"
+        },
+        "variables": {
+          "type": "array",
+          "description": "Array of external secret variables resolved from the provider",
+          "items": {
+            "$ref": "#/$defs/ExternalSecretVariable"
+          }
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "ExternalSecretVariable": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/HashicorpVaultExternalSecret"
+        },
+        {
+          "$ref": "#/$defs/AwsSecretsManagerExternalSecret"
+        },
+        {
+          "$ref": "#/$defs/AzureKeyVaultExternalSecret"
+        }
+      ],
+      "description": "An external secret variable, shaped per the secret provider that resolves it"
+    },
+    "HashicorpVaultExternalSecret": {
+      "type": "object",
+      "description": "An external secret resolved from HashiCorp Vault",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The variable name"
+        },
+        "description": {
+          "$ref": "#/$defs/Description"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether the external secret is disabled"
+        },
+        "path": {
+          "type": "string",
+          "description": "The path of the secret within HashiCorp Vault"
+        }
+      },
+      "required": ["name", "path"],
+      "additionalProperties": false
+    },
+    "AwsSecretsManagerExternalSecret": {
+      "type": "object",
+      "description": "An external secret resolved from AWS Secrets Manager",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The variable name"
+        },
+        "description": {
+          "$ref": "#/$defs/Description"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether the external secret is disabled"
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The name of the secret within AWS Secrets Manager"
+        }
+      },
+      "required": ["name", "secretName"],
+      "additionalProperties": false
+    },
+    "AzureKeyVaultExternalSecret": {
+      "type": "object",
+      "description": "An external secret resolved from Azure Key Vault",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The variable name"
+        },
+        "description": {
+          "$ref": "#/$defs/Description"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether the external secret is disabled"
+        },
+        "vaultName": {
+          "type": "string",
+          "description": "The name of the Azure Key Vault that holds the secret"
+        }
+      },
+      "required": ["name", "vaultName"],
       "additionalProperties": false
     },
     "VariableValue": {

--- a/packages/oc-types/src/common/variables.ts
+++ b/packages/oc-types/src/common/variables.ts
@@ -35,3 +35,37 @@ export interface SecretVariable {
   disabled?: boolean;
   type?: VariableValueType;
 }
+
+interface BaseExternalSecretVariable {
+  name: string;
+  description?: Description;
+  disabled?: boolean;
+}
+
+export interface HashicorpVaultExternalSecret extends BaseExternalSecretVariable {
+  path: string;
+}
+
+export interface AwsSecretsManagerExternalSecret extends BaseExternalSecretVariable {
+  secretName: string;
+}
+
+export interface AzureKeyVaultExternalSecret extends BaseExternalSecretVariable {
+  vaultName: string;
+}
+
+export type ExternalSecretVariable =
+  | HashicorpVaultExternalSecret
+  | AwsSecretsManagerExternalSecret
+  | AzureKeyVaultExternalSecret;
+
+export type SecretProviderType =
+  | 'hashicorp-vault-cloud'
+  | 'hashicorp-vault-server'
+  | 'aws-secrets-manager'
+  | 'azure-key-vault';
+
+export interface ExternalSecrets {
+  type: SecretProviderType;
+  variables?: ExternalSecretVariable[];
+}

--- a/packages/oc-types/src/config/environments.ts
+++ b/packages/oc-types/src/config/environments.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Description } from '../common/description';
-import type { Variable, SecretVariable } from '../common/variables';
+import type { Variable, SecretVariable, ExternalSecrets } from '../common/variables';
 import type { ClientCertificate } from './certificates';
 
 export interface Environment {
@@ -11,6 +11,7 @@ export interface Environment {
   color?: string;
   description?: Description;
   variables?: (Variable | SecretVariable)[];
+  externalSecrets?: ExternalSecrets;
   clientCertificates?: ClientCertificate[];
   extends?: string;
   dotEnvFilePath?: string;


### PR DESCRIPTION
Add the on-disk types for environment-scoped external secrets: the SecretProviderType union (hashicorp-vault-cloud/server, aws-secrets-manager, azure-key-vault), per-provider secret variable shapes (path / secretName / vaultName), and the ExternalSecrets block on Environment.