### PR TITLE
CDN URL build path change in opencollection

### DIFF
--- a/examples/standalone-html/index.html
+++ b/examples/standalone-html/index.html
@@ -14,8 +14,8 @@
 			height: 100vh;
 		}
 	</style>
-	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/docs.css">
-	<script src="../../packages/oc-docs/dist-standalone/docs.js"></script>
+	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/index.css">
+	<script src="../../packages/oc-docs/dist-standalone/index.js"></script>
 </head>
 
 

--- a/examples/standalone-html/index2.html
+++ b/examples/standalone-html/index2.html
@@ -14,8 +14,8 @@
 			height: 100vh;
 		}
 	</style>
-	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/docs.css">
-	<script src="../../packages/oc-docs/dist-standalone/docs.js"></script>
+	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/index.css">
+	<script src="../../packages/oc-docs/dist-standalone/index.js"></script>
 </head>
 
 

--- a/packages/oc-docs/playwright.config.ts
+++ b/packages/oc-docs/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     },
   ],
   webServer: {

--- a/packages/oc-docs/playwright.config.ts
+++ b/packages/oc-docs/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
   webServer: {

--- a/packages/oc-docs/vite.config.standalone.ts
+++ b/packages/oc-docs/vite.config.standalone.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/standalone.ts'),
       name: 'OpenCollectionPlayground',
-      fileName: (format) => format === 'umd' ? 'docs.js' : 'docs.esm.js',
+      fileName: (format) => format === 'umd' ? 'index.js' : 'index.esm.js',
       formats: ['umd', 'es']
     },
     cssCodeSplit: false,
@@ -36,7 +36,7 @@ export default defineConfig({
         // Ensure CSS is extracted properly
         assetFileNames: (assetInfo) => {
           if (assetInfo.name && assetInfo.name.endsWith('.css')) {
-            return 'docs.css';
+            return 'index.css';
           }
           return assetInfo.name || 'asset';
         }


### PR DESCRIPTION
Problem
The standalone renderer will be served from cdn.usebruno.com/docs/index.js + index.css (using index under the /docs/ prefix rather than repeating the name as docs.js). Two source changes are needed to make the emitted asset and the consumer agree on the new naming.

Proposed Solution
opencollection / oc-docs — in vite.config.standalone.ts, change the standalone build output names:

UMD fileName: docs.js → index.js

CSS assetFileNames: docs.css → index.css

ES fileName: docs.esm.js → index.esm.js for consistency

bruno / bruno-app — in the Generate Documentation component:

CDN_BASE_URL: https://cdn.opencollection.com → https://cdn.usebruno.com

template refs: ${CDN_BASE_URL}/docs.css → ${CDN_BASE_URL}/docs/index.css, ${CDN_BASE_URL}/docs.js → ${CDN_BASE_URL}/docs/index.js

https://usebruno.atlassian.net/browse/BRU-3709