### PR TITLE
feat(size/XXL):Environment UI revamp changes

### DIFF
--- a/packages/oc-docs/e2e/components/environments/environment-table.component.ts
+++ b/packages/oc-docs/e2e/components/environments/environment-table.component.ts
@@ -1,0 +1,33 @@
+import type { Locator } from '@playwright/test';
+import { BaseComponent } from '../base.component';
+
+export class EnvironmentTableComponent extends BaseComponent {
+  readonly root = this.page.getByTestId('environment-table');
+  readonly variableRows = this.page.getByTestId('environment-variable-row');
+  readonly secretVariableRows = this.page.getByTestId('environment-secret-variable-row');
+  readonly externalSecretRows = this.page.getByTestId('environment-external-secret-row');
+
+  columnHeader(key: string): Locator {
+    return this.root.getByTestId(`table-header-${key}`);
+  }
+
+  variableRow(name: string): Locator {
+    return this.variableRows.filter({ hasText: name });
+  }
+
+  secretVariableRow(name: string): Locator {
+    return this.secretVariableRows.filter({ hasText: name });
+  }
+
+  externalSecretRow(name: string): Locator {
+    return this.externalSecretRows.filter({ hasText: name });
+  }
+
+  valueOf(name: string): Locator {
+    return this.variableRow(name).getByTestId('table-cell-value');
+  }
+
+  dataTypeOf(name: string): Locator {
+    return this.variableRow(name).getByTestId('table-cell-type');
+  }
+}

--- a/packages/oc-docs/e2e/pages/environments.page.ts
+++ b/packages/oc-docs/e2e/pages/environments.page.ts
@@ -1,0 +1,27 @@
+import type { Locator } from '@playwright/test';
+import { BasePage } from './base.page';
+import { SidebarComponent } from '../components/sidebar.component';
+import { EnvironmentTableComponent } from '../components/environments/environment-table.component';
+
+export class EnvironmentsPage extends BasePage {
+  readonly root = this.page.getByTestId('environments-page');
+
+  readonly sidebar = new SidebarComponent(this.page);
+  readonly title = this.page.getByTestId('environments-title');
+  readonly tabs = this.page.getByTestId('environment-tab');
+  readonly table = new EnvironmentTableComponent(this.page);
+  readonly variablesGroup = this.page.getByTestId('environment-variables');
+  readonly secretVariablesGroup = this.page.getByTestId('environment-secret-variables');
+  readonly externalSecretsGroup = this.page.getByTestId('environment-external-secrets');
+  readonly emptyState = this.page.getByTestId('environments-empty');
+
+  async open(): Promise<void> {
+    await this.navigate('/');
+    await this.page.getByTestId('sidebar-environments-link').click();
+    await this.root.waitFor({ state: 'visible' });
+  }
+
+  tab(name: string): Locator {
+    return this.tabs.filter({ hasText: name });
+  }
+}

