### PR TITLE
fix: Use JSON import assertions in oc-schema

### DIFF
--- a/packages/oc-schema/src/index.js
+++ b/packages/oc-schema/src/index.js
@@ -1,5 +1,5 @@
-import OpenCollectionSchema from './opencollection.schema.json';
-import WorkspaceSchema from './worspace.schema.json';
+import OpenCollectionSchema from './opencollection.schema.json' with { type: 'json' };
+import WorkspaceSchema from './worspace.schema.json' with { type: 'json' };
 
 export {
   OpenCollectionSchema,


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-3739)

@opencollection/schema is an ESM package whose entry point (src/index.js) imports two .json files. Under Node 22 ESM (repo pins v22.11.0), a .json import requires an import attribute, so loading the package threw ERR_IMPORT_ATTRIBUTE_MISSING before exporting anything - breaking any native-ESM consumer.