### PR TITLE
docs: Add README and expand contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# OpenCollection
+
+An open specification for describing **executable API collections**: requests, environments, variables, authentication, scripts, and assertions, stored as plain YAML.
+
+- Specification: [spec.opencollection.com](https://spec.opencollection.com)
+- Schema explorer: [schema.opencollection.com](https://schema.opencollection.com)
+- Website: [opencollection.com](https://www.opencollection.com)
+
+## What is OpenCollection?
+
+OpenCollection is a format for describing API collections in a way that tools can read, write, and run. A collection is a tree of HTTP, GraphQL, gRPC, and WebSocket requests, together with the environments, variables, auth, scripts, and assertions needed to actually send them.
+
+Most API formats describe a contract. OpenAPI tells you an endpoint exists, what it accepts, and what it returns. OpenCollection captures the next step: the concrete request, with these headers, this body, this environment, this token, and these assertions on the response. A collection is something you run, not just something you read.
+
+The format is plain YAML with a published JSON Schema. It is an open specification: published, openly licensed, and not tied to any single application or proprietary format.
+
+## Why it exists
+
+| Layer | Format | Answers |
+|---|---|---|
+| Contract | OpenAPI | What does this API look like? |
+| Orchestration | Arazzo | How do I chain calls across APIs? |
+| **Execution** | **OpenCollection** | **Send this request, with these variables, and check this result.** |
+
+OpenAPI has no concept of "send this request now, with these variables, and assert this response." That executable working set is what teams keep in their API client, and until now it has lived in proprietary, tool-locked formats. OpenCollection is that artifact in an open, neutral YAML format.
+
+## Example
+
+```yaml
+opencollection: "1.0.0"
+info:
+  name: Sample API
+  version: "1.0.0"
+items:
+  - info:
+      name: Get Users
+      type: http
+    http:
+      method: GET
+      url: https://api.example.com/users
+      params:
+        - name: limit
+          value: "10"
+          type: query
+```
+
+A collection can be a single bundled file or a tree of files and folders on disk.
+
+## The specification
+
+The current version is **1.0.0**. The schema is authored in [JSON Schema (draft-07)](http://json-schema.org/draft-07/schema#).
+
+- Read the human-readable spec at [spec.opencollection.com](https://spec.opencollection.com).
+- Browse the schema interactively at [schema.opencollection.com](https://schema.opencollection.com).
+- Read the schema source at [`packages/oc-schema/src/opencollection.schema.json`](./packages/oc-schema/src/opencollection.schema.json).
+
+## Adoption
+
+[Bruno](https://www.usebruno.com), the open-source, git-native API client used by tens of thousands of teams, reads and writes OpenCollection as a native storage format. Bruno can generate documentation from a collection and import from and export to other formats through the same schema.
+
+## Repository layout
+
+This repository is an npm-workspaces monorepo.
+
+### Published packages
+
+| Package | Description |
+|---|---|
+| [`@opencollection/schema`](./packages/oc-schema) | The JSON Schema definitions for the OpenCollection format. |
+| [`@opencollection/types`](./packages/oc-types) | TypeScript types for the OpenCollection schema. |
+| [`@opencollection/converters`](./packages/oc-converters) | Converters from other collection formats into OpenCollection. |
+
+### Sites in this repository
+
+| Directory | Description |
+|---|---|
+| [`packages/oc-spec-site`](./packages/oc-spec-site) | The human-readable specification site (spec.opencollection.com). |
+| [`packages/oc-schema-explorer`](./packages/oc-schema-explorer) | The interactive schema explorer (schema.opencollection.com). |
+
+## Using OpenCollection in your tools
+
+OpenCollection is meant to be consumed by any tool. The packages below let you read, validate, and manipulate collections through openly-licensed libraries with no dependency on a particular application.
+
+### Validate a collection
+
+For a tool that ingests OpenCollection files (a CI check, an editor integration, a registry that validates on publish), the schema is published so you can validate against it directly:
+
+```bash
+npm install @opencollection/schema ajv
+```
+
+```js
+import Ajv from 'ajv';
+import { OpenCollectionSchema } from '@opencollection/schema';
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(OpenCollectionSchema);
+
+if (!validate(myCollection)) {
+  console.error(validate.errors);
+}
+```
+
+### Work with collections in TypeScript
+
+For type-safe access to collection objects in a TypeScript project:
+
+```bash
+npm install --save-dev @opencollection/types
+```
+
+### Migrate existing collections
+
+To convert collections from another format into OpenCollection:
+
+```bash
+npm install @opencollection/converters
+```
+
+```js
+import { brunoToOpenCollection } from '@opencollection/converters';
+
+const collection = brunoToOpenCollection(brunoCollection);
+```
+
+## Project and maintenance
+
+OpenCollection is currently authored and maintained by [Bruno](https://www.usebruno.com). The specification, schema, and tooling are developed in the open, and contributions are welcome.
+
+## Contributing
+
+See [contributing.md](./contributing.md) to build the packages locally. Issues and pull requests are tracked on [GitHub](https://github.com/opencollection-dev/opencollection).

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 An open specification for describing **executable API collections**: requests, environments, variables, authentication, scripts, and assertions, stored as plain YAML.
 
-- Specification: [spec.opencollection.com](https://spec.opencollection.com)
-- Schema explorer: [schema.opencollection.com](https://schema.opencollection.com)
-- Website: [opencollection.com](https://www.opencollection.com)
-
 ## What is OpenCollection?
 
 OpenCollection is a format for describing API collections in a way that tools can read, write, and run. A collection is a tree of HTTP, GraphQL, gRPC, and WebSocket requests, together with the environments, variables, auth, scripts, and assertions needed to actually send them.
@@ -23,6 +19,14 @@ The format is plain YAML with a published JSON Schema. It is an open specificati
 | **Execution** | **OpenCollection** | **Send this request, with these variables, and check this result.** |
 
 OpenAPI has no concept of "send this request now, with these variables, and assert this response." That executable working set is what teams keep in their API client, and until now it has lived in proprietary, tool-locked formats. OpenCollection is that artifact in an open, neutral YAML format.
+
+## The specification
+
+The current version is **1.0.0**. The schema is authored in [JSON Schema (draft-07)](http://json-schema.org/draft-07/schema#).
+
+- Read the human-readable spec at [spec.opencollection.com](https://spec.opencollection.com).
+- Browse the schema interactively at [schema.opencollection.com](https://schema.opencollection.com).
+- Read the schema source at [`packages/oc-schema/src/opencollection.schema.json`](./packages/oc-schema/src/opencollection.schema.json).
 
 ## Example
 
@@ -45,14 +49,6 @@ items:
 ```
 
 A collection can be a single bundled file or a tree of files and folders on disk.
-
-## The specification
-
-The current version is **1.0.0**. The schema is authored in [JSON Schema (draft-07)](http://json-schema.org/draft-07/schema#).
-
-- Read the human-readable spec at [spec.opencollection.com](https://spec.opencollection.com).
-- Browse the schema interactively at [schema.opencollection.com](https://schema.opencollection.com).
-- Read the schema source at [`packages/oc-schema/src/opencollection.schema.json`](./packages/oc-schema/src/opencollection.schema.json).
 
 ## Adoption
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,9 +1,89 @@
-### Build
+# Contributing to OpenCollection
+
+Thanks for your interest in OpenCollection. This guide covers how to set up the repository, work on the packages, and propose changes.
+
+For an overview of what OpenCollection is and how the repository is organized, see the [README](./README.md).
+
+## Prerequisites
+
+- Node.js `v22.11.0` (see [`.nvmrc`](./.nvmrc)). With nvm: `nvm use`.
+- npm (ships with Node).
+
+## Setup
+
+This repository is an npm-workspaces monorepo. Install all packages from the root:
 
 ```bash
-# bundle libraries
-npm run build:lib-bundle --workspace="@opencollection/core"
-
-# build standalone bundle
-npm run build:standalone --workspace="@opencollection/core"
+git clone https://github.com/opencollection-dev/opencollection.git
+cd opencollection
+npm install
 ```
+
+A single install at the root wires up every workspace.
+
+## Working on the packages
+
+Run a workspace script with `npm run <script> --workspace=<package-name>`.
+
+### `@opencollection/schema`
+
+The JSON Schema definitions for the OpenCollection format, and the source of truth for the spec. The schema files live in [`packages/oc-schema/src`](./packages/oc-schema/src). There is no build step: edit the JSON directly.
+
+Any change to the schema is a change to the specification. Update the schema explorer and the spec site to match, and follow the versioning rules below.
+
+### `@opencollection/types`
+
+TypeScript types for the OpenCollection schema. Build with:
+
+```bash
+npm run build --workspace=@opencollection/types
+```
+
+Keep the types in sync with the schema whenever the schema changes.
+
+### `@opencollection/converters`
+
+Converters from other collection formats into OpenCollection. Plain JavaScript source in [`packages/oc-converters/src`](./packages/oc-converters/src); no build step.
+
+### Schema explorer
+
+The interactive schema explorer served at schema.opencollection.com. A Vite app:
+
+```bash
+npm run dev     --workspace=@opencollection/schema-explorer   # local dev server
+npm run build   --workspace=@opencollection/schema-explorer   # production build
+npm run preview --workspace=@opencollection/schema-explorer   # preview the build
+```
+
+The build copies the schema from `@opencollection/schema`, so run a fresh build after changing the schema.
+
+### Spec site
+
+The human-readable specification served at spec.opencollection.com. A Vite app:
+
+```bash
+npm run dev     --workspace=oc-spec-site
+npm run build   --workspace=oc-spec-site
+npm run preview --workspace=oc-spec-site
+```
+
+## Making changes
+
+1. Open or comment on an issue first for anything beyond a small fix, so the change can be discussed before you build it.
+2. Create a branch from `main`.
+3. Make your change. If it touches the schema, update the types, the schema explorer, and the spec site so they stay consistent.
+4. Open a pull request against `main` describing the change and linking the issue.
+
+Continuous integration runs end-to-end tests on pull requests via GitHub Actions.
+
+## Changing the schema
+
+The schema is the specification, so changes are versioned deliberately.
+
+- Additive, backward-compatible changes are minor.
+- Changes that break existing valid collections are major and need a clear migration path.
+- Note the version impact of your change in the pull request.
+
+## Reporting issues
+
+File issues on [GitHub](https://github.com/opencollection-dev/opencollection/issues). For bugs, include the smallest collection that reproduces the problem and what you expected to happen.


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-3543)

Docs only. No code or schema changes. 

README.md(new): The repo had no top-level entry point. Adds one covering what OpenCollection is (open YAML spec for executable API collections), how it differs from OpenAPI/Arazzo, a minimal example, spec status (v1.0.0), repo layout, published packages, and how to validate/consume collections in your own tooling.

contributing.md: Replaces the two-command build stub (which referenced the stale @opencollection/core workspace) with real setup: prerequisites, monorepo install, per-package build/dev commands, change workflow, and schema-versioning rules.



