### PR TITLE
feat(file-body): add description field to file body variants

### DIFF
--- a/packages/oc-docs/src/utils/request.spec.ts
+++ b/packages/oc-docs/src/utils/request.spec.ts
@@ -96,13 +96,18 @@ describe('requestBody', () => {
     const view = getBodyView({
       type: 'file',
       data: [
-        { filePath: '/a.json', contentType: 'application/json', selected: true },
+        { filePath: '/a.json', contentType: 'application/json', selected: true, description: 'Primary payload' },
         { filePath: '/b.xml', contentType: 'application/xml', selected: false }
       ]
     } as any) as any;
     expect(view.render).toBe('file');
     expect(view.files).toHaveLength(2);
-    expect(view.files[0]).toMatchObject({ filePath: '/a.json', contentType: 'application/json', selected: true });
+    expect(view.files[0]).toMatchObject({
+      filePath: '/a.json',
+      contentType: 'application/json',
+      selected: true,
+      description: 'Primary payload'
+    });
   });
 
   it('treats an empty file body as none', () => {

--- a/packages/oc-docs/src/utils/request.ts
+++ b/packages/oc-docs/src/utils/request.ts
@@ -85,6 +85,7 @@ export interface FileBodyRow {
   filePath: string;
   contentType?: string;
   selected?: boolean;
+  description?: string;
 }
 
 export type BodyView =
@@ -257,7 +258,7 @@ export const getBodyView = (
     case 'file': {
       const variants: FileBodyVariant[] = body.data || [];
       const files: FileBodyRow[] = variants
-        .map((v) => ({ filePath: v.filePath, contentType: v.contentType, selected: v.selected }))
+        .map((v) => ({ filePath: v.filePath, contentType: v.contentType, selected: v.selected, description: getDescription(v) }))
         .filter((f) => f.filePath || f.contentType);
       if (files.length === 0) return { render: 'none' };
       return { render: 'file', contentTypeLabel: bodyContentTypeLabel('file'), files };

--- a/packages/oc-schema/src/opencollection.schema.json
+++ b/packages/oc-schema/src/opencollection.schema.json
@@ -819,6 +819,10 @@
         "selected": {
           "type": "boolean",
           "description": "Whether the file is selected"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the file variant"
         }
       },
       "required": ["filePath", "contentType", "selected"],

--- a/packages/oc-spec-site/src/components/sections/BodyType.jsx
+++ b/packages/oc-spec-site/src/components/sections/BodyType.jsx
@@ -34,7 +34,7 @@ function BodyType({ bodyType, schema }) {
       'file-body': {
         type: "file",
         data: [
-          { filePath: "/path/to/upload.jpg", contentType: "image/jpeg", selected: true }
+          { filePath: "/path/to/upload.jpg", contentType: "image/jpeg", selected: true, description: "Profile picture upload" }
         ]
       }
     };

--- a/packages/oc-spec-site/src/schema.json
+++ b/packages/oc-spec-site/src/schema.json
@@ -820,6 +820,10 @@
         "selected": {
           "type": "boolean",
           "description": "Whether the file is selected"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the file variant"
         }
       },
       "required": ["filePath", "contentType", "selected"],

--- a/packages/oc-types/src/requests/http.ts
+++ b/packages/oc-types/src/requests/http.ts
@@ -65,6 +65,7 @@ export interface FileBodyVariant {
   filePath: string;
   contentType: string;
   selected: boolean;
+  description?: Description;
 }
 
 /** @deprecated Use FileBodyVariant instead */


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-2308)

Adds `description` as a field for FileBodyVariants type to support row level descriptions for file/binary items. 

This is supported in all other rows but not in `FileBodyVariants`

Done to support the implementation of [PR](https://github.com/usebruno/bruno/pull/8434)