--- a/packages/oc-docs/e2e/pages/environments.page.ts
+++ b/packages/oc-docs/e2e/pages/environments.page.ts
@@ -4,16 +4,17 @@ import { SidebarComponent } from '../components/sidebar.component';
 import { EnvironmentTableComponent } from '../components/environments/environment-table.component';
 
 export class EnvironmentsPage extends BasePage {
-  readonly root = this.page.getByTestId('environments-page');
 
-  readonly sidebar = new SidebarComponent(this.page);
+  readonly root = this.page.getByTestId('environments-page');
   readonly title = this.page.getByTestId('environments-title');
   readonly tabs = this.page.getByTestId('environment-tab');
-  readonly table = new EnvironmentTableComponent(this.page);
   readonly variablesGroup = this.page.getByTestId('environment-variables');
   readonly secretVariablesGroup = this.page.getByTestId('environment-secret-variables');
   readonly externalSecretsGroup = this.page.getByTestId('environment-external-secrets');
   readonly emptyState = this.page.getByTestId('environments-empty');
+
+  readonly table = new EnvironmentTableComponent(this.page);
+  readonly sidebar = new SidebarComponent(this.page);
 
   async open(): Promise<void> {
     await this.navigate('/');

--- a/packages/oc-docs/e2e/playwright/pages.fixture.ts
+++ b/packages/oc-docs/e2e/playwright/pages.fixture.ts
@@ -1,5 +1,6 @@
 import { test as base } from '@playwright/test';
 import { OverviewPage } from '../pages/overview.page';
+import { EnvironmentsPage } from '../pages/environments.page';
 import { RequestPage } from '../pages/request.page';
 import { ScriptPage } from '../pages/script.page';
 import { UnsupportedRequestPage } from '../pages/unsupported-request.page';
@@ -10,6 +11,7 @@ import { PageHeaderComponent } from '../components/layout/page-header.component'
 
 type Fixtures = {
   overviewPage: OverviewPage;
+  environmentsPage: EnvironmentsPage;
   requestPage: RequestPage;
   scriptPage: ScriptPage;
   unsupportedRequestPage: UnsupportedRequestPage;
@@ -22,8 +24,8 @@ export const test = base.extend<Fixtures>({
   overviewPage: async ({ page }, use) => {
     await use(new OverviewPage(page));
   },
-  pageHeader: async ({ page }, use) => {
-    await use(new PageHeaderComponent(page));
+  environmentsPage: async ({ page }, use) => {
+    await use(new EnvironmentsPage(page));
   },
   requestPage: async ({ page }, use) => {
     await use(new RequestPage(page));
@@ -36,6 +38,9 @@ export const test = base.extend<Fixtures>({
   },
   sidebar: async ({ page }, use) => {
     await use(new SidebarComponent(page));
+  },
+  pageHeader: async ({ page }, use) => {
+    await use(new PageHeaderComponent(page));
   },
   themeToggle: async ({ page }, use) => {
     await use(new ThemeToggleComponent(page));

--- a/packages/oc-docs/e2e/tests/environments/environments.spec.ts
+++ b/packages/oc-docs/e2e/tests/environments/environments.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '../../playwright';
+
+test.describe('Environments page', () => {
+  test.beforeEach(async ({ environmentsPage }) => {
+    await environmentsPage.open();
+  });
+
+  test('opens from the sidebar and shows a tab per environment', async ({ environmentsPage }) => {
+    await expect(environmentsPage.title).toHaveText('Environments');
+    await expect(environmentsPage.tabs).toHaveCount(2);
+    await expect(environmentsPage.tab('Local')).toBeVisible();
+    await expect(environmentsPage.tab('Prod')).toBeVisible();
+  });
+
+  test('selects the first environment by default', async ({ environmentsPage }) => {
+    await expect(environmentsPage.tab('Local')).toHaveAttribute('aria-selected', 'true');
+    await expect(environmentsPage.tab('Prod')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('lists the active environment variables with their value and data type', async ({ environmentsPage }) => {
+    const { table } = environmentsPage;
+
+    await test.step('the Variables group is shown', async () => {
+      await expect(environmentsPage.variablesGroup).toBeVisible();
+    });
+
+    await test.step('the host variable shows its value and a String data type', async () => {
+      await expect(table.variableRow('host')).toBeVisible();
+      await expect(table.valueOf('host')).toContainText('http://localhost:8081');
+      await expect(table.dataTypeOf('host')).toHaveText('String');
+    });
+  });
+
+  test('shows secret variables masked under a Secret Variables group', async ({ environmentsPage }) => {
+    const { table } = environmentsPage;
+    const row = table.secretVariableRow('bearer_auth_token');
+
+    await expect(environmentsPage.secretVariablesGroup).toBeVisible();
+    await expect(row).toBeVisible();
+    await expect(row).toContainText('Secret');
+    await expect(row).not.toContainText('your_secret_token');
+  });
+
+  test('switches the table when another environment tab is selected', async ({ environmentsPage }) => {
+    const { table } = environmentsPage;
+
+    await expect(table.valueOf('host')).toContainText('http://localhost:8081');
+
+    await environmentsPage.tab('Prod').click();
+
+    await expect(environmentsPage.tab('Prod')).toHaveAttribute('aria-selected', 'true');
+    await expect(table.valueOf('host')).toContainText('https://echo.usebruno.com');
+  });
+
+  test('renders an accessible columnar table with Name, Value and Data Type headers', async ({ environmentsPage }) => {
+    const { table } = environmentsPage;
+    await expect(table.columnHeader('name')).toHaveText('Name');
+    await expect(table.columnHeader('value')).toHaveText('Value');
+    await expect(table.columnHeader('type')).toHaveText('Data Type');
+  });
+
+  test('hides the External Secret Variables section when the environment has none', async ({ environmentsPage }) => {
+    await expect(environmentsPage.tab('Local')).toHaveAttribute('aria-selected', 'true');
+    await expect(environmentsPage.externalSecretsGroup).toBeHidden();
+  });
+
+  test('shows external secrets with the manager label and reference for the Prod environment', async ({
+    environmentsPage
+  }) => {
+    const { table } = environmentsPage;
+
+    await environmentsPage.tab('Prod').click();
+
+    await test.step('the External Secret Variables group is shown with its manager', async () => {
+      await expect(environmentsPage.externalSecretsGroup).toBeVisible();
+      await expect(environmentsPage.externalSecretsGroup).toContainText('AWS Secrets Manager');
+    });
+
+    await test.step('each external secret lists its name and secret reference', async () => {
+      await expect(table.externalSecretRow('dbPassword')).toContainText('prod/db/credentials');
+      await expect(table.externalSecretRow('apiKey')).toContainText('prod/payment-gateway/api-key');
+    });
+
+    await test.step('external secrets without a type show an empty data type', async () => {
+      await expect(table.externalSecretRow('dbPassword')).toContainText('(empty)');
+    });
+  });
+});

--- a/packages/oc-docs/e2e/tests/overview/overview.spec.ts
+++ b/packages/oc-docs/e2e/tests/overview/overview.spec.ts
@@ -5,9 +5,9 @@ test.describe('Collection Overview', () => {
     await overviewPage.goto();
   });
 
-  test('header shows the collection version ("version : 1.0.0") and name ("Bruno Testbench")', async ({ overviewPage }) => {
+  test('header shows the collection version ("Version : 1.0.0") and name ("Bruno Testbench")', async ({ overviewPage }) => {
     await test.step('the raw version is shown, unformatted', async () => {
-      await expect(overviewPage.header.collectionVersion).toHaveText('version : 1.0.0');
+      await expect(overviewPage.header.collectionVersion).toHaveText('Version : 1.0.0');
     });
 
     await test.step('the collection name is shown as the page title', async () => {

--- a/packages/oc-docs/playwright.config.ts
+++ b/packages/oc-docs/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     },
   ],
   webServer: {

--- a/packages/oc-docs/playwright.config.ts
+++ b/packages/oc-docs/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
   webServer: {

--- a/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
@@ -7,12 +7,17 @@ import OpenCollectionLogo from '../../../assets/opencollection-logo.svg';
 import { SidebarContainer, SidebarItems, SidebarItem } from './StyledWrapper';
 import ThemeToggle from '../../ThemeToggle/ThemeToggle';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import { toggleItem, expandFolders, selectDocsCollection } from '../../../store/slices/docs';
+import {
+  toggleItem,
+  expandFolders,
+  selectDocsCollection
+} from '../../../store/slices/docs';
 import { getItemType, getItemName, getHttpMethod, isFolder, isScriptFile } from '../../../utils/schemaHelpers';
 import { getItemUuid } from '../../../utils/itemUtils';
 import { useNavModel } from '../../../routing/hooks';
 import { normalizeSlug } from '../../../routing/resolve';
 import { OVERVIEW_SLUG, ENVIRONMENTS_SLUG, sortSiblings } from '../../../routing/navModel';
+import { GlobeIcon, BookIcon } from '../../../assets/icons';
 
 const Sidebar: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -154,18 +159,22 @@ const Sidebar: React.FC = () => {
         {/* Built-in pages */}
         <SidebarItem
           className={`flex items-center select-none text-sm cursor-pointer ${activeSlug === OVERVIEW_SLUG ? 'active' : ''}`}
+          data-testid="sidebar-overview-link"
           style={{ paddingLeft: '8px' }}
           onClick={() => goTo(OVERVIEW_SLUG)}
         >
+          <span className="sidebar-nav-icon"><BookIcon /></span>
           <div className="truncate flex-1">Overview</div>
         </SidebarItem>
 
         {hasEnvironments && (
           <SidebarItem
+            data-testid="sidebar-environments-link"
             className={`flex items-center select-none text-sm cursor-pointer ${activeSlug === ENVIRONMENTS_SLUG ? 'active' : ''}`}
             style={{ paddingLeft: '8px' }}
             onClick={() => goTo(ENVIRONMENTS_SLUG)}
           >
+            <span className="sidebar-nav-icon"><GlobeIcon /></span>
             <div className="truncate flex-1">Environments</div>
           </SidebarItem>
         )}

--- a/packages/oc-docs/src/components/Docs/Sidebar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Docs/Sidebar/StyledWrapper.ts
@@ -45,6 +45,24 @@ export const SidebarItems = styled.div`
   ${SidebarContainer}.compact & {
     padding: 0 4px;
   }
+
+  .sidebar-root-nav {
+    margin-bottom: 6px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .sidebar-nav-icon {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 8px;
+    flex-shrink: 0;
+    color: var(--text-tertiary);
+  }
+  .sidebar-nav-icon svg {
+    width: 15px;
+    height: 15px;
+  }
 `;
 
 export const SidebarItem = styled.div`

--- a/packages/oc-docs/src/components/EnvironmentLabel/EnvironmentLabel.spec.tsx
+++ b/packages/oc-docs/src/components/EnvironmentLabel/EnvironmentLabel.spec.tsx
@@ -1,25 +1,25 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
+import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { EnvironmentLabel } from './EnvironmentLabel';
 
 describe('EnvironmentLabel', () => {
-  it('renders the environment name', () => {
-    const html = renderToStaticMarkup(<EnvironmentLabel name="Development" />);
-    expect(html).toContain('Development');
-    expect(html).toContain('environment-label-dot');
+  it('renders the environment name and a color dot', () => {
+    const root = useRenderToDom(<EnvironmentLabel name="Development" />);
+    expect(root.querySelector('.environment-label-name')?.text.trim()).toBe('Development');
+    expect(root.querySelector('.environment-label-dot')).toBeTruthy();
   });
 
   it('applies the environment color to the dot', () => {
-    const html = renderToStaticMarkup(<EnvironmentLabel name="Prod" color="#dc2626" />);
-    expect(html).toContain('#dc2626');
+    const root = useRenderToDom(<EnvironmentLabel name="Prod" color="#dc2626" />);
+    expect(root.querySelector('.environment-label-dot')?.getAttribute('style')).toContain('#dc2626');
   });
 
-  it('forwards custom class names', () => {
-    const html = renderToStaticMarkup(
+  it('forwards custom class names to the root and the name', () => {
+    const root = useRenderToDom(
       <EnvironmentLabel name="Staging" className="env-tab" nameClassName="env-tab-name" />
     );
-    expect(html).toContain('env-tab');
-    expect(html).toContain('env-tab-name');
+    expect(root.querySelector('.environment-label.env-tab')).toBeTruthy();
+    expect(root.querySelector('.environment-label-name.env-tab-name')).toBeTruthy();
   });
 });

--- a/packages/oc-docs/src/components/EnvironmentLabel/EnvironmentLabel.spec.tsx
+++ b/packages/oc-docs/src/components/EnvironmentLabel/EnvironmentLabel.spec.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { EnvironmentLabel } from './EnvironmentLabel';
+
+describe('EnvironmentLabel', () => {
+  it('renders the environment name', () => {
+    const html = renderToStaticMarkup(<EnvironmentLabel name="Development" />);
+    expect(html).toContain('Development');
+    expect(html).toContain('environment-label-dot');
+  });
+
+  it('applies the environment color to the dot', () => {
+    const html = renderToStaticMarkup(<EnvironmentLabel name="Prod" color="#dc2626" />);
+    expect(html).toContain('#dc2626');
+  });
+
+  it('forwards custom class names', () => {
+    const html = renderToStaticMarkup(
+      <EnvironmentLabel name="Staging" className="env-tab" nameClassName="env-tab-name" />
+    );
+    expect(html).toContain('env-tab');
+    expect(html).toContain('env-tab-name');
+  });
+});

--- a/packages/oc-docs/src/components/EnvironmentLabel/EnvironmentLabel.tsx
+++ b/packages/oc-docs/src/components/EnvironmentLabel/EnvironmentLabel.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { StyledWrapper } from './StyledWrapper';
+
+interface EnvironmentLabelProps {
+  name: string;
+  color?: string;
+  className?: string;
+  nameClassName?: string;
+  testId?: string;
+}
+
+export const EnvironmentLabel: React.FC<EnvironmentLabelProps> = ({
+  name,
+  color,
+  className,
+  nameClassName,
+  testId
+}) => (
+  <StyledWrapper className={['environment-label', className].filter(Boolean).join(' ')} data-testid={testId}>
+    <span className="environment-label-dot" style={color ? { background: color } : undefined} />
+    <span className={['environment-label-name', nameClassName].filter(Boolean).join(' ')}>{name}</span>
+  </StyledWrapper>
+);
+
+export default EnvironmentLabel;

--- a/packages/oc-docs/src/components/EnvironmentLabel/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/EnvironmentLabel/StyledWrapper.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+
+  .environment-label-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--text-tertiary);
+  }
+
+  .environment-label-name {
+    color: inherit;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;

--- a/packages/oc-docs/src/components/OverviewEnvironments/EnvironmentSummaryItem/EnvironmentSummaryItem.tsx
+++ b/packages/oc-docs/src/components/OverviewEnvironments/EnvironmentSummaryItem/EnvironmentSummaryItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Environment } from '@opencollection/types/config/environments';
+import { EnvironmentLabel } from '../../EnvironmentLabel/EnvironmentLabel';
 import { StyledWrapper } from './StyledWrapper';
 
 const formatVariableCount = (count: number): string => `${count} variable${count === 1 ? '' : 's'}`;
@@ -12,11 +13,7 @@ interface EnvironmentSummaryItemProps {
 /** A single environment row: color dot, name, and variable count. Renders an `<li>`. */
 export const EnvironmentSummaryItem: React.FC<EnvironmentSummaryItemProps> = ({ environment, testId = 'environment-summary-item' }) => (
   <StyledWrapper className="environment-summary-item" data-testid={testId}>
-    <span
-      className="environment-summary-dot"
-      style={environment.color ? { background: environment.color } : undefined}
-    />
-    <span className="environment-summary-name">{environment.name}</span>
+    <EnvironmentLabel name={environment.name} color={environment.color} className="environment-summary-label" />
     <span className="environment-summary-spacer" />
     <span className="environment-summary-vars" data-testid={testId ? `${testId}-variable-count` : undefined}>
       {formatVariableCount(environment.variables?.length ?? 0)}

--- a/packages/oc-docs/src/components/OverviewEnvironments/EnvironmentSummaryItem/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/OverviewEnvironments/EnvironmentSummaryItem/StyledWrapper.ts
@@ -10,21 +10,10 @@ export const StyledWrapper = styled.li`
   font-size: 0.75rem;
   line-height: 1.125rem;
   letter-spacing: normal;
+  color: var(--oc-text);
 
   &:last-child {
     border-bottom: none;
-  }
-
-  .environment-summary-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    background: var(--text-tertiary);
-  }
-
-  .environment-summary-name {
-    color: var(--oc-text);
   }
 
   .environment-summary-spacer {

--- a/packages/oc-docs/src/components/PageWrapper/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/PageWrapper/StyledWrapper.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const StyledWrapper = styled.div`
-  max-width: 1200px;
+  max-width: 1280px;
   margin-inline: auto;
   padding: 0.9375rem 3rem;
 

--- a/packages/oc-docs/src/constants/environment.ts
+++ b/packages/oc-docs/src/constants/environment.ts
@@ -1,0 +1,17 @@
+import type { VariableValueType } from '@opencollection/types/common/variables';
+
+export const TYPE_LABELS: Record<VariableValueType, string> = {
+  string: 'String',
+  number: 'Number',
+  boolean: 'Boolean',
+  null: 'Null',
+  object: 'Object'
+};
+
+export const MANAGER_LABELS: Record<string, string> = {
+  vault: 'Vault',
+  'vault-server': 'Vault Server',
+  'vault-cloud': 'Vault Cloud',
+  'aws-secrets-manager': 'AWS Secrets Manager',
+  'azure-key-vault': 'Azure Key Vault'
+};

--- a/packages/oc-docs/src/constants/index.ts
+++ b/packages/oc-docs/src/constants/index.ts
@@ -11,3 +11,5 @@ export {
 } from './request';
 
 export { TEMPLATE_VARIABLE_BODY_PATTERN, TEMPLATE_VARIABLE_SOURCE_PATTERN } from './regex';
+
+export { TYPE_LABELS, MANAGER_LABELS } from './environment';

--- a/packages/oc-docs/src/hooks/useRenderToDom.ts
+++ b/packages/oc-docs/src/hooks/useRenderToDom.ts
@@ -1,0 +1,9 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { parse } from 'node-html-parser';
+import type { ReactElement } from 'react';
+
+export const useRenderToDom = (ui: ReactElement) => {
+  const root = parse(renderToStaticMarkup(ui));
+  root.querySelectorAll('style').forEach((node) => node.remove());
+  return root;
+};

--- a/packages/oc-docs/src/pages/Environments/Environments.spec.tsx
+++ b/packages/oc-docs/src/pages/Environments/Environments.spec.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import type { OpenCollection } from '@opencollection/types';
+import { Environments } from './Environments';
+
+describe('Environments', () => {
+  it('renders a tab per environment and the active environment variable table', () => {
+    const collection: OpenCollection = {
+      info: { name: 'Hotel Booking API', version: '1.0.0' },
+      config: {
+        environments: [
+          {
+            name: 'Development',
+            color: '#16a34a',
+            variables: [
+              { name: 'baseUrl', value: 'https://api.dev' },
+              { name: 'authToken', secret: true, type: 'string' }
+            ]
+          },
+          { name: 'Prod', variables: [{ name: 'baseUrl', value: 'https://api.prod' }] }
+        ]
+      }
+    };
+
+    const html = renderToStaticMarkup(<Environments collection={collection} />);
+
+    expect(html).toContain('Environments');
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('Development');
+    expect(html).toContain('Prod');
+    expect(html).toContain('role="tabpanel"');
+    expect(html).toContain('Variables');
+    expect(html).toContain('Secret Variables');
+    expect(html).toContain('baseUrl');
+    expect(html).toContain('https://api.dev');
+    expect(html).toContain('Secret');
+  });
+
+  it('renders an external secret variables section with the manager label', () => {
+    const collection = {
+      info: { name: 'API', version: '1.0.0' },
+      config: {
+        environments: [
+          {
+            name: 'Prod',
+            variables: [{ name: 'baseUrl', value: 'https://api.prod' }],
+            externalSecrets: {
+              type: 'aws-secrets-manager',
+              variables: [{ name: 'dbPassword', secretName: 'prod/db/credentials', enabled: true }]
+            }
+          }
+        ]
+      }
+    } as unknown as OpenCollection;
+
+    const html = renderToStaticMarkup(<Environments collection={collection} />);
+
+    expect(html).toContain('External Secret Variables');
+    expect(html).toContain('AWS Secrets Manager');
+    expect(html).toContain('dbPassword');
+    expect(html).toContain('prod/db/credentials');
+  });
+
+  it('omits sections that have no entries', () => {
+    const collection: OpenCollection = {
+      info: { name: 'API', version: '1.0.0' },
+      config: { environments: [{ name: 'Dev', variables: [{ name: 'baseUrl', value: 'x' }] }] }
+    };
+
+    const html = renderToStaticMarkup(<Environments collection={collection} />);
+
+    expect(html).toContain('Variables');
+    expect(html).not.toContain('Secret Variables');
+    expect(html).not.toContain('External Secret Variables');
+  });
+
+  it('shows "(empty)" for both the value and the data type when a variable has no value', () => {
+    const collection: OpenCollection = {
+      info: { name: 'API', version: '1.0.0' },
+      config: { environments: [{ name: 'Dev', variables: [{ name: 'transactionId', value: '' }] }] }
+    };
+
+    const html = renderToStaticMarkup(<Environments collection={collection} />);
+    const matches = html.match(/\(empty\)/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  it('renders an empty state when there are no environments', () => {
+    const collection: OpenCollection = { info: { name: 'Empty API', version: '1.0.0' } };
+    const html = renderToStaticMarkup(<Environments collection={collection} />);
+    expect(html).toContain('No environments configured');
+    expect(html).not.toContain('role="tablist"');
+  });
+});

--- a/packages/oc-docs/src/pages/Environments/Environments.spec.tsx
+++ b/packages/oc-docs/src/pages/Environments/Environments.spec.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
 import type { OpenCollection } from '@opencollection/types';
+import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { Environments } from './Environments';
+
+const groupLabels = (root: ReturnType<typeof useRenderToDom>) =>
+  root.querySelectorAll('.table-group-label').map((el) => el.text.trim());
+
+const cellText = (root: ReturnType<typeof useRenderToDom>, selector: string) =>
+  root.querySelectorAll(selector).map((el) => el.text.trim());
 
 describe('Environments', () => {
   it('renders a tab per environment and the active environment variable table', () => {
@@ -23,18 +29,17 @@ describe('Environments', () => {
       }
     };
 
-    const html = renderToStaticMarkup(<Environments collection={collection} />);
+    const root = useRenderToDom(<Environments collection={collection} />);
 
-    expect(html).toContain('Environments');
-    expect(html).toContain('role="tablist"');
-    expect(html).toContain('Development');
-    expect(html).toContain('Prod');
-    expect(html).toContain('role="tabpanel"');
-    expect(html).toContain('Variables');
-    expect(html).toContain('Secret Variables');
-    expect(html).toContain('baseUrl');
-    expect(html).toContain('https://api.dev');
-    expect(html).toContain('Secret');
+    expect(root.querySelector('[data-testid="environments-title"]')?.text.trim()).toBe('Environments');
+    expect(root.querySelector('[role="tablist"]')).toBeTruthy();
+    expect(root.querySelectorAll('[role="tab"]').map((t) => t.text.trim())).toEqual(['Development', 'Prod']);
+    expect(root.querySelector('[role="tabpanel"]')).toBeTruthy();
+
+    expect(groupLabels(root)).toEqual(['Variables', 'Secret Variables']);
+    expect(cellText(root, '.environment-name')).toContain('baseUrl');
+    expect(cellText(root, '.environment-value')).toContain('https://api.dev');
+    expect(root.querySelector('.environment-secret')?.text).toContain('Secret');
   });
 
   it('renders an external secret variables section with the manager label', () => {
@@ -54,12 +59,12 @@ describe('Environments', () => {
       }
     } as unknown as OpenCollection;
 
-    const html = renderToStaticMarkup(<Environments collection={collection} />);
+    const root = useRenderToDom(<Environments collection={collection} />);
 
-    expect(html).toContain('External Secret Variables');
-    expect(html).toContain('AWS Secrets Manager');
-    expect(html).toContain('dbPassword');
-    expect(html).toContain('prod/db/credentials');
+    expect(groupLabels(root)).toContain('External Secret Variables');
+    expect(root.querySelector('.table-group-meta')?.text.trim()).toBe('AWS Secrets Manager');
+    expect(cellText(root, '.environment-name')).toContain('dbPassword');
+    expect(cellText(root, '.environment-value')).toContain('prod/db/credentials');
   });
 
   it('omits sections that have no entries', () => {
@@ -68,11 +73,8 @@ describe('Environments', () => {
       config: { environments: [{ name: 'Dev', variables: [{ name: 'baseUrl', value: 'x' }] }] }
     };
 
-    const html = renderToStaticMarkup(<Environments collection={collection} />);
-
-    expect(html).toContain('Variables');
-    expect(html).not.toContain('Secret Variables');
-    expect(html).not.toContain('External Secret Variables');
+    const root = useRenderToDom(<Environments collection={collection} />);
+    expect(groupLabels(root)).toEqual(['Variables']);
   });
 
   it('shows "(empty)" for both the value and the data type when a variable has no value', () => {
@@ -81,15 +83,14 @@ describe('Environments', () => {
       config: { environments: [{ name: 'Dev', variables: [{ name: 'transactionId', value: '' }] }] }
     };
 
-    const html = renderToStaticMarkup(<Environments collection={collection} />);
-    const matches = html.match(/\(empty\)/g) ?? [];
-    expect(matches.length).toBe(2);
+    const root = useRenderToDom(<Environments collection={collection} />);
+    expect(root.querySelectorAll('.environment-empty').length).toBe(2);
   });
 
   it('renders an empty state when there are no environments', () => {
     const collection: OpenCollection = { info: { name: 'Empty API', version: '1.0.0' } };
-    const html = renderToStaticMarkup(<Environments collection={collection} />);
-    expect(html).toContain('No environments configured');
-    expect(html).not.toContain('role="tablist"');
+    const root = useRenderToDom(<Environments collection={collection} />);
+    expect(root.querySelector('.empty-state-heading')?.text.trim()).toBe('No environments configured');
+    expect(root.querySelector('[role="tablist"]')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/pages/Environments/Environments.tsx
+++ b/packages/oc-docs/src/pages/Environments/Environments.tsx
@@ -1,12 +1,197 @@
-import React from 'react';
-import type { PageProps } from '../../routing/types';
+import React, { useId, useMemo, useRef, useState } from 'react';
+import type { OpenCollection } from '@opencollection/types';
+import { getEnvironmentVariables } from '../../utils/environments';
+import { Table, type TableColumn, type TableGroup } from '../../ui/Table/Table';
+import { EnvironmentLabel } from '../../components/EnvironmentLabel/EnvironmentLabel';
+import { VariableText } from '../../components/VariableText/VariableText';
+import { EmptyState } from '../../ui/EmptyState/EmptyState';
 import { PageWrapper } from '../../components/PageWrapper/PageWrapper';
-import EnvironmentsView from '../../components/PlaygroundDrawer/DrawerContent/Views/EnvironmentsView/EnvironmentsView';
+import { Heading } from '../../components/Heading/Heading';
+import { GlobeIcon, EyeOffIcon } from '../../assets/icons';
+import { StyledWrapper } from './StyledWrapper';
 
-export const Environments: React.FC<PageProps> = ({ collection }) => (
-  <PageWrapper>
-    <EnvironmentsView collection={collection} />
-  </PageWrapper>
+const COLUMNS: TableColumn[] = [
+  { key: 'name', header: 'Name', width: '13rem' },
+  { key: 'value', header: 'Value' },
+  { key: 'type', header: 'Data Type', width: '9rem' }
+];
+
+const emptyCell = <span className="environment-empty">(empty)</span>;
+
+const nameCell = (name: string): React.ReactNode => <span className="environment-name">{name}</span>;
+
+const valueCell = (value: string): React.ReactNode =>
+  value ? (
+    <span className="environment-value">
+      <VariableText value={value} />
+    </span>
+  ) : (
+    emptyCell
+  );
+
+const secretCell: React.ReactNode = (
+  <span className="environment-secret">
+    <EyeOffIcon />
+    Secret
+  </span>
 );
+
+const typeCell = (dataType: string): React.ReactNode =>
+  dataType ? <span className="environment-type">{dataType}</span> : emptyCell;
+
+interface EnvironmentsProps {
+  collection: OpenCollection;
+}
+
+export const Environments: React.FC<EnvironmentsProps> = ({ collection }) => {
+  const environments = collection.config?.environments ?? [];
+  const [activeIndex, setActiveIndex] = useState(0);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const tablistId = useId();
+  const panelId = useId();
+
+  const activeTab = environments.length ? Math.min(activeIndex, environments.length - 1) : 0;
+  const active = environments[activeTab];
+
+  const groups = useMemo<TableGroup[]>(() => {
+    if (!active) return [];
+    const { variables, secretVariables, externalSecrets } = getEnvironmentVariables(active);
+    const result: TableGroup[] = [];
+
+    if (variables.length) {
+      result.push({
+        id: 'variables',
+        label: 'Variables',
+        badge: variables.length,
+        testId: 'environment-variables',
+        rows: variables.map((row) => ({
+          id: `var-${row.name}`,
+          rowHeaderKey: 'name',
+          disabled: row.disabled,
+          testId: 'environment-variable-row',
+          cells: {
+            name: nameCell(row.name),
+            value: valueCell(row.value),
+            type: typeCell(row.dataType)
+          }
+        }))
+      });
+    }
+
+    if (secretVariables.length) {
+      result.push({
+        id: 'secret-variables',
+        label: 'Secret Variables',
+        badge: secretVariables.length,
+        testId: 'environment-secret-variables',
+        rows: secretVariables.map((row) => ({
+          id: `secret-${row.name}`,
+          rowHeaderKey: 'name',
+          disabled: row.disabled,
+          testId: 'environment-secret-variable-row',
+          cells: {
+            name: nameCell(row.name),
+            value: secretCell,
+            type: typeCell(row.dataType)
+          }
+        }))
+      });
+    }
+
+    if (externalSecrets) {
+      result.push({
+        id: 'external-secrets',
+        label: 'External Secret Variables',
+        badge: externalSecrets.variables.length,
+        meta: externalSecrets.typeLabel,
+        testId: 'environment-external-secrets',
+        rows: externalSecrets.variables.map((row) => ({
+          id: `ext-${row.name}`,
+          rowHeaderKey: 'name',
+          disabled: row.disabled,
+          testId: 'environment-external-secret-row',
+          cells: {
+            name: nameCell(row.name),
+            value: valueCell(row.secretName),
+            type: typeCell(row.dataType)
+          }
+        }))
+      });
+    }
+
+    return result;
+  }, [active]);
+
+  const onTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+    event.preventDefault();
+    const delta = event.key === 'ArrowRight' ? 1 : -1;
+    const next = (activeTab + delta + environments.length) % environments.length;
+    setActiveIndex(next);
+    tabRefs.current[next]?.focus();
+  };
+
+  return (
+    <PageWrapper>
+      <StyledWrapper className="environments" data-testid="environments-page">
+        <Heading size='md' testId="environments-title">Environments</Heading>
+
+        {environments.length ? (
+          <>
+            <div role="tablist" aria-label="Environments" className="environment-tabs">
+              {environments.map((environment, index) => {
+                const selected = index === activeTab;
+                return (
+                  <button
+                    key={`${environment.name}-${index}`}
+                    ref={(element) => {
+                      tabRefs.current[index] = element;
+                    }}
+                    type="button"
+                    role="tab"
+                    id={`${tablistId}-${index}`}
+                    aria-selected={selected}
+                    aria-controls={panelId}
+                    tabIndex={selected ? 0 : -1}
+                    className={['environment-tab', selected ? 'is-active' : ''].filter(Boolean).join(' ')}
+                    data-testid="environment-tab"
+                    onClick={() => setActiveIndex(index)}
+                    onKeyDown={onTabKeyDown}
+                  >
+                    <EnvironmentLabel name={environment.name} color={environment.color} />
+                  </button>
+                );
+              })}
+            </div>
+
+            <div
+              role="tabpanel"
+              id={panelId}
+              aria-labelledby={`${tablistId}-${activeTab}`}
+              className="environment-panel"
+            >
+              <Table
+                columns={COLUMNS}
+                groups={groups}
+                minWidth="34rem"
+                emptyMessage="This environment has no variables."
+                caption={`Variables for the ${active?.name ?? ''} environment`}
+                testId="environment-table"
+              />
+            </div>
+          </>
+        ) : (
+          <EmptyState
+            testId="environments-empty"
+            icon={<GlobeIcon />}
+            className='environment-empty'
+            heading="No environments configured"
+            subheading="This collection has no environments yet. Add an environment in Bruno to define base URLs, tokens, and other variables that requests can reference."
+          />
+        )}
+      </StyledWrapper>
+    </PageWrapper>
+  );
+};
 
 export default Environments;

--- a/packages/oc-docs/src/pages/Environments/Environments.tsx
+++ b/packages/oc-docs/src/pages/Environments/Environments.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import type { OpenCollection } from '@opencollection/types';
 import { getEnvironmentVariables } from '../../utils/environments';
 import { Table, type TableColumn, type TableGroup } from '../../ui/Table/Table';
@@ -47,8 +47,8 @@ export const Environments: React.FC<EnvironmentsProps> = ({ collection }) => {
   const environments = collection.config?.environments ?? [];
   const [activeIndex, setActiveIndex] = useState(0);
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const tablistId = useId();
-  const panelId = useId();
+  const tablistId = 'environments-tab';
+  const panelId = 'environments-panel';
 
   const activeTab = environments.length ? Math.min(activeIndex, environments.length - 1) : 0;
   const active = environments[activeTab];

--- a/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
+++ b/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
@@ -1,0 +1,103 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  color: var(--text-primary);
+  padding-bottom: 2rem;
+
+  .environment-tabs {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.25rem;
+    margin-top: 1.25rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .environment-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .environment-tab {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.375rem;
+    border: none;
+    background: transparent;
+    font-family: var(--font-sans);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+  .environment-tab:hover {
+    color: var(--text-primary);
+  }
+  .environment-tab.is-active {
+    color: var(--text-primary);
+    font-weight: 600;
+    background: color-mix(in srgb, var(--oc-text) 6%, transparent);
+  }
+  .environment-tab:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+
+  .environment-panel {
+    margin-top: 1rem;
+  }
+
+  .environment-name {
+    font-family: var(--font-sans);
+    font-weight: 400;
+    font-size: 0.75rem;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--oc-primary-strong);
+  }
+
+  .environment-value {
+    font-family: 'Fira Code', var(--font-mono);
+    font-weight: 400;
+    font-size: 0.75rem;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--text-primary);
+  }
+
+  .environment-empty {
+    font-style: italic;
+    font-size: 0.75rem;
+    color: var(--oc-colors-text-subtext0);
+  }
+
+  .environment-secret {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-style: italic;
+    font-size: 0.75rem;
+    color: var(--oc-colors-text-subtext0);
+  }
+  .environment-secret svg {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  .environment-type {
+    font-family: var(--font-sans);
+    font-weight: 400;
+    font-size: 0.75rem;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--oc-overlay-overlay2);
+  }
+  .environment-empty {
+    margin-top: 0.8rem;
+  }
+`;

--- a/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
+++ b/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
@@ -26,7 +26,7 @@ export const StyledWrapper = styled.div`
     border: none;
     background: transparent;
     font-family: var(--font-sans);
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     font-weight: 500;
     line-height: 1;
     letter-spacing: 0;
@@ -41,7 +41,7 @@ export const StyledWrapper = styled.div`
   .environment-tab.is-active {
     color: var(--text-primary);
     font-weight: 600;
-    background: color-mix(in srgb, var(--oc-text) 6%, transparent);
+    background: var(--oc-background-surface0);
   }
   .environment-tab:focus-visible {
     outline: 2px solid var(--primary-color);
@@ -49,16 +49,19 @@ export const StyledWrapper = styled.div`
   }
 
   .environment-panel {
-    margin-top: 1rem;
+    margin-top: 0.625rem;
   }
 
   .environment-name {
-    font-family: var(--font-sans);
-    font-weight: 400;
+    font-family: 'Fira Code', var(--font-mono);
+    font-weight: 500;
     font-size: 0.75rem;
     line-height: 1;
     letter-spacing: 0;
     color: var(--oc-primary-strong);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .environment-value {
@@ -67,13 +70,16 @@ export const StyledWrapper = styled.div`
     font-size: 0.75rem;
     line-height: 1;
     letter-spacing: 0;
-    color: var(--text-primary);
+    color: var(--text-primary); /* #343434 */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .environment-empty {
     font-style: italic;
     font-size: 0.75rem;
-    color: var(--oc-colors-text-subtext0);
+    color: var(--text-muted); /* #838383 */
   }
 
   .environment-secret {
@@ -82,7 +88,7 @@ export const StyledWrapper = styled.div`
     gap: 0.375rem;
     font-style: italic;
     font-size: 0.75rem;
-    color: var(--oc-colors-text-subtext0);
+    color: var(--text-muted); /* #838383 */
   }
   .environment-secret svg {
     width: 0.875rem;
@@ -95,7 +101,7 @@ export const StyledWrapper = styled.div`
     font-size: 0.75rem;
     line-height: 1;
     letter-spacing: 0;
-    color: var(--oc-overlay-overlay2);
+    color: var(--text-secondary); /* #666666 */
   }
   .environment-empty {
     margin-top: 0.8rem;

--- a/packages/oc-docs/src/pages/Overview/Overview.spec.tsx
+++ b/packages/oc-docs/src/pages/Overview/Overview.spec.tsx
@@ -16,7 +16,7 @@ describe('Overview', () => {
     const html = renderToStaticMarkup(<Overview collection={collection} />);
 
     expect(html).toContain('Hotel Booking API');
-    expect(html).toContain('version : 1.0.0');
+    expect(html).toContain('Version : 1.0.0');
     expect(html).toContain('Development');
     expect(html).toContain('1 variable');
     expect(html).toContain('Accept');

--- a/packages/oc-docs/src/pages/Overview/Overview.tsx
+++ b/packages/oc-docs/src/pages/Overview/Overview.tsx
@@ -60,7 +60,7 @@ export const Overview: React.FC<OverviewProps> = ({ collection, testId = 'overvi
         <header className="overview-headline">
           <div>
             {version ? (
-              <div className="overview-version" data-testid="overview-collection-version">{`version : ${version}`}</div>
+              <div className="overview-version" data-testid="overview-collection-version">{`Version : ${version}`}</div>
             ) : null}
             <Heading testId="overview-collection-name">{name}</Heading>
           </div>

--- a/packages/oc-docs/src/sampleCollection.ts
+++ b/packages/oc-docs/src/sampleCollection.ts
@@ -7,17 +7,30 @@ info:
 config:
   environments:
     - name: "Local"
+      color: "#16a34a"
       variables:
         - name: "host"
           value: "http://localhost:8081"
         - name: "bearer_auth_token"
-          value: "your_secret_token"
+          secret: true
+          type: "string"
     - name: "Prod"
+      color: "#dc2626"
       variables:
         - name: "host"
           value: "https://echo.usebruno.com"
         - name: "bearer_auth_token"
-          value: "your_secret_token"
+          secret: true
+          type: "string"
+      externalSecrets:
+        type: aws-secrets-manager
+        variables:
+          - name: dbPassword
+            secretName: prod/db/credentials
+            enabled: true
+          - name: apiKey
+            secretName: prod/payment-gateway/api-key
+            enabled: true
 request:
   headers:
     - name: "collection-header"

--- a/packages/oc-docs/src/store/slices/docs.ts
+++ b/packages/oc-docs/src/store/slices/docs.ts
@@ -5,8 +5,6 @@ import type { RootState } from '../store';
 import { hydrateWithUUIDs, findAndUpdateItem } from '../../utils/fileUtils';
 import { isFolder } from '../../utils/schemaHelpers';
 
-export type RootView = 'overview' | 'environments';
-
 export interface DocsState {
   collection: OpenCollectionCollection | null;
   selectedItemId: string | null;
@@ -14,7 +12,7 @@ export interface DocsState {
 
 const initialState: DocsState = {
   collection: null,
-  selectedItemId: null,
+  selectedItemId: null
 };
 
 // Helper function to initialize isCollapsed for folders
@@ -79,7 +77,7 @@ const docsSlice = createSlice({
         });
       }
     },
-}
+  }
 });
 
 export const { setDocsCollection, clearDocsCollection, toggleItem, selectItem, expandFolders } = docsSlice.actions;

--- a/packages/oc-docs/src/store/slices/docs.ts
+++ b/packages/oc-docs/src/store/slices/docs.ts
@@ -10,13 +10,11 @@ export type RootView = 'overview' | 'environments';
 export interface DocsState {
   collection: OpenCollectionCollection | null;
   selectedItemId: string | null;
-  activeRootView: RootView;
 }
 
 const initialState: DocsState = {
   collection: null,
   selectedItemId: null,
-  activeRootView: 'overview'
 };
 
 // Helper function to initialize isCollapsed for folders
@@ -51,12 +49,10 @@ const docsSlice = createSlice({
       }
       // Reset selected item when collection changes
       state.selectedItemId = null;
-      state.activeRootView = 'overview';
     },
     clearDocsCollection: (state: DocsState) => {
       state.collection = null;
       state.selectedItemId = null;
-      state.activeRootView = 'overview';
     },
     toggleItem: (state: DocsState, action: PayloadAction<string>) => {
       const uuid = action.payload;
@@ -83,18 +79,13 @@ const docsSlice = createSlice({
         });
       }
     },
-    selectRootView: (state: DocsState, action: PayloadAction<RootView>) => {
-      state.selectedItemId = null;
-      state.activeRootView = action.payload;
-    }
 }
 });
 
-export const { setDocsCollection, clearDocsCollection, toggleItem, selectItem, expandFolders, selectRootView } = docsSlice.actions;
+export const { setDocsCollection, clearDocsCollection, toggleItem, selectItem, expandFolders } = docsSlice.actions;
 export default docsSlice.reducer;
 
 export const selectDocsCollection = (state: RootState) => state.docs.collection;
 export const selectSelectedItemId = (state: RootState) => state.docs.selectedItemId;
-export const selectActiveRootView = (state: RootState) => state.docs.activeRootView;
 
 

--- a/packages/oc-docs/src/store/slices/docs.ts
+++ b/packages/oc-docs/src/store/slices/docs.ts
@@ -5,14 +5,18 @@ import type { RootState } from '../store';
 import { hydrateWithUUIDs, findAndUpdateItem } from '../../utils/fileUtils';
 import { isFolder } from '../../utils/schemaHelpers';
 
+export type RootView = 'overview' | 'environments';
+
 export interface DocsState {
   collection: OpenCollectionCollection | null;
   selectedItemId: string | null;
+  activeRootView: RootView;
 }
 
 const initialState: DocsState = {
   collection: null,
-  selectedItemId: null
+  selectedItemId: null,
+  activeRootView: 'overview'
 };
 
 // Helper function to initialize isCollapsed for folders
@@ -47,10 +51,12 @@ const docsSlice = createSlice({
       }
       // Reset selected item when collection changes
       state.selectedItemId = null;
+      state.activeRootView = 'overview';
     },
     clearDocsCollection: (state: DocsState) => {
       state.collection = null;
       state.selectedItemId = null;
+      state.activeRootView = 'overview';
     },
     toggleItem: (state: DocsState, action: PayloadAction<string>) => {
       const uuid = action.payload;
@@ -77,13 +83,18 @@ const docsSlice = createSlice({
         });
       }
     },
-  }
+    selectRootView: (state: DocsState, action: PayloadAction<RootView>) => {
+      state.selectedItemId = null;
+      state.activeRootView = action.payload;
+    }
+}
 });
 
-export const { setDocsCollection, clearDocsCollection, toggleItem, selectItem, expandFolders } = docsSlice.actions;
+export const { setDocsCollection, clearDocsCollection, toggleItem, selectItem, expandFolders, selectRootView } = docsSlice.actions;
 export default docsSlice.reducer;
 
 export const selectDocsCollection = (state: RootState) => state.docs.collection;
 export const selectSelectedItemId = (state: RootState) => state.docs.selectedItemId;
+export const selectActiveRootView = (state: RootState) => state.docs.activeRootView;
 
 

--- a/packages/oc-docs/src/styles/index.css
+++ b/packages/oc-docs/src/styles/index.css
@@ -807,6 +807,8 @@ tr.themed-row:nth-child(even) {
   max-width: 100% !important;
   overflow-x: auto !important;
   margin: 1em 0 !important;
+  border: 1px solid var(--oc-border-border1) !important;
+  border-radius: 0.5rem !important;
 }
 
 .markdown-documentation table {
@@ -814,26 +816,24 @@ tr.themed-row:nth-child(even) {
   border-collapse: collapse !important;
   margin: 0 !important;
   font-size: 0.875em !important;
-  border: 1px solid var(--border-color) !important;
-  border-radius: 6px !important;
-  overflow: hidden !important;
 }
 
 .markdown-documentation th,
 .markdown-documentation td {
   padding: 0.5em 0.75em !important;
-  border: 1px solid var(--border-color) !important;
+  border-bottom: 1px solid var(--oc-table-border) !important;
   text-align: left !important;
+}
+
+.markdown-documentation tr:last-child td,
+.markdown-documentation tr:last-child th {
+  border-bottom: none !important;
 }
 
 .markdown-documentation th {
   background-color: var(--table-header-bg) !important;
   font-weight: 600 !important;
   color: var(--text-secondary) !important;
-}
-
-.markdown-documentation tr:nth-child(even) {
-  background-color: var(--table-row-even-bg) !important;
 }
 
 .markdown-documentation strong {

--- a/packages/oc-docs/src/ui/Table/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/Table/StyledWrapper.ts
@@ -1,0 +1,133 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+
+  &:hover {
+    scrollbar-color: var(--oc-scrollbar-color) transparent;
+  }
+
+  &::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 4px;
+  }
+  &:hover::-webkit-scrollbar-thumb {
+    background-color: var(--oc-scrollbar-color);
+  }
+
+  .table-empty-message {
+    margin: 0;
+    font-family: var(--font-sans);
+    font-weight: 500;
+    font-style: italic;
+    font-size: 0.8125rem;
+    line-height: 1;
+    color: var(--text-secondary);
+  }
+
+  .table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--font-sans);
+    table-layout: fixed;
+  }
+
+  .table-caption {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .table-head-cell {
+    padding: 0.55rem 0.9rem;
+    font-weight: 700;
+    font-size: 0.6875rem;
+    line-height: 1;
+    letter-spacing: 0.0394rem;
+    text-transform: uppercase;
+    text-align: left;
+    color: var(--oc-colors-text-subtext1);
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .table-group-cell {
+    padding: 0.65rem 0.9rem;
+    font-size: 0.6875rem;
+    line-height: 1;
+    letter-spacing: 0.055rem;
+    text-transform: uppercase;
+    color: var(--oc-colors-text-subtext1);
+    border-bottom: 1px solid var(--border-color);
+    text-align: left;
+  }
+
+  .table-group-label {
+    font-weight: 700;
+    vertical-align: middle;
+  }
+
+  .table-group-badge,
+  .table-group-meta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.5rem;
+    padding: 0.125rem 0.25rem;
+    border: 1px solid var(--oc-border-border0);
+    border-radius: 0.25rem;
+    background: transparent;
+    font-family: var(--font-sans);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    line-height: 1;
+    letter-spacing: 0;
+    text-transform: none;
+    color: var(--oc-colors-text-subtext1);
+  }
+
+  .table-group-badge {
+    background: var(--oc-background-mantle);
+    color: var(--text-muted);
+  }
+
+  .table-row:not(:last-child) {
+    border-bottom: 1px solid var(--border-color);
+  }
+  .table-row--disabled {
+    opacity: 0.55;
+  }
+
+  .table-cell {
+    padding: 0.625rem 1rem;
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    color: var(--text-primary);
+    text-align: left;
+    vertical-align: middle;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .table-cell--right {
+    text-align: right;
+  }
+  .table-cell--head {
+    font-weight: 500;
+  }
+`;

--- a/packages/oc-docs/src/ui/Table/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/Table/StyledWrapper.ts
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 export const StyledWrapper = styled.div`
   width: 100%;
+  border: 1px solid var(--oc-border-border1); /* #e5e5e5 */
+  border-radius: 0.5rem;
   overflow-x: auto;
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;
@@ -56,30 +58,37 @@ export const StyledWrapper = styled.div`
 
   .table-head-cell {
     padding: 0.55rem 0.9rem;
-    font-weight: 700;
-    font-size: 0.6875rem;
+    font-weight: 600;
+    font-size: 0.65625rem; /* 10.5px */
     line-height: 1;
-    letter-spacing: 0.0394rem;
+    letter-spacing: 0.04375rem; /* 0.7px */
     text-transform: uppercase;
     text-align: left;
-    color: var(--oc-colors-text-subtext1);
-    border-bottom: 1px solid var(--border-color);
+    color: var(--oc-colors-text-subtext0); /* #9b9b9b */
+    border-bottom: 1px solid var(--oc-table-border); /* #efefef */
   }
 
   .table-group-cell {
-    padding: 0.65rem 0.9rem;
-    font-size: 0.6875rem;
-    line-height: 1;
-    letter-spacing: 0.055rem;
-    text-transform: uppercase;
-    color: var(--oc-colors-text-subtext1);
-    border-bottom: 1px solid var(--border-color);
+    padding: 0.5625rem 0.875rem; /* 9px 14px */
+    background: var(--oc-background-mantle);
+    border-bottom: 1px solid var(--oc-table-border); /* #efefef */
     text-align: left;
   }
 
+  .table-group-inner {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+    line-height: 1.2;
+    color: var(--text-primary);
+  }
+
   .table-group-label {
-    font-weight: 700;
-    vertical-align: middle;
+    font-size: 0.75rem; /* 12px */
+    font-weight: 600;
+    color: var(--text-primary); /* #343434 */
+    white-space: nowrap;
   }
 
   .table-group-badge,
@@ -87,34 +96,41 @@ export const StyledWrapper = styled.div`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-left: 0.5rem;
-    padding: 0.125rem 0.25rem;
-    border: 1px solid var(--oc-border-border0);
-    border-radius: 0.25rem;
-    background: transparent;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.375rem;
     font-family: var(--font-sans);
     font-size: 0.6875rem;
     font-weight: 500;
     line-height: 1;
     letter-spacing: 0;
     text-transform: none;
-    color: var(--oc-colors-text-subtext1);
   }
 
   .table-group-badge {
-    background: var(--oc-background-mantle);
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-size: 0.6875rem; /* 11px */
+    font-weight: 600;
+    color: var(--text-muted); /* #838383 */
+    background: var(--oc-background-surface0); /* #f1f1f1 */
+  }
+
+  .table-group-meta {
+    margin-left: auto;
+    border: 1px solid var(--oc-border-border1);
+    background: var(--oc-background-base);
     color: var(--text-muted);
   }
 
   .table-row:not(:last-child) {
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--oc-table-border); /* #efefef */
   }
   .table-row--disabled {
     opacity: 0.55;
   }
 
   .table-cell {
-    padding: 0.625rem 1rem;
+    padding: 0.5rem 0.875rem; /* 8px 14px */
     font-size: 0.8125rem;
     line-height: 1.3;
     color: var(--text-primary);

--- a/packages/oc-docs/src/ui/Table/Table.spec.tsx
+++ b/packages/oc-docs/src/ui/Table/Table.spec.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { Table, type TableColumn } from './Table';
+
+const columns: TableColumn[] = [
+  { key: 'name', header: 'Name' },
+  { key: 'value', header: 'Value' }
+];
+
+describe('Table', () => {
+  it('renders column headers and flat rows', () => {
+    const html = renderToStaticMarkup(
+      <Table
+        columns={columns}
+        rows={[{ id: 'a', rowHeaderKey: 'name', cells: { name: 'baseUrl', value: 'https://api' } }]}
+      />
+    );
+    expect(html).toContain('scope="col"');
+    expect(html).toContain('Name');
+    expect(html).toContain('Value');
+    expect(html).toContain('<th scope="row"');
+    expect(html).toContain('baseUrl');
+    expect(html).toContain('https://api');
+  });
+
+  it('renders grouped rows with a colgroup-scoped group header', () => {
+    const html = renderToStaticMarkup(
+      <Table
+        columns={columns}
+        groups={[
+          { id: 'g1', label: 'Variables', badge: 1, rows: [{ id: 'r1', cells: { name: 'x', value: '1' } }] },
+          { id: 'g2', label: 'Secret Variables', badge: 1, rows: [{ id: 'r2', cells: { name: 'y', value: '2' } }] }
+        ]}
+      />
+    );
+    expect(html).toContain('scope="colgroup"');
+    expect(html).toContain('Variables');
+    expect(html).toContain('Secret Variables');
+  });
+
+  it('renders an accessible caption', () => {
+    const html = renderToStaticMarkup(<Table columns={columns} rows={[]} caption="My data" />);
+    expect(html).toContain('<caption');
+    expect(html).toContain('My data');
+  });
+
+  it('shows the empty message when every group is empty', () => {
+    const html = renderToStaticMarkup(<Table columns={columns} rows={[]} emptyMessage="Nothing here" />);
+    expect(html).toContain('Nothing here');
+    expect(html).not.toContain('<table');
+  });
+});

--- a/packages/oc-docs/src/ui/Table/Table.spec.tsx
+++ b/packages/oc-docs/src/ui/Table/Table.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
+import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { Table, type TableColumn } from './Table';
 
 const columns: TableColumn[] = [
@@ -10,22 +10,22 @@ const columns: TableColumn[] = [
 
 describe('Table', () => {
   it('renders column headers and flat rows', () => {
-    const html = renderToStaticMarkup(
+    const root = useRenderToDom(
       <Table
         columns={columns}
         rows={[{ id: 'a', rowHeaderKey: 'name', cells: { name: 'baseUrl', value: 'https://api' } }]}
       />
     );
-    expect(html).toContain('scope="col"');
-    expect(html).toContain('Name');
-    expect(html).toContain('Value');
-    expect(html).toContain('<th scope="row"');
-    expect(html).toContain('baseUrl');
-    expect(html).toContain('https://api');
+
+    const headers = root.querySelectorAll('thead th[scope="col"]').map((th) => th.text.trim());
+    expect(headers).toEqual(['Name', 'Value']);
+
+    expect(root.querySelector('tbody th[scope="row"]')?.text.trim()).toBe('baseUrl');
+    expect(root.querySelectorAll('tbody td').map((td) => td.text.trim())).toContain('https://api');
   });
 
   it('renders grouped rows with a colgroup-scoped group header', () => {
-    const html = renderToStaticMarkup(
+    const root = useRenderToDom(
       <Table
         columns={columns}
         groups={[
@@ -34,20 +34,21 @@ describe('Table', () => {
         ]}
       />
     );
-    expect(html).toContain('scope="colgroup"');
-    expect(html).toContain('Variables');
-    expect(html).toContain('Secret Variables');
+
+    const groupHeaders = root
+      .querySelectorAll('th[scope="colgroup"] .table-group-label')
+      .map((el) => el.text.trim());
+    expect(groupHeaders).toEqual(['Variables', 'Secret Variables']);
   });
 
   it('renders an accessible caption', () => {
-    const html = renderToStaticMarkup(<Table columns={columns} rows={[]} caption="My data" />);
-    expect(html).toContain('<caption');
-    expect(html).toContain('My data');
+    const root = useRenderToDom(<Table columns={columns} rows={[]} caption="My data" />);
+    expect(root.querySelector('caption')?.text.trim()).toBe('My data');
   });
 
   it('shows the empty message when every group is empty', () => {
-    const html = renderToStaticMarkup(<Table columns={columns} rows={[]} emptyMessage="Nothing here" />);
-    expect(html).toContain('Nothing here');
-    expect(html).not.toContain('<table');
+    const root = useRenderToDom(<Table columns={columns} rows={[]} emptyMessage="Nothing here" />);
+    expect(root.querySelector('.table-empty-message')?.text.trim()).toBe('Nothing here');
+    expect(root.querySelector('table')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/ui/Table/Table.tsx
+++ b/packages/oc-docs/src/ui/Table/Table.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { StyledWrapper } from './StyledWrapper';
+
+export interface TableColumn {
+  key: string;
+  header: React.ReactNode;
+  align?: 'left' | 'right';
+  width?: string;
+}
+
+export interface TableRow {
+  id: string;
+  cells: Record<string, React.ReactNode>;
+  rowHeaderKey?: string;
+  disabled?: boolean;
+  testId?: string;
+}
+
+export interface TableGroup {
+  id: string;
+  label?: React.ReactNode;
+  badge?: React.ReactNode;
+  meta?: React.ReactNode;
+  rows: TableRow[];
+  testId?: string;
+}
+
+interface TableProps {
+  columns: TableColumn[];
+  groups?: TableGroup[];
+  rows?: TableRow[];
+  caption?: string;
+  emptyMessage?: string;
+  minWidth?: string;
+  className?: string;
+  testId?: string;
+}
+
+const Cells: React.FC<{ row: TableRow; columns: TableColumn[] }> = ({ row, columns }) =>
+  columns.map((column) => {
+    const content = row.cells[column.key];
+    const alignment = column.align ?? 'left';
+    if (row.rowHeaderKey === column.key) {
+      return (
+        <th
+          key={column.key}
+          scope="row"
+          className={`table-cell table-cell--${alignment} table-cell--head`}
+          data-testid={`table-cell-${column.key}`}
+        >
+          {content}
+        </th>
+      );
+    }
+    return (
+      <td
+        key={column.key}
+        className={`table-cell table-cell--${alignment}`}
+        data-testid={`table-cell-${column.key}`}
+      >
+        {content}
+      </td>
+    );
+  });
+
+const Rows: React.FC<{ rows: TableRow[]; columns: TableColumn[] }> = ({ rows, columns }) =>
+  rows.map((row) => (
+    <tr
+      key={row.id}
+      className={['table-row', row.disabled ? 'table-row--disabled' : ''].filter(Boolean).join(' ')}
+      data-testid={row.testId}
+    >
+      <Cells row={row} columns={columns} />
+    </tr>
+  ));
+
+export const Table: React.FC<TableProps> = ({
+  columns,
+  groups,
+  rows,
+  caption,
+  emptyMessage,
+  minWidth,
+  className,
+  testId
+}) => {
+  const groupList = groups ?? (rows ? [{ id: 'default', rows }] : []);
+  const isEmpty = groupList.every((group) => group.rows.length === 0);
+
+  if (isEmpty && emptyMessage) {
+    return (
+      <StyledWrapper className={['table-wrapper', className].filter(Boolean).join(' ')} data-testid={testId}>
+        <p className="table-empty-message">{emptyMessage}</p>
+      </StyledWrapper>
+    );
+  }
+
+  return (
+    <StyledWrapper className={['table-wrapper', className].filter(Boolean).join(' ')} data-testid={testId}>
+      <table className="table" style={minWidth ? { minWidth } : undefined}>
+        {caption && <caption className="table-caption">{caption}</caption>}
+        <colgroup>
+          {columns.map((column) => (
+            <col key={column.key} style={column.width ? { width: column.width } : undefined} />
+          ))}
+        </colgroup>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                scope="col"
+                className={`table-head-cell table-cell--${column.align ?? 'left'}`}
+                data-testid={`table-header-${column.key}`}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        {groupList.map((group) => (
+          <tbody key={group.id} className="table-group" data-testid={group.testId}>
+            {group.label !== undefined && (
+              <tr className="table-group-row">
+                <th scope="colgroup" colSpan={columns.length} className="table-group-cell">
+                  <span className="table-group-label">{group.label}</span>
+                  {group.badge !== undefined && <span className="table-group-badge">{group.badge}</span>}
+                  {group.meta !== undefined && <span className="table-group-meta">{group.meta}</span>}
+                </th>
+              </tr>
+            )}
+            <Rows rows={group.rows} columns={columns} />
+          </tbody>
+        ))}
+      </table>
+    </StyledWrapper>
+  );
+};
+
+export default Table;

--- a/packages/oc-docs/src/ui/Table/Table.tsx
+++ b/packages/oc-docs/src/ui/Table/Table.tsx
@@ -123,9 +123,11 @@ export const Table: React.FC<TableProps> = ({
             {group.label !== undefined && (
               <tr className="table-group-row">
                 <th scope="colgroup" colSpan={columns.length} className="table-group-cell">
-                  <span className="table-group-label">{group.label}</span>
-                  {group.badge !== undefined && <span className="table-group-badge">{group.badge}</span>}
-                  {group.meta !== undefined && <span className="table-group-meta">{group.meta}</span>}
+                  <div className="table-group-inner">
+                    <span className="table-group-label">{group.label}</span>
+                    {group.badge !== undefined && <span className="table-group-badge">{group.badge}</span>}
+                    {group.meta !== undefined && <span className="table-group-meta">{group.meta}</span>}
+                  </div>
                 </th>
               </tr>
             )}

--- a/packages/oc-docs/src/utils/environments.spec.ts
+++ b/packages/oc-docs/src/utils/environments.spec.ts
@@ -127,4 +127,14 @@ describe('getEnvironmentVariables', () => {
     };
     expect(getEnvironmentVariables(env).externalSecrets?.typeLabel).toBe('My Custom Vault');
   });
+
+  it('labels the Bruno secret manager types (vault / aws / azure)', () => {
+    const withType = (type: string) =>
+      ({ name: 'Prod', externalSecrets: { type, variables: [{ name: 'x', secretName: 'y' }] } }) as any;
+    expect(getEnvironmentVariables(withType('vault')).externalSecrets?.typeLabel).toBe('Vault');
+    expect(getEnvironmentVariables(withType('aws-secrets-manager')).externalSecrets?.typeLabel).toBe(
+      'AWS Secrets Manager'
+    );
+    expect(getEnvironmentVariables(withType('azure-key-vault')).externalSecrets?.typeLabel).toBe('Azure Key Vault');
+  });
 });

--- a/packages/oc-docs/src/utils/environments.spec.ts
+++ b/packages/oc-docs/src/utils/environments.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { getEnvironmentVariables } from './environments';
+
+describe('getEnvironmentVariables', () => {
+  it('splits regular and secret variables', () => {
+    const env: any = {
+      name: 'Dev',
+      variables: [
+        { name: 'baseUrl', value: 'https://api.test' },
+        { name: 'authToken', secret: true, type: 'string' }
+      ]
+    };
+    const { variables, secretVariables } = getEnvironmentVariables(env);
+    expect(variables).toEqual([
+      { name: 'baseUrl', value: 'https://api.test', dataType: 'String', secret: false, disabled: false }
+    ]);
+    expect(secretVariables).toEqual([
+      { name: 'authToken', value: '', dataType: 'String', secret: true, disabled: false }
+    ]);
+  });
+
+  it('humanizes typed values and reads the typed data', () => {
+    const env: any = {
+      name: 'Dev',
+      variables: [
+        { name: 'count', value: { type: 'number', data: '8842' } },
+        { name: 'enabled', value: { type: 'boolean', data: 'true' } },
+        { name: 'payload', value: { type: 'object', data: '{}' } }
+      ]
+    };
+    expect(getEnvironmentVariables(env).variables.map((v) => `${v.name}:${v.value}:${v.dataType}`)).toEqual([
+      'count:8842:Number',
+      'enabled:true:Boolean',
+      'payload:{}:Object'
+    ]);
+  });
+
+  it('resolves the selected value from variants', () => {
+    const env: any = {
+      name: 'Dev',
+      variables: [
+        {
+          name: 'region',
+          value: [
+            { title: 'us', value: 'us-east-1' },
+            { title: 'eu', selected: true, value: 'eu-west-1' }
+          ]
+        }
+      ]
+    };
+    expect(getEnvironmentVariables(env).variables[0]).toMatchObject({ value: 'eu-west-1', dataType: 'String' });
+  });
+
+  it('leaves an untyped secret data type empty and marks disabled rows', () => {
+    const env: any = {
+      name: 'Dev',
+      variables: [
+        { name: 'token', secret: true },
+        { name: 'legacy', value: 'x', disabled: true }
+      ]
+    };
+    const { variables, secretVariables } = getEnvironmentVariables(env);
+    expect(secretVariables[0]).toMatchObject({ dataType: '', secret: true });
+    expect(variables[0].disabled).toBe(true);
+  });
+
+  it('leaves the data type empty for a variable with no value', () => {
+    const env: any = { name: 'Dev', variables: [{ name: 'transactionId', value: '' }, { name: 'reviewId' }] };
+    expect(getEnvironmentVariables(env).variables.map((v) => `${v.name}:${v.value}:${v.dataType}`)).toEqual([
+      'transactionId::',
+      'reviewId::'
+    ]);
+  });
+
+  it('returns empty groups for a missing environment', () => {
+    const empty = { variables: [], secretVariables: [], externalSecrets: null };
+    expect(getEnvironmentVariables(null)).toEqual(empty);
+    expect(getEnvironmentVariables(undefined)).toEqual(empty);
+    expect(getEnvironmentVariables({ name: 'Empty' } as any)).toEqual(empty);
+  });
+
+  it('extracts external secrets and humanizes the manager type', () => {
+    const env: any = {
+      name: 'Prod',
+      externalSecrets: {
+        type: 'aws-secrets-manager',
+        variables: [
+          { name: 'dbPassword', secretName: 'prod/db/credentials', enabled: true },
+          { name: 'apiKey', secretName: 'prod/payment/api-key', enabled: false }
+        ]
+      }
+    };
+    const { externalSecrets } = getEnvironmentVariables(env);
+    expect(externalSecrets?.typeLabel).toBe('AWS Secrets Manager');
+    expect(externalSecrets?.variables).toEqual([
+      { name: 'dbPassword', secretName: 'prod/db/credentials', dataType: '', disabled: false },
+      { name: 'apiKey', secretName: 'prod/payment/api-key', dataType: '', disabled: true }
+    ]);
+  });
+
+  it('reads a data type for external secret variables when present', () => {
+    const env: any = {
+      name: 'Prod',
+      externalSecrets: {
+        type: 'aws-secrets-manager',
+        variables: [
+          { name: 'dbPassword', secretName: 'p', type: 'string' },
+          { name: 'apiKey', secretName: 'q' }
+        ]
+      }
+    };
+    expect(getEnvironmentVariables(env).externalSecrets?.variables.map((v) => v.dataType)).toEqual(['String', '']);
+  });
+
+  it('is null when there are no external secret variables', () => {
+    expect(getEnvironmentVariables({ name: 'Dev' } as any).externalSecrets).toBeNull();
+    expect(
+      getEnvironmentVariables({ name: 'Dev', externalSecrets: { type: 'aws-secrets-manager', variables: [] } } as any)
+        .externalSecrets
+    ).toBeNull();
+  });
+
+  it('title-cases an unknown manager type', () => {
+    const env: any = {
+      name: 'Prod',
+      externalSecrets: { type: 'my-custom-vault', variables: [{ name: 'x', secretName: 'y' }] }
+    };
+    expect(getEnvironmentVariables(env).externalSecrets?.typeLabel).toBe('My Custom Vault');
+  });
+});

--- a/packages/oc-docs/src/utils/environments.ts
+++ b/packages/oc-docs/src/utils/environments.ts
@@ -5,21 +5,7 @@ import type {
   VariableValueOrVariants,
   VariableValueType
 } from '@opencollection/types/common/variables';
-
-const TYPE_LABELS: Record<VariableValueType, string> = {
-  string: 'String',
-  number: 'Number',
-  boolean: 'Boolean',
-  null: 'Null',
-  object: 'Object'
-};
-
-const MANAGER_LABELS: Record<string, string> = {
-  'aws-secrets-manager': 'AWS Secrets Manager',
-  'azure-key-vault': 'Azure Key Vault',
-  'gcp-secret-manager': 'GCP Secret Manager',
-  'hashicorp-vault': 'HashiCorp Vault'
-};
+import { MANAGER_LABELS, TYPE_LABELS } from '../constants';
 
 const humanizeType = (type: VariableValueType | undefined): string => (type && TYPE_LABELS[type]) || 'String';
 

--- a/packages/oc-docs/src/utils/environments.ts
+++ b/packages/oc-docs/src/utils/environments.ts
@@ -1,0 +1,128 @@
+import type { Environment } from '@opencollection/types/config/environments';
+import type {
+  Variable,
+  SecretVariable,
+  VariableValueOrVariants,
+  VariableValueType
+} from '@opencollection/types/common/variables';
+
+const TYPE_LABELS: Record<VariableValueType, string> = {
+  string: 'String',
+  number: 'Number',
+  boolean: 'Boolean',
+  null: 'Null',
+  object: 'Object'
+};
+
+const MANAGER_LABELS: Record<string, string> = {
+  'aws-secrets-manager': 'AWS Secrets Manager',
+  'azure-key-vault': 'Azure Key Vault',
+  'gcp-secret-manager': 'GCP Secret Manager',
+  'hashicorp-vault': 'HashiCorp Vault'
+};
+
+const humanizeType = (type: VariableValueType | undefined): string => (type && TYPE_LABELS[type]) || 'String';
+
+const humanizeManager = (type: string | undefined): string => {
+  if (!type) return 'External';
+  return (
+    MANAGER_LABELS[type] ||
+    type
+      .split(/[-_\s]+/)
+      .filter(Boolean)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ')
+  );
+};
+
+const isSecretVariable = (variable: Variable | SecretVariable): variable is SecretVariable =>
+  (variable as SecretVariable).secret === true;
+
+const resolveValue = (value: VariableValueOrVariants | undefined): { value: string; type: VariableValueType } => {
+  if (value == null) return { value: '', type: 'string' };
+  if (typeof value === 'string') return { value, type: 'string' };
+  if (Array.isArray(value)) {
+    const selected = value.find((variant) => variant.selected) ?? value[0];
+    return selected ? resolveValue(selected.value) : { value: '', type: 'string' };
+  }
+  return { value: typeof value.data === 'string' ? value.data : '', type: value.type ?? 'string' };
+};
+
+interface ExternalSecretsConfig {
+  type?: string;
+  variables?: { name?: string; secretName?: string; enabled?: boolean; type?: VariableValueType }[];
+}
+
+export interface EnvironmentVariableRow {
+  name: string;
+  value: string;
+  dataType: string;
+  secret: boolean;
+  disabled: boolean;
+}
+
+export interface ExternalSecretRow {
+  name: string;
+  secretName: string;
+  dataType: string;
+  disabled: boolean;
+}
+
+export interface EnvironmentExternalSecrets {
+  type: string;
+  typeLabel: string;
+  variables: ExternalSecretRow[];
+}
+
+export interface EnvironmentVariableGroups {
+  variables: EnvironmentVariableRow[];
+  secretVariables: EnvironmentVariableRow[];
+  externalSecrets: EnvironmentExternalSecrets | null;
+}
+
+const getExternalSecrets = (environment: Environment): EnvironmentExternalSecrets | null => {
+  const config = (environment as { externalSecrets?: ExternalSecretsConfig }).externalSecrets;
+  const variables = (config?.variables ?? [])
+    .filter((variable) => variable && variable.name)
+    .map((variable) => ({
+      name: variable.name ?? '',
+      secretName: variable.secretName ?? '',
+      dataType: variable.type ? humanizeType(variable.type) : '',
+      disabled: variable.enabled === false
+    }));
+
+  if (!variables.length) return null;
+  return { type: config?.type ?? '', typeLabel: humanizeManager(config?.type), variables };
+};
+
+export const getEnvironmentVariables = (environment: Environment | null | undefined): EnvironmentVariableGroups => {
+  const variables: EnvironmentVariableRow[] = [];
+  const secretVariables: EnvironmentVariableRow[] = [];
+
+  (environment?.variables ?? []).forEach((variable) => {
+    if (isSecretVariable(variable)) {
+      secretVariables.push({
+        name: variable.name ?? '',
+        value: '',
+        dataType: variable.type ? humanizeType(variable.type) : '',
+        secret: true,
+        disabled: variable.disabled === true
+      });
+      return;
+    }
+    const resolved = resolveValue(variable.value);
+    variables.push({
+      name: variable.name,
+      value: resolved.value,
+      dataType: resolved.value ? humanizeType(resolved.type) : '',
+      secret: false,
+      disabled: variable.disabled === true
+    });
+  });
+
+  return {
+    variables,
+    secretVariables,
+    externalSecrets: environment ? getExternalSecrets(environment) : null
+  };
+};


### PR DESCRIPTION
Problem
Generated documentation includes every environment in the collection, with no way to scope which envs ship, so internal, local, or staging envs leak into docs shared externally. The modal also doesn't surface which collection version the docs represent.

Proposed Solution
The Generate Documentation modal produces a standalone, interactive HTML file (it loads OpenCollection's JS/CSS from a CDN) that can be hosted anywhere or shared. The modal includes:

Collection summary card — collection name, a version badge (e.g. v1.2.0), and folder/request counts.

Environments to include — a multi-select with a "Select all" toggle and a count of selected envs (e.g. 5/6 selected). Only checked envs (and their variables/values) are written into the generated docs; unchecked envs are omitted entirely.

https://usebruno.atlassian.net/browse/BRU-2548

<img width="2880" height="1788" alt="image" src="https://github.com/user-attachments/assets/128fcab9-fe16-492a-aa53-5bb057d9ffdd" />

<img width="2872" height="1764" alt="image" src="https://github.com/user-attachments/assets/ae97add4-9522-4258-8f02-a4a795c0a02e" />
