### PR TITLE
feat(size/XXL):Folder page UI revamp changes

### DIFF
--- a/packages/oc-docs/e2e/components/folder/folder-configuration.component.ts
+++ b/packages/oc-docs/e2e/components/folder/folder-configuration.component.ts
@@ -1,0 +1,10 @@
+import { BaseComponent } from '../base.component';
+
+export class FolderConfigurationComponent extends BaseComponent {
+  readonly root = this.page.getByTestId('folder-config');
+  readonly headers = this.page.getByTestId('folder-config-headers');
+  readonly auth = this.page.getByTestId('folder-config-auth');
+  readonly script = this.page.getByTestId('folder-config-script');
+  readonly vars = this.page.getByTestId('folder-config-vars');
+  readonly tests = this.page.getByTestId('folder-config-tests');
+}

--- a/packages/oc-docs/e2e/pages/folder.page.ts
+++ b/packages/oc-docs/e2e/pages/folder.page.ts
@@ -5,15 +5,15 @@ import { FolderConfigurationComponent } from '../components/folder/folder-config
 
 export class FolderPage extends BasePage {
   readonly root = this.page.getByTestId('folder-page');
-
-  readonly sidebar = new SidebarComponent(this.page);
-  readonly breadcrumb = new BreadcrumbComponent(this.page, 'folder-breadcrumb');
   readonly title = this.page.getByTestId('folder-title');
   readonly requestCount = this.page.getByTestId('folder-request-count');
   readonly folderMarkdownDocs = this.page.getByTestId('folder-docs');
   readonly folderMarkdownDocsToggle = this.page.getByTestId('folder-docs-toggle');
-  readonly configuration = new FolderConfigurationComponent(this.page);
   readonly emptyState = this.page.getByTestId('folder-config-empty');
+
+  readonly sidebar = new SidebarComponent(this.page);
+  readonly breadcrumb = new BreadcrumbComponent(this.page, 'folder-breadcrumb');
+  readonly configuration = new FolderConfigurationComponent(this.page);
 
   async open(trail: string[]): Promise<void> {
     await this.navigate('/');

--- a/packages/oc-docs/e2e/pages/folder.page.ts
+++ b/packages/oc-docs/e2e/pages/folder.page.ts
@@ -1,0 +1,23 @@
+import { BasePage } from './base.page';
+import { SidebarComponent } from '../components/sidebar.component';
+import { BreadcrumbComponent } from '../components/breadcrumb.component';
+import { FolderConfigurationComponent } from '../components/folder/folder-configuration.component';
+
+export class FolderPage extends BasePage {
+  readonly root = this.page.getByTestId('folder-page');
+
+  readonly sidebar = new SidebarComponent(this.page);
+  readonly breadcrumb = new BreadcrumbComponent(this.page, 'folder-breadcrumb');
+  readonly title = this.page.getByTestId('folder-title');
+  readonly requestCount = this.page.getByTestId('folder-request-count');
+  readonly folderMarkdownDocs = this.page.getByTestId('folder-docs');
+  readonly folderMarkdownDocsToggle = this.page.getByTestId('folder-docs-toggle');
+  readonly configuration = new FolderConfigurationComponent(this.page);
+  readonly emptyState = this.page.getByTestId('folder-config-empty');
+
+  async open(trail: string[]): Promise<void> {
+    await this.navigate('/');
+    await this.sidebar.open(trail);
+    await this.root.waitFor({ state: 'visible' });
+  }
+}

--- a/packages/oc-docs/e2e/playwright/pages.fixture.ts
+++ b/packages/oc-docs/e2e/playwright/pages.fixture.ts
@@ -2,16 +2,17 @@ import { test as base } from '@playwright/test';
 import { OverviewPage } from '../pages/overview.page';
 import { RequestPage } from '../pages/request.page';
 import { ScriptPage } from '../pages/script.page';
+import { FolderPage } from '../pages/folder.page';
 import { UnsupportedRequestPage } from '../pages/unsupported-request.page';
 import { SidebarComponent } from '../components/sidebar.component';
 import { ThemeToggleComponent } from '../components/layout/theme-toggle.component';
 import { PageHeaderComponent } from '../components/layout/page-header.component';
 
-
 type Fixtures = {
   overviewPage: OverviewPage;
   requestPage: RequestPage;
   scriptPage: ScriptPage;
+  folderPage: FolderPage;
   unsupportedRequestPage: UnsupportedRequestPage;
   sidebar: SidebarComponent;
   pageHeader: PageHeaderComponent;
@@ -22,20 +23,23 @@ export const test = base.extend<Fixtures>({
   overviewPage: async ({ page }, use) => {
     await use(new OverviewPage(page));
   },
-  pageHeader: async ({ page }, use) => {
-    await use(new PageHeaderComponent(page));
-  },
   requestPage: async ({ page }, use) => {
     await use(new RequestPage(page));
   },
   scriptPage: async ({ page }, use) => {
     await use(new ScriptPage(page));
   },
+  folderPage: async ({ page }, use) => {
+    await use(new FolderPage(page));
+  },
   unsupportedRequestPage: async ({ page }, use) => {
     await use(new UnsupportedRequestPage(page));
   },
   sidebar: async ({ page }, use) => {
     await use(new SidebarComponent(page));
+  },
+  pageHeader: async ({ page }, use) => {
+    await use(new PageHeaderComponent(page));
   },
   themeToggle: async ({ page }, use) => {
     await use(new ThemeToggleComponent(page));

--- a/packages/oc-docs/e2e/tests/folder/folder.spec.ts
+++ b/packages/oc-docs/e2e/tests/folder/folder.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../../playwright';
+
+test.describe('Folder page', () => {
+  test('displays the folder name and how many requests it contains', async ({ folderPage }) => {
+    await folderPage.open(['Realtime']);
+    await expect(folderPage.title).toHaveText('Realtime');
+    await expect(folderPage.requestCount).toHaveText('3 requests');
+  });
+
+  test('shows the "No folder configuration" empty state when the folder has no config', async ({ folderPage }) => {
+    await folderPage.open(['Realtime']);
+    await expect(folderPage.emptyState).toBeVisible();
+    await expect(folderPage.emptyState).toContainText('No folder configuration');
+    await expect(folderPage.configuration.root).toBeHidden();
+  });
+
+  test('renders the configuration with inherited auth and folder-level scripts', async ({ folderPage }) => {
+    await folderPage.open(['billing']);
+
+    await test.step('the configuration is shown instead of the empty state', async () => {
+      await expect(folderPage.configuration.root).toBeVisible();
+      await expect(folderPage.emptyState).toBeHidden();
+    });
+
+    await test.step('the auth group shows the inherited-from-collection badge', async () => {
+      await expect(folderPage.configuration.auth).toBeVisible();
+      await expect(folderPage.configuration.auth).toContainText('Inherited from collection');
+    });
+
+    await test.step('the script group is shown', async () => {
+      await expect(folderPage.configuration.script).toBeVisible();
+    });
+  });
+
+  test('shows the Tests group when the folder defines folder-scoped tests', async ({ folderPage }) => {
+    await folderPage.open(['billing', 'customers']);
+    await expect(folderPage.title).toHaveText('customers');
+    await expect(folderPage.configuration.tests).toBeVisible();
+  });
+
+  test('renders the folder docs as markdown and collapses long content behind a "View more" toggle', async ({
+    folderPage
+  }) => {
+    await folderPage.open(['billing']);
+
+    await test.step('the markdown is rendered with formatting', async () => {
+      await expect(folderPage.folderMarkdownDocs).toBeVisible();
+      await expect(folderPage.folderMarkdownDocs).toContainText('Endpoints for managing');
+      await expect(folderPage.folderMarkdownDocs.locator('strong').first()).toHaveText('customers');
+    });
+
+    await test.step('long docs collapse to a preview with a "View more" toggle', async () => {
+      await expect(folderPage.folderMarkdownDocsToggle).toHaveText('View more');
+      await folderPage.folderMarkdownDocsToggle.click();
+      await expect(folderPage.folderMarkdownDocsToggle).toHaveText('View less');
+    });
+  });
+});

--- a/packages/oc-docs/e2e/tests/request/request-details.spec.ts
+++ b/packages/oc-docs/e2e/tests/request/request-details.spec.ts
@@ -18,6 +18,8 @@ test.describe('Request page — Details', () => {
     test('returns to a parent folder when its segment is clicked', async ({ requestPage, page }) => {
       await requestPage.breadcrumb.segment('customers').click();
       await expect(page.getByTestId('overview')).toBeVisible();
+      await expect(page.getByTestId('folder-page')).toBeVisible();
+      await expect(page.getByTestId('folder-title')).toHaveText('customers');
     });
   });
 

--- a/packages/oc-docs/e2e/tests/request/request-details.spec.ts
+++ b/packages/oc-docs/e2e/tests/request/request-details.spec.ts
@@ -17,7 +17,6 @@ test.describe('Request page — Details', () => {
 
     test('returns to a parent folder when its segment is clicked', async ({ requestPage, page }) => {
       await requestPage.breadcrumb.segment('customers').click();
-      await expect(page.getByTestId('overview')).toBeVisible();
       await expect(page.getByTestId('folder-page')).toBeVisible();
       await expect(page.getByTestId('folder-title')).toHaveText('customers');
     });

--- a/packages/oc-docs/src/assets/icons/FolderIcon.tsx
+++ b/packages/oc-docs/src/assets/icons/FolderIcon.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { baseIconProps } from './baseIconProps';
+
+export const FolderIcon: React.FC = () => (
+  <svg {...baseIconProps}>
+    <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+  </svg>
+);

--- a/packages/oc-docs/src/assets/icons/index.ts
+++ b/packages/oc-docs/src/assets/icons/index.ts
@@ -3,6 +3,7 @@ export * from './HamburgerIcon';
 export * from './OverflowIcon';
 export * from './BrunoGlyph';
 export * from './GlobeIcon';
+export * from './FolderIcon';
 export * from './BookIcon';
 export * from './ExpandIcon';
 export * from './CloseIcon';

--- a/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
@@ -35,11 +35,6 @@ const Sidebar: React.FC = () => {
     return map;
   }, [model]);
 
-  // Auto-reveal the active node by expanding only its ANCESTOR folders, and only
-  // when the active slug changes (i.e. on navigation). A folder's own open/close
-  // is left to the user's toggle: since toggling mutates the collection (and thus
-  // the memoised nav model), guarding on the slug keeps a manual collapse from
-  // being undone on the next render.
   const autoRevealedSlug = useRef<string | null>(null);
   useEffect(() => {
     if (autoRevealedSlug.current === activeSlug) return;

--- a/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import type { Item as OpenCollectionItem, Folder } from '@opencollection/types/collection/item';
 import type { HttpRequest } from '@opencollection/types/requests/http';
@@ -35,19 +35,22 @@ const Sidebar: React.FC = () => {
     return map;
   }, [model]);
 
-  // Auto-expand (expand-only) the active node's ancestor folders — and the
-  // active folder itself — so a deep-linked item is always visible.
+  // Auto-reveal the active node by expanding only its ANCESTOR folders, and only
+  // when the active slug changes (i.e. on navigation). A folder's own open/close
+  // is left to the user's toggle: since toggling mutates the collection (and thus
+  // the memoised nav model), guarding on the slug keeps a manual collapse from
+  // being undone on the next render.
+  const autoRevealedSlug = useRef<string | null>(null);
   useEffect(() => {
+    if (autoRevealedSlug.current === activeSlug) return;
+    autoRevealedSlug.current = activeSlug;
+
     const entry = model.bySlug.get(activeSlug);
     if (!entry) return;
 
     const uuids: string[] = [];
     for (const ancestor of entry.ancestors) {
       const uuid = getItemUuid(model.bySlug.get(ancestor.slug)?.item);
-      if (uuid) uuids.push(uuid);
-    }
-    if (entry.type === 'folder') {
-      const uuid = getItemUuid(entry.item);
       if (uuid) uuids.push(uuid);
     }
     if (uuids.length) dispatch(expandFolders(uuids));
@@ -91,7 +94,11 @@ const Sidebar: React.FC = () => {
             transition-all duration-200
           `}
           style={{ paddingLeft: `${level * 16 + 8}px` }}
-          onClick={() => itemSlug !== undefined && goTo(itemSlug)}
+          onClick={() => {
+            // A folder click both opens/closes it and shows its folder page.
+            if (itemIsFolder && itemUuid) dispatch(toggleItem(itemUuid));
+            if (itemSlug !== undefined) goTo(itemSlug);
+          }}
         >
           {level > 0 && (
             <div
@@ -101,16 +108,7 @@ const Sidebar: React.FC = () => {
           )}
 
           {itemIsFolder ? (
-            <div
-              className="mr-2 flex-shrink-0"
-              role="button"
-              aria-label={isExpanded ? 'Collapse folder' : 'Expand folder'}
-              onClick={(e) => {
-                // Chevron toggles collapse independently of navigating to the folder page.
-                e.stopPropagation();
-                if (itemUuid) dispatch(toggleItem(itemUuid));
-              }}
-            >
+            <div className="mr-2 flex-shrink-0" aria-hidden="true">
               {renderFolderIcon(isExpanded)}
             </div>
           ) : itemIsScript ? null : (

--- a/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
+++ b/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { FolderConfiguration } from './FolderConfiguration';
+import type { FolderConfig } from '../../utils/folder';
+
+const baseConfig: FolderConfig = {
+  headers: [],
+  auth: undefined,
+  authSource: undefined,
+  preRequest: undefined,
+  postResponse: undefined,
+  tests: undefined,
+  variables: []
+};
+
+describe('FolderConfiguration', () => {
+  it('shows only the groups that have content and omits the empty ones', () => {
+    const config: FolderConfig = {
+      ...baseConfig,
+      headers: [{ name: 'Accept', value: 'application/json' }],
+      preRequest: 'console.log(1)'
+    };
+    const html = renderToStaticMarkup(<FolderConfiguration config={config} />);
+    expect(html).toContain('folder-config-headers');
+    expect(html).toContain('folder-config-script');
+    expect(html).toContain('Accept');
+    expect(html).not.toContain('folder-config-auth');
+    expect(html).not.toContain('folder-config-vars');
+    expect(html).not.toContain('folder-config-tests');
+  });
+
+  it('labels the Auth group with an "Inherited from collection" badge when auth is inherited', () => {
+    const config: FolderConfig = {
+      ...baseConfig,
+      auth: { type: 'bearer', token: 't' } as any,
+      authSource: { level: 'collection', name: 'API' }
+    };
+    const html = renderToStaticMarkup(
+      <FolderConfiguration config={config} authModeLabels={{ bearer: 'Bearer Token' }} />
+    );
+    expect(html).toContain('folder-config-auth');
+    expect(html).toContain('Inherited from collection');
+  });
+
+  it('renders Pre-Request and Post-Response script columns and a separate Tests group', () => {
+    const config: FolderConfig = {
+      ...baseConfig,
+      preRequest: 'pre()',
+      postResponse: 'post()',
+      tests: 'test()'
+    };
+    const html = renderToStaticMarkup(<FolderConfiguration config={config} />);
+    expect(html).toContain('Pre-Request');
+    expect(html).toContain('Post-Response');
+    expect(html).toContain('folder-config-tests');
+  });
+});

--- a/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
+++ b/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
+import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { FolderConfiguration } from './FolderConfiguration';
 import type { FolderConfig } from '../../utils/folder';
 
@@ -21,13 +21,15 @@ describe('FolderConfiguration', () => {
       headers: [{ name: 'Accept', value: 'application/json' }],
       preRequest: 'console.log(1)'
     };
-    const html = renderToStaticMarkup(<FolderConfiguration config={config} />);
-    expect(html).toContain('folder-config-headers');
-    expect(html).toContain('folder-config-script');
-    expect(html).toContain('Accept');
-    expect(html).not.toContain('folder-config-auth');
-    expect(html).not.toContain('folder-config-vars');
-    expect(html).not.toContain('folder-config-tests');
+    const root = useRenderToDom(<FolderConfiguration config={config} />);
+
+    expect(root.querySelector('[data-testid="folder-config-headers"]')).toBeTruthy();
+    expect(root.querySelector('[data-testid="folder-config-script"]')).toBeTruthy();
+    expect(root.querySelector('[data-testid="folder-config-headers"] .property-key')?.text.trim()).toBe('Accept');
+
+    expect(root.querySelector('[data-testid="folder-config-auth"]')).toBeNull();
+    expect(root.querySelector('[data-testid="folder-config-vars"]')).toBeNull();
+    expect(root.querySelector('[data-testid="folder-config-tests"]')).toBeNull();
   });
 
   it('labels the Auth group with an "Inherited from collection" badge when auth is inherited', () => {
@@ -36,11 +38,11 @@ describe('FolderConfiguration', () => {
       auth: { type: 'bearer', token: 't' } as any,
       authSource: { level: 'collection', name: 'API' }
     };
-    const html = renderToStaticMarkup(
-      <FolderConfiguration config={config} authModeLabels={{ bearer: 'Bearer Token' }} />
-    );
-    expect(html).toContain('folder-config-auth');
-    expect(html).toContain('Inherited from collection');
+    const root = useRenderToDom(<FolderConfiguration config={config} authModeLabels={{ bearer: 'Bearer Token' }} />);
+
+    const authGroup = root.querySelector('[data-testid="folder-config-auth"]');
+    expect(authGroup).toBeTruthy();
+    expect(authGroup?.querySelector('.config-group-head')?.text).toContain('Inherited from collection');
   });
 
   it('renders Pre-Request and Post-Response script columns and a separate Tests group', () => {
@@ -50,9 +52,12 @@ describe('FolderConfiguration', () => {
       postResponse: 'post()',
       tests: 'test()'
     };
-    const html = renderToStaticMarkup(<FolderConfiguration config={config} />);
-    expect(html).toContain('Pre-Request');
-    expect(html).toContain('Post-Response');
-    expect(html).toContain('folder-config-tests');
+    const root = useRenderToDom(<FolderConfiguration config={config} />);
+
+    const phases = root
+      .querySelectorAll('[data-testid="folder-config-script"] .config-phase-label')
+      .map((el) => el.text.trim());
+    expect(phases).toEqual(['Pre-Request', 'Post-Response']);
+    expect(root.querySelector('[data-testid="folder-config-tests"]')).toBeTruthy();
   });
 });

--- a/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.tsx
+++ b/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import type { FolderConfig } from '../../utils/folder';
+import { Code } from '../Code/Code';
+import { SectionLabel } from '../SectionLabel/SectionLabel';
+import { PropertyTable } from '../PropertyTable/PropertyTable';
+import { AuthDetails } from '../AuthDetails/AuthDetails';
+import { ContentTypeBadge } from '../ContentTypeBadge/ContentTypeBadge';
+import { StyledWrapper } from './StyledWrapper';
+
+interface FolderConfigurationProps {
+  config: FolderConfig;
+  authModeLabels?: Record<string, string>;
+  testId?: string;
+}
+
+export const FolderConfiguration: React.FC<FolderConfigurationProps> = ({ config, authModeLabels = {}, testId }) => {
+  const hasHeaders = config.headers.length > 0;
+  const hasAuth = Boolean(config.auth);
+  const hasScripts = Boolean(config.preRequest || config.postResponse);
+  const hasVariables = config.variables.length > 0;
+  const hasTests = Boolean(config.tests);
+  const inheritedBadge = config.authSource ? `Inherited from ${config.authSource.level}` : undefined;
+
+  return (
+    <StyledWrapper className="folder-configuration" data-testid={testId}>
+      {hasHeaders && (
+        <div className="config-group" data-testid="folder-config-headers">
+          <div className="config-group-head">
+            <SectionLabel className="config-group-label">Headers</SectionLabel>
+          </div>
+          <PropertyTable
+            rows={config.headers.map((header) => ({ label: header.name, value: header.value, disabled: header.disabled }))}
+          />
+        </div>
+      )}
+
+      {hasAuth && (
+        <div className="config-group" data-testid="folder-config-auth">
+          <div className="config-group-head">
+            <SectionLabel className="config-group-label">Auth</SectionLabel>
+            {inheritedBadge && <ContentTypeBadge label={inheritedBadge} />}
+          </div>
+          <AuthDetails auth={config.auth} authModeLabels={authModeLabels} testId="folder-config-auth-details" />
+        </div>
+      )}
+
+      {hasScripts && (
+        <div className="config-group" data-testid="folder-config-script">
+          <div className="config-group-head">
+            <SectionLabel className="config-group-label">Script</SectionLabel>
+          </div>
+          <div className="config-columns">
+            {config.preRequest && (
+              <div className="config-column">
+                <p className="config-phase-label">Pre-Request</p>
+                <Code code={config.preRequest} language="javascript" showLineNumbers />
+              </div>
+            )}
+            {config.postResponse && (
+              <div className="config-column">
+                <p className="config-phase-label">Post-Response</p>
+                <Code code={config.postResponse} language="javascript" showLineNumbers />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {hasVariables && (
+        <div className="config-group" data-testid="folder-config-vars">
+          <div className="config-group-head">
+            <SectionLabel className="config-group-label">Vars</SectionLabel>
+          </div>
+          <div className="config-columns">
+            <div className="config-column">
+              <p className="config-phase-label">Pre-Request</p>
+              <PropertyTable
+                rows={config.variables.map((variable) => ({
+                  label: variable.name,
+                  value: variable.value,
+                  disabled: variable.disabled
+                }))}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {hasTests && (
+        <div className="config-group" data-testid="folder-config-tests">
+          <div className="config-group-head">
+            <SectionLabel className="config-group-label">Tests</SectionLabel>
+          </div>
+          <Code code={config.tests as string} language="javascript" showLineNumbers testId="folder-config-tests-code" />
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+export default FolderConfiguration;

--- a/packages/oc-docs/src/components/FolderConfiguration/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/FolderConfiguration/StyledWrapper.ts
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  .config-group:not(:first-child) {
+    margin-top: 1.75rem;
+  }
+
+  .config-group-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.625rem;
+  }
+  .config-group-head .config-group-label {
+    margin: 0;
+  }
+
+  .config-columns {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+
+  @media (max-width: 900px) {
+    .config-columns {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+
+  .config-column {
+    min-width: 0;
+  }
+
+  .config-phase-label {
+    margin: 0 0 0.375rem 0;
+    font-family: var(--font-sans);
+    font-weight: 500;
+    font-size: 0.625rem;
+    line-height: 1;
+    letter-spacing: 0.0525rem;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+  }
+`;

--- a/packages/oc-docs/src/components/PageRouter/PageRouter.tsx
+++ b/packages/oc-docs/src/components/PageRouter/PageRouter.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import type { HttpRequest } from '@opencollection/types/requests/http';
-import type { ScriptFile } from '@opencollection/types/collection/item';
+import type { ScriptFile, Folder as FolderItem } from '@opencollection/types/collection/item';
 import { useActiveResolution, useNavModel } from '../../routing/hooks';
 import { useAppSelector } from '../../store/hooks';
 import { selectDocsCollection } from '../../store/slices/docs';
@@ -13,6 +13,7 @@ import { StyledWrapper } from './StyledWrapper';
 import { Overview } from '../../pages/Overview/Overview';
 import Request from '../../pages/Request/Request';
 import Script from '../../pages/Script/Script';
+import Folder from '../../pages/Folder/Folder';
 import Environments from '../../pages/Environments/Environments';
 import type { PageProps } from '../../routing/types';
 
@@ -63,8 +64,11 @@ const PageRouter: React.FC<PageRouterProps> = ({ onOpenPlayground, testId = 'pag
       case 'environments':
         return <Environments {...pageProps} />;
       case 'folder':
-        // A folder shows the collection overview (matches the pre-routing behaviour).
-        return <Overview collection={collection} />;
+        return item ? (
+          <Folder item={item as FolderItem} ancestry={ancestry} collection={collection} onBreadcrumbClick={goToUuid} />
+        ) : (
+          <Overview collection={collection} />
+        );
       case 'script':
         return item ? (
           <Script item={item as ScriptFile} ancestry={ancestry} collection={collection} onBreadcrumbClick={goToUuid} />

--- a/packages/oc-docs/src/components/Request/RequestDescription/RequestDescription.tsx
+++ b/packages/oc-docs/src/components/Request/RequestDescription/RequestDescription.tsx
@@ -9,14 +9,14 @@ interface RequestDescriptionProps {
 }
 
 const DURATION_MS = 280;
-const PREVIEW_LINES = 3;
+const PREVIEW_MAX_HEIGHT_REM = 4.5;
 
 const prefersReducedMotion = (): boolean =>
   typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
 
-const previewHeight = (el: HTMLElement): number => {
-  const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
-  return Math.round((Number.isNaN(lineHeight) ? el.clientHeight / PREVIEW_LINES : lineHeight) * PREVIEW_LINES);
+const previewHeight = (): number => {
+  const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+  return Math.round(PREVIEW_MAX_HEIGHT_REM * rootFontSize);
 };
 
 export const RequestDescription: React.FC<RequestDescriptionProps> = ({ html, style, className, testId = 'request-description' }) => {
@@ -63,7 +63,7 @@ export const RequestDescription: React.FC<RequestDescriptionProps> = ({ html, st
 
     requestAnimationFrame(() => {
       void el.offsetHeight;
-      el.style.maxHeight = `${next ? el.scrollHeight : previewHeight(el)}px`;
+      el.style.maxHeight = `${next ? el.scrollHeight : previewHeight()}px`;
     });
   };
 
@@ -87,6 +87,7 @@ export const RequestDescription: React.FC<RequestDescriptionProps> = ({ html, st
           type="button"
           className="request-description-toggle"
           aria-expanded={expanded}
+          data-testid={`${testId}-toggle`}
           onClick={toggle}
         >
           <span>{expanded ? 'View less' : 'View more'}</span>

--- a/packages/oc-docs/src/components/Request/RequestDescription/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Request/RequestDescription/StyledWrapper.ts
@@ -3,15 +3,22 @@ import styled from '@emotion/styled';
 export const StyledWrapper = styled.div`
   .request-description-body {
     color: var(--text-secondary);
+    overflow: hidden;
+  }
+  .request-description-body > :first-child {
+    margin-top: 0;
+  }
+  .request-description-body > :last-child {
+    margin-bottom: 0;
+  }
+  &:not(.is-expanded) .request-description-body {
+    -webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent);
+    mask-image: linear-gradient(to bottom, #000 55%, transparent);
   }
   &:not(.is-expanded):not(.is-animating) .request-description-body {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    max-height: 4.5rem;
   }
   &.is-animating .request-description-body {
-    overflow: hidden;
     transition: max-height 0.28s cubic-bezier(0.4, 0, 0.2, 1);
     will-change: max-height;
   }

--- a/packages/oc-docs/src/hooks/useRenderToDom.ts
+++ b/packages/oc-docs/src/hooks/useRenderToDom.ts
@@ -1,0 +1,9 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { parse } from 'node-html-parser';
+import type { ReactElement } from 'react';
+
+export const useRenderToDom = (ui: ReactElement) => {
+  const root = parse(renderToStaticMarkup(ui));
+  root.querySelectorAll('style').forEach((node) => node.remove());
+  return root;
+};

--- a/packages/oc-docs/src/pages/Folder/Folder.spec.tsx
+++ b/packages/oc-docs/src/pages/Folder/Folder.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import type { OpenCollection } from '@opencollection/types';
+import { Folder } from './Folder';
+
+const collection = {
+  info: { name: 'Hotel Booking API' },
+  request: { auth: { type: 'bearer', token: 't' } }
+} as unknown as OpenCollection;
+
+describe('Folder', () => {
+  it('renders the folder name, request count and its configuration', () => {
+    const folder: any = {
+      info: { name: 'Authentication' },
+      request: { auth: 'inherit', scripts: [{ type: 'before-request', code: 'pre()' }] },
+      items: [{ info: { type: 'http' } }, { info: { type: 'http' } }, { info: { type: 'http' } }]
+    };
+
+    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+
+    expect(html).toContain('Authentication');
+    expect(html).toContain('3 requests');
+    expect(html).toContain('Folder Configuration');
+    expect(html).toContain('folder-config-auth');
+    expect(html).toContain('Inherited from collection');
+    expect(html).toContain('folder-config-script');
+    expect(html).not.toContain('folder-config-empty');
+  });
+
+  it('renders the documentation markdown in its own section', () => {
+    const folder: any = {
+      info: { name: 'Authentication' },
+      docs: { content: '# Auth docs\n\nDetailed **markdown** documentation.', type: 'text/markdown' },
+      items: []
+    };
+
+    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+
+    expect(html).toContain('Documentation');
+    expect(html).toContain('folder-docs');
+    expect(html).toContain('Auth docs');
+    expect(html).toContain('<strong>markdown</strong>');
+  });
+
+  it('omits the documentation section when the folder has no docs', () => {
+    const folder: any = { info: { name: 'Auth' }, items: [] };
+
+    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+
+    expect(html).not.toContain('folder-docs');
+    expect(html).not.toContain('Documentation');
+  });
+
+  it('renders the empty state when the folder has no configuration', () => {
+    const folder: any = { info: { name: 'Realtime' }, items: [{ info: { type: 'websocket' } }] };
+
+    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+
+    expect(html).toContain('Realtime');
+    expect(html).toContain('1 request');
+    expect(html).toContain('folder-config-empty');
+    expect(html).toContain('No folder configuration');
+    expect(html).not.toContain('folder-config-headers');
+  });
+});

--- a/packages/oc-docs/src/pages/Folder/Folder.spec.tsx
+++ b/packages/oc-docs/src/pages/Folder/Folder.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
 import type { OpenCollection } from '@opencollection/types';
+import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { Folder } from './Folder';
 
 const collection = {
@@ -17,15 +17,17 @@ describe('Folder', () => {
       items: [{ info: { type: 'http' } }, { info: { type: 'http' } }, { info: { type: 'http' } }]
     };
 
-    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+    const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
-    expect(html).toContain('Authentication');
-    expect(html).toContain('3 requests');
-    expect(html).toContain('Folder Configuration');
-    expect(html).toContain('folder-config-auth');
-    expect(html).toContain('Inherited from collection');
-    expect(html).toContain('folder-config-script');
-    expect(html).not.toContain('folder-config-empty');
+    expect(root.querySelector('[data-testid="folder-title"]')?.text.trim()).toBe('Authentication');
+    expect(root.querySelector('[data-testid="folder-request-count"]')?.text.trim()).toBe('3 requests');
+    expect(root.querySelector('[data-testid="folder-section-configuration"] h2')?.text.trim()).toBe('Folder Configuration');
+
+    const authGroup = root.querySelector('[data-testid="folder-config-auth"]');
+    expect(authGroup).toBeTruthy();
+    expect(authGroup?.text).toContain('Inherited from collection');
+    expect(root.querySelector('[data-testid="folder-config-script"]')).toBeTruthy();
+    expect(root.querySelector('[data-testid="folder-config-empty"]')).toBeNull();
   });
 
   it('renders the documentation markdown in its own section', () => {
@@ -35,32 +37,35 @@ describe('Folder', () => {
       items: []
     };
 
-    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+    const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
-    expect(html).toContain('Documentation');
-    expect(html).toContain('folder-docs');
-    expect(html).toContain('Auth docs');
-    expect(html).toContain('<strong>markdown</strong>');
+    expect(root.querySelector('[data-testid="folder-section-documentation"] h2')?.text.trim()).toBe('Documentation');
+    const docs = root.querySelector('[data-testid="folder-docs"]');
+    expect(docs).toBeTruthy();
+    expect(docs?.querySelector('h1')?.text.trim()).toBe('Auth docs');
+    expect(docs?.querySelector('strong')?.text.trim()).toBe('markdown');
   });
 
   it('omits the documentation section when the folder has no docs', () => {
     const folder: any = { info: { name: 'Auth' }, items: [] };
 
-    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+    const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
-    expect(html).not.toContain('folder-docs');
-    expect(html).not.toContain('Documentation');
+    expect(root.querySelector('[data-testid="folder-docs"]')).toBeNull();
+    expect(root.querySelector('[data-testid="folder-section-documentation"]')).toBeNull();
   });
 
   it('renders the empty state when the folder has no configuration', () => {
     const folder: any = { info: { name: 'Realtime' }, items: [{ info: { type: 'websocket' } }] };
 
-    const html = renderToStaticMarkup(<Folder item={folder} collection={collection} />);
+    const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
-    expect(html).toContain('Realtime');
-    expect(html).toContain('1 request');
-    expect(html).toContain('folder-config-empty');
-    expect(html).toContain('No folder configuration');
-    expect(html).not.toContain('folder-config-headers');
+    expect(root.querySelector('[data-testid="folder-title"]')?.text.trim()).toBe('Realtime');
+    expect(root.querySelector('[data-testid="folder-request-count"]')?.text.trim()).toBe('1 request');
+
+    const empty = root.querySelector('[data-testid="folder-config-empty"]');
+    expect(empty).toBeTruthy();
+    expect(empty?.querySelector('.empty-state-heading')?.text.trim()).toBe('No folder configuration');
+    expect(root.querySelector('[data-testid="folder-config-headers"]')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/pages/Folder/Folder.tsx
+++ b/packages/oc-docs/src/pages/Folder/Folder.tsx
@@ -4,6 +4,7 @@ import type { Item, Folder as FolderItem } from '@opencollection/types/collectio
 import { useMarkdownRenderer } from '../../hooks';
 import { AUTH_MODE_LABELS } from '../../constants';
 import { getItemName, getItemDocs } from '../../utils/schemaHelpers';
+import { buildBreadcrumbSegments } from '../../utils/common';
 import { getFolderConfig, hasFolderConfig, countFolderRequests } from '../../utils/folder';
 import { PageWrapper } from '../../components/PageWrapper/PageWrapper';
 import { Heading } from '../../components/Heading/Heading';
@@ -38,11 +39,8 @@ export const Folder: React.FC<FolderProps> = ({ item, ancestry = [], collection,
   }, [item, md]);
 
   const segments = useMemo<BreadcrumbSegment[]>(
-    () =>
-      ancestry
-        .map((folder) => ({ name: getItemName(folder) || 'Folder', uuid: (folder as { uuid?: string }).uuid || '' }))
-        .filter((segment) => segment.uuid),
-    [ancestry]
+    () => buildBreadcrumbSegments(collection, ancestry),
+    [collection, ancestry]
   );
 
   return (

--- a/packages/oc-docs/src/pages/Folder/Folder.tsx
+++ b/packages/oc-docs/src/pages/Folder/Folder.tsx
@@ -1,0 +1,88 @@
+import React, { useMemo } from 'react';
+import type { OpenCollection } from '@opencollection/types';
+import type { Item, Folder as FolderItem } from '@opencollection/types/collection/item';
+import { useMarkdownRenderer } from '../../hooks';
+import { AUTH_MODE_LABELS } from '../../constants';
+import { getItemName, getItemDocs } from '../../utils/schemaHelpers';
+import { getFolderConfig, hasFolderConfig, countFolderRequests } from '../../utils/folder';
+import { PageWrapper } from '../../components/PageWrapper/PageWrapper';
+import { Heading } from '../../components/Heading/Heading';
+import { Section } from '../../components/Section/Section';
+import { Breadcrumb, type BreadcrumbSegment } from '../../ui/Breadcrumb/Breadcrumb';
+import { RequestDescription } from '../../components/Request/RequestDescription/RequestDescription';
+import { EmptyState } from '../../ui/EmptyState/EmptyState';
+import { FolderConfiguration } from '../../components/FolderConfiguration/FolderConfiguration';
+import { FolderIcon } from '../../assets/icons';
+import { StyledWrapper } from './StyledWrapper';
+
+interface FolderProps {
+  item: FolderItem;
+  ancestry?: Item[];
+  collection?: OpenCollection | null;
+  onBreadcrumbClick?: (uuid: string) => void;
+}
+
+const requestCountLabel = (count: number): string => `${count} request${count === 1 ? '' : 's'}`;
+
+export const Folder: React.FC<FolderProps> = ({ item, ancestry = [], collection, onBreadcrumbClick }) => {
+  const md = useMarkdownRenderer();
+
+  const name = getItemName(item) || 'Untitled Folder';
+  const requestCount = useMemo(() => countFolderRequests(item), [item]);
+  const config = useMemo(() => getFolderConfig(collection, ancestry, item), [collection, ancestry, item]);
+  const showConfig = useMemo(() => hasFolderConfig(config), [config]);
+
+  const docsHtml = useMemo(() => {
+    const content = getItemDocs(item) || '';
+    return content ? md.render(content) : '';
+  }, [item, md]);
+
+  const segments = useMemo<BreadcrumbSegment[]>(
+    () =>
+      ancestry
+        .map((folder) => ({ name: getItemName(folder) || 'Folder', uuid: (folder as { uuid?: string }).uuid || '' }))
+        .filter((segment) => segment.uuid),
+    [ancestry]
+  );
+
+  return (
+    <PageWrapper>
+      <StyledWrapper className="folder" data-testid="folder-page">
+        <Breadcrumb segments={segments} current={name} onSegmentClick={onBreadcrumbClick} testId="folder-breadcrumb" />
+
+        <header className="folder-header">
+          <span className="folder-header-icon" aria-hidden="true">
+            <FolderIcon />
+          </span>
+          <div className="folder-header-text">
+            <Heading size="md" testId="folder-title">{name}</Heading>
+            <span className="folder-header-count" data-testid="folder-request-count">
+              {requestCountLabel(requestCount)}
+            </span>
+          </div>
+        </header>
+
+        {docsHtml && (
+          <Section label="Documentation" testId="folder-section-documentation" className="folder-fullwidth">
+            <RequestDescription html={docsHtml} testId="folder-docs" />
+          </Section>
+        )}
+
+        <Section label="Folder Configuration" testId="folder-section-configuration" className="folder-fullwidth">
+          {showConfig ? (
+            <FolderConfiguration config={config} authModeLabels={AUTH_MODE_LABELS} testId="folder-config" />
+          ) : (
+            <EmptyState
+              testId="folder-config-empty"
+              icon={<FolderIcon />}
+              heading="No folder configuration"
+              subheading="This folder has no headers, auth, scripts, vars, or tests set. Requests inside it inherit configuration from the collection."
+            />
+          )}
+        </Section>
+      </StyledWrapper>
+    </PageWrapper>
+  );
+};
+
+export default Folder;

--- a/packages/oc-docs/src/pages/Folder/StyledWrapper.ts
+++ b/packages/oc-docs/src/pages/Folder/StyledWrapper.ts
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  color: var(--text-primary);
+  padding-bottom: 2rem;
+
+  .folder-header {
+    display: flex;
+    align-items: center;
+    gap: 0.875rem;
+    margin-top: 0.875rem;
+  }
+
+  .folder-header-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 0.625rem;
+    background: var(--oc-background-mantle);
+    color: var(--text-secondary);
+    flex-shrink: 0;
+  }
+  .folder-header-icon svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .folder-header-text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.375rem;
+    min-width: 0;
+  }
+
+  .folder-header-count {
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    background: var(--oc-background-surface0);
+    font-family: var(--font-sans);
+    font-weight: 700;
+    font-size: 0.75rem;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--oc-colors-text-subtext1);
+  }
+
+  .folder-fullwidth {
+    margin-top: 1rem;
+  }
+`;

--- a/packages/oc-docs/src/pages/Request/Request.tsx
+++ b/packages/oc-docs/src/pages/Request/Request.tsx
@@ -18,6 +18,7 @@ import {
   getHttpBody,
   getRequestAuth,
   getItemDocs,
+  getItemDescription,
   getRequestExamples,
   isUnsupportedRequest
 } from '../../utils/schemaHelpers';
@@ -58,15 +59,9 @@ interface RequestProps {
   onBreadcrumbClick?: (uuid: string) => void;
 }
 
-type RequestContentProps = Omit<RequestProps, 'item'> & { item: HttpRequest; testId?: string };
+type RequestContentProps = Omit<RequestProps, 'item'> & { item: HttpRequest };
 
-const descriptionContent = (item: HttpRequest): string => {
-  const docs = getItemDocs(item);
-  if (docs) return docs;
-  const info = (item.info?.description ?? '') as Description;
-  if (typeof info === 'string') return info;
-  return (info && typeof info === 'object' && 'content' in info ? info.content : '') || '';
-};
+const descriptionContent = (item: HttpRequest): string => getItemDocs(item) || getItemDescription(item);
 
 const RequestContent: React.FC<RequestContentProps> = ({
   item,
@@ -96,12 +91,10 @@ const RequestContent: React.FC<RequestContentProps> = ({
     return content ? md.render(content) : '';
   }, [item, md]);
 
-  // Auth: resolve `inherit` to its effective source for display + code generation.
   const ownAuth = getRequestAuth(item) as Auth | undefined;
   const resolved = useMemo(() => resolveInheritedAuth(collection, ancestry, item), [collection, ancestry, item]);
   const effectiveAuth = ownAuth === 'inherit' ? resolved.auth : ownAuth;
   const showAuth = ownAuth !== undefined;
-  // Heading badge for inherited auth, e.g. "Inherited from collection".
   const authInheritedBadge =
     ownAuth === 'inherit' ? (resolved.source ? `Inherited from ${resolved.source.level}` : 'Inherited') : undefined;
 
@@ -126,7 +119,6 @@ const RequestContent: React.FC<RequestContentProps> = ({
   const hasExecutionContext = scriptChain.length > 0 || hasVars || assertions.length > 0 || tests.length > 0;
   const hasLeftColumn = showAuth || hasParams || hasBody || hasHeaders;
 
-  // Content-type label shown as a badge on the BODY heading (e.g. "application/json").
   const bodyContentType = useMemo(() => {
     const view = getBodyView(body);
     return view.render !== 'none' ? view.contentTypeLabel : undefined;
@@ -179,7 +171,6 @@ const RequestContent: React.FC<RequestContentProps> = ({
                   <AuthDetails auth={effectiveAuth} authModeLabels={AUTH_MODE_LABELS} />
                 </Section>
               )}
-
             </div>
 
             <div className="request-col-right">

--- a/packages/oc-docs/src/pages/Request/Request.tsx
+++ b/packages/oc-docs/src/pages/Request/Request.tsx
@@ -3,7 +3,6 @@ import type { OpenCollection } from '@opencollection/types';
 import type { Item } from '@opencollection/types/collection/item';
 import type { HttpRequest, HttpRequestParam } from '@opencollection/types/requests/http';
 import type { Auth } from '@opencollection/types/common/auth';
-import type { Description } from '@opencollection/types/common/description';
 import type { GraphQLRequest } from '@opencollection/types/requests/graphql';
 import type { GrpcRequest } from '@opencollection/types/requests/grpc';
 import type { WebSocketRequest } from '@opencollection/types/requests/websocket';
@@ -57,6 +56,7 @@ interface RequestProps {
   collection?: OpenCollection | null;
   onTryClick?: () => void;
   onBreadcrumbClick?: (uuid: string) => void;
+  testId?: string;
 }
 
 type RequestContentProps = Omit<RequestProps, 'item'> & { item: HttpRequest };

--- a/packages/oc-docs/src/sampleCollection.ts
+++ b/packages/oc-docs/src/sampleCollection.ts
@@ -104,6 +104,13 @@ items:
       name: billing
       type: folder
       seq: 4
+    docs: |
+      ## Billing
+
+      Endpoints for managing **customers** and their invoices.
+
+      - Auth is **inherited** from the collection.
+      - Folder-level scripts record the execution chain for every request inside.
     request:
       auth: inherit
       scripts:

--- a/packages/oc-docs/src/utils/folder.spec.ts
+++ b/packages/oc-docs/src/utils/folder.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { getFolderConfig, hasFolderConfig, countFolderRequests, resolveFolderAuth } from './folder';
+
+const collection: any = {
+  info: { name: 'Hotel Booking API' },
+  request: { auth: { type: 'bearer', token: '{{token}}' } }
+};
+
+describe('resolveFolderAuth', () => {
+  it('returns the folder own auth when it is concrete', () => {
+    const folder: any = { request: { auth: { type: 'basic', username: 'u' } } };
+    expect(resolveFolderAuth(collection, [], folder)).toEqual({ auth: { type: 'basic', username: 'u' } });
+  });
+
+  it('resolves inherited auth from the collection with a source', () => {
+    const folder: any = { request: { auth: 'inherit' } };
+    const resolved = resolveFolderAuth(collection, [], folder);
+    expect(resolved.auth).toMatchObject({ type: 'bearer' });
+    expect(resolved.source).toEqual({ level: 'collection', name: 'Hotel Booking API' });
+  });
+
+  it('resolves inherited auth from the nearest ancestor folder', () => {
+    const parent: any = { info: { name: 'Parent' }, request: { auth: { type: 'apikey', key: 'k' } } };
+    const folder: any = { request: { auth: 'inherit' } };
+    const resolved = resolveFolderAuth(collection, [parent], folder);
+    expect(resolved.auth).toMatchObject({ type: 'apikey' });
+    expect(resolved.source).toEqual({ level: 'folder', name: 'Parent' });
+  });
+});
+
+describe('getFolderConfig', () => {
+  it('derives headers, auth, scripts and variables from the folder request block', () => {
+    const folder: any = {
+      request: {
+        headers: [
+          { name: 'Accept', value: 'application/json' },
+          { name: 'X-Disabled', value: 'x', disabled: true }
+        ],
+        auth: 'inherit',
+        variables: [{ name: 'sessionId', value: '{{$randomUUID}}' }],
+        scripts: [
+          { type: 'before-request', code: 'pre' },
+          { type: 'after-response', code: 'post' },
+          { type: 'tests', code: 'test()' }
+        ]
+      }
+    };
+
+    const config = getFolderConfig(collection, [], folder);
+
+    expect(config.headers).toEqual([{ name: 'Accept', value: 'application/json', disabled: undefined }]);
+    expect(config.auth).toMatchObject({ type: 'bearer' });
+    expect(config.authSource).toEqual({ level: 'collection', name: 'Hotel Booking API' });
+    expect(config.preRequest).toBe('pre');
+    expect(config.postResponse).toBe('post');
+    expect(config.tests).toBe('test()');
+    expect(config.variables).toEqual([{ name: 'sessionId', value: '{{$randomUUID}}', disabled: undefined }]);
+  });
+
+  it('leaves auth undefined when inheritance cannot resolve to a concrete value', () => {
+    const folder: any = { request: { auth: 'inherit' } };
+    expect(getFolderConfig(null, [], folder).auth).toBeUndefined();
+  });
+});
+
+describe('hasFolderConfig', () => {
+  it('is false for a folder with no configuration', () => {
+    const folder: any = { items: [{ info: { type: 'http' } }] };
+    expect(hasFolderConfig(getFolderConfig(null, [], folder))).toBe(false);
+  });
+
+  it('is true when any configuration is present', () => {
+    const folder: any = { request: { scripts: [{ type: 'before-request', code: 'x' }] } };
+    expect(hasFolderConfig(getFolderConfig(null, [], folder))).toBe(true);
+  });
+});
+
+describe('countFolderRequests', () => {
+  it('counts request items recursively, excluding folders and scripts', () => {
+    const folder: any = {
+      items: [
+        { info: { type: 'http' } },
+        { info: { type: 'script' }, script: '{}' },
+        {
+          info: { type: 'folder' },
+          items: [{ info: { type: 'graphql' } }, { info: { type: 'grpc' } }]
+        }
+      ]
+    };
+    expect(countFolderRequests(folder)).toBe(3);
+  });
+
+  it('returns zero for an empty folder', () => {
+    expect(countFolderRequests({ items: [] } as any)).toBe(0);
+    expect(countFolderRequests({} as any)).toBe(0);
+  });
+});

--- a/packages/oc-docs/src/utils/folder.ts
+++ b/packages/oc-docs/src/utils/folder.ts
@@ -1,0 +1,117 @@
+import type { OpenCollection } from '@opencollection/types';
+import type { Item, Folder } from '@opencollection/types/collection/item';
+import type { Auth } from '@opencollection/types/common/auth';
+import type { Variable } from '@opencollection/types/common/variables';
+import { getItemName, isFolder, isScriptFile, scriptsArrayToObject } from './schemaHelpers';
+
+export interface FolderHeaderRow {
+  name: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface FolderVariableRow {
+  name: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface FolderAuthSource {
+  level: 'collection' | 'folder';
+  name: string;
+}
+
+export interface FolderConfig {
+  headers: FolderHeaderRow[];
+  auth?: Auth;
+  authSource?: FolderAuthSource;
+  preRequest?: string;
+  postResponse?: string;
+  tests?: string;
+  variables: FolderVariableRow[];
+}
+
+const isConcrete = (auth: Auth | undefined): boolean => !!auth && auth !== 'inherit';
+
+const folderAuthOf = (item: Item): Auth | undefined => (item as { request?: { auth?: Auth } }).request?.auth;
+
+const flattenValue = (value: Variable['value']): string => {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const selected = value.find((variant) => variant.selected) ?? value[0];
+    return selected ? flattenValue(selected.value) : '';
+  }
+  return typeof value.data === 'string' ? value.data : '';
+};
+
+export const resolveFolderAuth = (
+  collection: OpenCollection | null | undefined,
+  ancestors: Item[],
+  folder: Folder
+): { auth?: Auth; source?: FolderAuthSource } => {
+  const own = folder.request?.auth;
+  if (own !== 'inherit') return { auth: own };
+
+  for (let i = ancestors.length - 1; i >= 0; i -= 1) {
+    const auth = folderAuthOf(ancestors[i]);
+    if (isConcrete(auth)) {
+      return { auth, source: { level: 'folder', name: getItemName(ancestors[i]) || 'Folder' } };
+    }
+  }
+
+  const collectionAuth = collection?.request?.auth as Auth | undefined;
+  if (isConcrete(collectionAuth)) {
+    return { auth: collectionAuth, source: { level: 'collection', name: collection?.info?.name || 'Collection' } };
+  }
+
+  return { auth: 'inherit' };
+};
+
+export const getFolderConfig = (
+  collection: OpenCollection | null | undefined,
+  ancestors: Item[],
+  folder: Folder
+): FolderConfig => {
+  const headers = (folder.request?.headers ?? [])
+    .filter((header) => header && header.name && header.disabled !== true)
+    .map((header) => ({ name: header.name, value: header.value, disabled: header.disabled }));
+
+  const { auth, source } = resolveFolderAuth(collection, ancestors, folder);
+  const scripts = scriptsArrayToObject(folder.request?.scripts);
+
+  const variables = (folder.request?.variables ?? [])
+    .filter((variable) => variable && variable.name)
+    .map((variable) => ({ name: variable.name, value: flattenValue(variable.value), disabled: variable.disabled }));
+
+  return {
+    headers,
+    auth: isConcrete(auth) ? auth : undefined,
+    authSource: source,
+    preRequest: scripts.preRequest,
+    postResponse: scripts.postResponse,
+    tests: scripts.tests,
+    variables
+  };
+};
+
+export const hasFolderConfig = (config: FolderConfig): boolean =>
+  config.headers.length > 0 ||
+  Boolean(config.auth) ||
+  Boolean(config.preRequest || config.postResponse || config.tests) ||
+  config.variables.length > 0;
+
+export const countFolderRequests = (folder: Folder): number => {
+  let count = 0;
+  const walk = (items: Item[] | undefined): void => {
+    for (const item of items ?? []) {
+      if (isFolder(item)) {
+        walk((item as Folder).items);
+      } else if (!isScriptFile(item)) {
+        count += 1;
+      }
+    }
+  };
+  walk(folder.items);
+  return count;
+};

--- a/packages/oc-docs/src/utils/schemaHelpers.spec.ts
+++ b/packages/oc-docs/src/utils/schemaHelpers.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getItemDescription } from './schemaHelpers';
+
+describe('getItemDescription', () => {
+  it('reads a plain string description from the info block', () => {
+    expect(getItemDescription({ info: { description: 'Short summary.' } } as any)).toBe('Short summary.');
+  });
+
+  it('reads the content of a structured description', () => {
+    expect(
+      getItemDescription({ info: { description: { content: 'Rich summary.', type: 'text/markdown' } } } as any)
+    ).toBe('Rich summary.');
+  });
+
+  it('returns an empty string when there is no description', () => {
+    expect(getItemDescription({ info: {} } as any)).toBe('');
+    expect(getItemDescription({} as any)).toBe('');
+    expect(getItemDescription(null)).toBe('');
+    expect(getItemDescription(undefined)).toBe('');
+  });
+});

--- a/packages/oc-docs/src/utils/schemaHelpers.ts
+++ b/packages/oc-docs/src/utils/schemaHelpers.ts
@@ -475,6 +475,19 @@ export const getItemDocs = (item: OpenCollectionItem | null | undefined): string
 };
 
 /**
+ * Get the short description from an item's info block.
+ * Handles both string format and object format { content, type }.
+ */
+export const getItemDescription = (item: OpenCollectionItem | null | undefined): string => {
+  const description = (item as { info?: { description?: unknown } } | null | undefined)?.info?.description;
+  if (typeof description === 'string') return description;
+  if (description && typeof description === 'object' && 'content' in description) {
+    return (description as { content?: string }).content || '';
+  }
+  return '';
+};
+
+/**
  * Get settings from a request (from settings block or root)
  */
 export const getRequestSettings = (item: RequestItem | null | undefined): any => {


### PR DESCRIPTION
Problem
Folders render inline in the flat list; there's no dedicated folder page for folder docs, its headers/auth/variables/scripts, and child requests.

Proposed Solution
A folder page that separates the folder docs from the folder configuration. It renders the folder docs (markdown) at the top, a Folder Configuration section grouping the folder's headers, auth, script (pre-request and post-response), and variables via the shared sections, and a list of child endpoints with a count.

https://usebruno.atlassian.net/browse/BRU-3569

<img width="2988" height="1778" alt="image" src="https://github.com/user-attachments/assets/12c96f5d-378f-4ac0-b480-046824d53119" />
