### PR TITLE
fix(oc-docs): sort sidebar to mirror the Bruno app order (BRU-3403)

### DIFF
--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.tsx
@@ -5,7 +5,7 @@ import { ChevronRightIcon } from '../../../../assets/icons';
 import { StyledWrapper } from './StyledWrapper';
 import { getItemName, isFolder, isScriptFile, getRequestBadgeLabel } from '../../../../utils/schemaHelpers';
 import { getItemUuid } from '../../../../utils/itemUtils';
-import { sortSiblings } from '../../../../routing/navModel';
+import { orderSiblings } from '../../../../routing/navModel';
 
 interface SidebarTreeProps {
   items: OpenCollectionItem[];
@@ -25,7 +25,7 @@ const SidebarTree: React.FC<SidebarTreeProps> = ({
   onToggleFolder,
 }) => (
   <>
-    {sortSiblings(items).map((item: OpenCollectionItem) => {
+    {orderSiblings(items).map((item: OpenCollectionItem) => {
       const uuid = getItemUuid(item);
       const name = getItemName(item) || 'Untitled';
       const slug = uuid !== undefined ? uuidToSlug.get(uuid) : undefined;

--- a/packages/oc-docs/src/routing/index.ts
+++ b/packages/oc-docs/src/routing/index.ts
@@ -1,5 +1,5 @@
 export * from './types';
 export * from './slug';
-export { buildNavModel, sortSiblings, OVERVIEW_SLUG, ENVIRONMENTS_SLUG } from './navModel';
+export { buildNavModel, orderSiblings, OVERVIEW_SLUG, ENVIRONMENTS_SLUG } from './navModel';
 export { resolveSlug, normalizeSlug, type Resolution } from './resolve';
 export { useNavModel, useActiveResolution } from './hooks';

--- a/packages/oc-docs/src/routing/navModel.spec.ts
+++ b/packages/oc-docs/src/routing/navModel.spec.ts
@@ -3,12 +3,12 @@ import type { OpenCollection } from '@opencollection/types';
 import { buildNavModel, OVERVIEW_SLUG, ENVIRONMENTS_SLUG } from './navModel';
 
 // --- factories (new-schema info-block shape) -------------------------------
-const req = (name: string, seq: number, method = 'GET') => ({
+const req = (name: string, seq?: number, method = 'GET') => ({
   info: { name, type: 'http', seq },
   http: { method, url: `https://x/${name}` },
 });
 
-const folder = (name: string, seq: number, items: unknown[] = []) => ({
+const folder = (name: string, seq?: number, items: unknown[] = []) => ({
   info: { name, type: 'folder', seq },
   items,
 });
@@ -56,10 +56,34 @@ describe('buildNavModel — ordered sequence', () => {
     expect(slugs(c)).toEqual([OVERVIEW_SLUG, 'ping']);
   });
 
-  it('orders siblings by seq then name (honours reordering)', () => {
-    const c = collection([req('Zebra', 1), req('Apple', 2)]);
-    // seq wins over alphabetical
-    expect(slugs(c)).toEqual([OVERVIEW_SLUG, ENVIRONMENTS_SLUG, 'zebra', 'apple']);
+  it('sorts requests by seq (mirrors the Bruno app)', () => {
+    const c = collection([req('Zebra', 2), req('Apple', 1)]);
+    expect(slugs(c)).toEqual([OVERVIEW_SLUG, ENVIRONMENTS_SLUG, 'apple', 'zebra']);
+  });
+
+  it('groups folders before requests regardless of seq', () => {
+    // Request seq (1) is lower than the folder seq (2), but folders still come
+    // first — matching the app grouping [folders, requests, files].
+    const c = collection([req('Ping', 1), folder('Tools', 2, [req('Run', 1)])]);
+    expect(slugs(c)).toEqual([OVERVIEW_SLUG, ENVIRONMENTS_SLUG, 'tools', 'tools/run', 'ping']);
+  });
+
+  it('orders folders without a valid seq alphabetically', () => {
+    const c = collection([folder('Zoo', 0, []), folder('Ant', 0, [])]);
+    expect(slugs(c)).toEqual([OVERVIEW_SLUG, ENVIRONMENTS_SLUG, 'ant', 'zoo']);
+  });
+
+  it('splices a seq folder into the alphabetical base at position seq-1 (Bruno app parity)', () => {
+    // Alphabetical base = [Apple, Mango]; Zed has seq 1 so it lands at index 0.
+    const c = collection([folder('Zed', 1, []), folder('Apple'), folder('Mango')]);
+    expect(slugs(c)).toEqual([OVERVIEW_SLUG, ENVIRONMENTS_SLUG, 'zed', 'apple', 'mango']);
+  });
+
+  it('orders requests by seq and keeps a request without a seq', () => {
+    const c = collection([req('Zed', 2), req('Yak', 1), req('Loner')]);
+    const s = slugs(c);
+    expect(s).toContain('loner');
+    expect(s.indexOf('yak')).toBeLessThan(s.indexOf('zed'));
   });
 });
 

--- a/packages/oc-docs/src/routing/navModel.ts
+++ b/packages/oc-docs/src/routing/navModel.ts
@@ -1,6 +1,6 @@
 import type { OpenCollection } from '@opencollection/types';
 import type { Item as OpenCollectionItem, Folder } from '@opencollection/types/collection/item';
-import { getItemName, getItemSeq, getItemType, isFolder, getRequestBadgeLabel } from '../utils/schemaHelpers';
+import { getItemName, getItemSeq, getItemType, isFolder, isScriptFile, getRequestBadgeLabel } from '../utils/schemaHelpers';
 import { slugifySegment, dedupeSiblingSlugs } from './slug';
 import type { BreadcrumbSegment, NavEntry, NavModel, PageType } from './types';
 
@@ -14,18 +14,63 @@ const hasEnvironments = (collection: OpenCollection): boolean => {
   return Array.isArray(envs) && envs.length > 0;
 };
 
-/** Sort siblings by seq (ascending), then by name. */
-export const sortSiblings = (items: OpenCollectionItem[]): OpenCollectionItem[] =>
-  [...items].filter(Boolean).sort((a, b) => {
-    const seqA = getItemSeq(a);
-    const seqB = getItemSeq(b);
-    if (seqA !== undefined && seqB !== undefined && seqA !== seqB) {
-      return seqA - seqB;
+const isSeqValid = (seq: number | undefined): boolean =>
+  typeof seq === 'number' && Number.isFinite(seq) && Number.isInteger(seq) && seq > 0;
+
+/**
+ * Ported 1:1 from the Bruno app (`bruno-app/src/utils/common`, named
+ * `sortByNameThenSequence` there) so docs order matches the app. Sequence wins:
+ * items with a valid seq are spliced into index `seq - 1` (same-seq grouped);
+ * items without a seq keep their alphabetical position. Renamed here for clarity
+ * since seq, not name, is the primary signal.
+ */
+const sortBySequenceElseName = (items: OpenCollectionItem[]): OpenCollectionItem[] => {
+  const alphabetical = [...items].sort((a, b) => (getItemName(a) || '').localeCompare(getItemName(b) || ''));
+
+  const withoutSeq: (OpenCollectionItem | OpenCollectionItem[])[] = alphabetical.filter(
+    (item) => !isSeqValid(getItemSeq(item))
+  );
+  const withSeq = alphabetical
+    .filter((item) => isSeqValid(getItemSeq(item)))
+    .sort((a, b) => (getItemSeq(a) as number) - (getItemSeq(b) as number));
+
+  withSeq.forEach((item) => {
+    const position = (getItemSeq(item) as number) - 1;
+    const existing = withoutSeq[position];
+    const existingSeq = Array.isArray(existing)
+      ? getItemSeq(existing[0])
+      : existing
+        ? getItemSeq(existing)
+        : undefined;
+
+    if (existingSeq === getItemSeq(item)) {
+      const group = Array.isArray(existing) ? [...existing, item] : [existing as OpenCollectionItem, item];
+      withoutSeq.splice(position, 1, group);
+    } else {
+      withoutSeq.splice(position, 0, item);
     }
-    if (seqA !== undefined && seqB === undefined) return -1;
-    if (seqA === undefined && seqB !== undefined) return 1;
-    return (getItemName(a) || '').localeCompare(getItemName(b) || '');
   });
+
+  return withoutSeq.flat();
+};
+
+/** Bruno app orders requests purely by seq. */
+const sortBySequence = (items: OpenCollectionItem[]): OpenCollectionItem[] =>
+  [...items].sort((a, b) => (getItemSeq(a) as number) - (getItemSeq(b) as number));
+
+/**
+ * Orders one level of sibling items for the sidebar/nav, matching the Bruno app.
+ * Folders come first, then requests, then files. Folders are ordered by seq and
+ * fall back to name; requests are ordered by seq; files keep their given order.
+ * Called for each level (children are ordered when their folder is walked).
+ */
+export const orderSiblings = (items: OpenCollectionItem[]): OpenCollectionItem[] => {
+  const present = items.filter(Boolean);
+  const folders = present.filter((item) => isFolder(item));
+  const files = present.filter((item) => isScriptFile(item));
+  const requests = present.filter((item) => !isFolder(item) && !isScriptFile(item));
+  return [...sortBySequenceElseName(folders), ...sortBySequence(requests), ...files];
+};
 
 const pageTypeOf = (item: OpenCollectionItem): PageType => {
   if (isFolder(item)) return 'folder';
@@ -42,12 +87,12 @@ const walk = (
 ): void => {
   if (!items || items.length === 0) return;
 
-  const sorted = sortSiblings(items);
+  const ordered = orderSiblings(items);
   const segments = dedupeSiblingSlugs(
-    sorted.map((item) => slugifySegment(getItemName(item) || ''))
+    ordered.map((item) => slugifySegment(getItemName(item) || ''))
   );
 
-  sorted.forEach((item, i) => {
+  ordered.forEach((item, i) => {
     const slug = parentSlug ? `${parentSlug}/${segments[i]}` : segments[i];
     const name = getItemName(item) || 'Untitled';
     const type = pageTypeOf(item);

--- a/packages/oc-docs/src/utils/schemaHelpers.ts
+++ b/packages/oc-docs/src/utils/schemaHelpers.ts
@@ -60,19 +60,16 @@ export const getItemName = (item: OpenCollectionItem | null | undefined): string
 };
 
 /**
- * Get the sequence number of an item
+ * Get the sequence number of an item, from the info block or the root level.
  */
 export const getItemSeq = (item: OpenCollectionItem | null | undefined): number | undefined => {
   if (!item) return undefined;
-  
-  if ('info' in item && (item as any).info?.seq !== undefined) {
-    return (item as any).info.seq;
+  if ('info' in item && (item as { info?: { seq?: number } }).info?.seq !== undefined) {
+    return (item as { info: { seq?: number } }).info.seq;
   }
-  
   if ('seq' in item) {
-    return (item as any).seq;
+    return (item as { seq?: number }).seq;
   }
-  
   return undefined;
 };
 


### PR DESCRIPTION
Docs now sort sidebar/nav siblings the same way as the Bruno app (sortItemsBySidebarOrder): grouped by type - folders first (name-then-seq), then requests (by seq), then files - so the docs sidebar order matches the app exactly, respecting seq.
JIRA : https://usebruno.atlassian.net/browse/BRU-3403