### PR TITLE
fix(oc-docs): apply query & path params to the sent request URL (BRU-3724)

### DIFF
--- a/packages/oc-docs/src/components/PlaygroundDrawer/DrawerContent/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/PlaygroundDrawer/DrawerContent/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import type { HttpRequest } from '@opencollection/types/requests/http';
 import { StyledWrapper } from './StyledWrapper';
 import { getHttpMethod, getRequestUrl, getHttpParams } from '../../../../../../utils/schemaHelpers';
-import { syncPathParams } from '../../../../../../utils/pathParams';
+import { syncPathParams, syncQueryParams } from '../../../../../../utils/pathParams';
 import { methodColorVars, getMethodColorVar } from '../../../../../../theme/methodColors';
 
 interface QueryBarProps {
@@ -24,10 +24,8 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
   const handleUrlChange = (newUrl: string) => {
     setUrl(newUrl);
 
-    // Keep the path params in sync with the URL's `:name` segments (add on type,
-    // remove on delete).
     const currentParams = getHttpParams(item);
-    const syncedParams = syncPathParams(currentParams, newUrl);
+    const syncedParams = syncQueryParams(syncPathParams(currentParams, newUrl), newUrl);
 
     const updatedItem = {
       ...item,

--- a/packages/oc-docs/src/components/PlaygroundDrawer/DrawerContent/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/PlaygroundDrawer/DrawerContent/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -20,8 +20,10 @@ import {
   getRequestAssertions,
   getRequestScripts,
   scriptsArrayToObject,
-  scriptsObjectToArray
+  scriptsObjectToArray,
+  getRequestUrl
 } from '../../../../../../utils/schemaHelpers';
+import { setUrlQueryParams } from '../../../../../../utils/pathParams';
 
 interface RequestPaneProps {
   item: HttpRequest;
@@ -38,12 +40,14 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       disabled: !p?.enabled,
       type: p?.type
     }));
-    onItemChange({ 
+    const url = setUrlQueryParams(getRequestUrl(item), updatedParams);
+    onItemChange({
       ...item, 
       http: { 
         ...item.http, 
-        params: updatedParams 
-      } 
+        params: updatedParams,
+        url
+      }
     });
   };
 

--- a/packages/oc-docs/src/runner/RequestExecutor.ts
+++ b/packages/oc-docs/src/runner/RequestExecutor.ts
@@ -1,6 +1,7 @@
 import type { HttpRequest } from '@opencollection/types/requests/http';
 import { RunRequestResponse } from './index';
-import { getHttpMethod, getRequestUrl, getHttpHeaders, getHttpBody, getRequestAuth } from '../utils/schemaHelpers';
+import { getHttpMethod, getRequestUrl, getHttpHeaders, getHttpBody, getRequestAuth, getHttpParams } from '../utils/schemaHelpers';
+import { buildRequestUrl } from '../utils/pathParams';
 import { classifyRequestError, DEFAULT_TIMEOUT_MS } from './classifyRequestError';
 import stripJsonComments from 'strip-json-comments';
 
@@ -8,10 +9,10 @@ export class RequestExecutor {
   async executeRequest(request: HttpRequest, options: { timeout?: number } = {}): Promise<RunRequestResponse> {
     const startTime = Date.now();
     const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    const requestUrl = buildRequestUrl(getRequestUrl(request), getHttpParams(request));
 
     try {
       const fetchOptions = await this.buildFetchOptions(request, timeoutMs);
-      const requestUrl = getRequestUrl(request);
       const response = await fetch(requestUrl, fetchOptions);
       const endTime = Date.now();
 
@@ -31,7 +32,7 @@ export class RequestExecutor {
       const endTime = Date.now();
       const classified = classifyRequestError(error, {
         timeoutMs,
-        requestUrl: getRequestUrl(request),
+        requestUrl,
         pageUrl: typeof window !== 'undefined' ? window.location.href : undefined
       });
 
@@ -76,7 +77,7 @@ export class RequestExecutor {
 
     // Auto-set Content-Type for JSON bodies if not already set
     if (body && 'type' in body && body.type === 'json') {
-      const hasContentType = requestHeaders?.some(h => 
+      const hasContentType = requestHeaders?.some(h =>
         !h.disabled && h.name.toLowerCase() === 'content-type'
       );
       if (!hasContentType) {
@@ -117,7 +118,7 @@ export class RequestExecutor {
   private async buildBody(request: HttpRequest): Promise<BodyInit | null> {
     const body = getHttpBody(request);
     const headers = getHttpHeaders(request);
-    
+
     if (!body) return null;
 
     if ('type' in body) {
@@ -199,4 +200,4 @@ export class RequestExecutor {
     });
     return result;
   }
-} 
+}

--- a/packages/oc-docs/src/utils/pathParams.spec.ts
+++ b/packages/oc-docs/src/utils/pathParams.spec.ts
@@ -4,7 +4,9 @@ import {
   syncPathParams,
   applyPathParams,
   resolvePathAndQueryParams,
-  buildRequestUrl
+  buildRequestUrl,
+  syncQueryParams,
+  setUrlQueryParams
 } from './pathParams';
 
 describe('parsePathParamNames', () => {
@@ -351,5 +353,111 @@ describe('buildRequestUrl', () => {
     expect(buildRequestUrl('', [query('q', 'x')])).toBe('');
     expect(buildRequestUrl(undefined, [query('q', 'x')])).toBe('');
     expect(buildRequestUrl(null, [query('q', 'x')])).toBe('');
+  });
+});
+
+describe('syncQueryParams', () => {
+  const query = (name: string, value = '', extra: object = {}): any => ({ name, value, type: 'query', ...extra });
+  const path = (name: string, value = ''): any => ({ name, value, type: 'path' });
+
+  it('adds query params when the URL gains a ?a=b string', () => {
+    const result = syncQueryParams([], 'https://api.com/search?q=alice&role=admin');
+    expect(result).toEqual([
+      { name: 'q', value: 'alice', type: 'query' },
+      { name: 'role', value: 'admin', type: 'query' }
+    ]);
+  });
+
+  it('updates the value of an existing query param from the URL', () => {
+    const result = syncQueryParams([query('page', '1')], 'https://api.com/x?page=5');
+    expect(result).toEqual([{ name: 'page', value: '5', type: 'query' }]);
+  });
+
+  it('removes an enabled query param dropped from the URL', () => {
+    const result = syncQueryParams([query('q', 'alice'), query('role', 'admin')], 'https://api.com/x?q=alice');
+    expect(result.map((p) => p.name)).toEqual(['q']);
+  });
+
+  it('preserves a disabled query param the URL does not mention', () => {
+    const result = syncQueryParams([query('q', 'alice'), query('debug', 'true', { disabled: true })], 'https://api.com/x?q=alice');
+    expect(result).toEqual([
+      { name: 'q', value: 'alice', type: 'query' },
+      { name: 'debug', value: 'true', type: 'query', disabled: true }
+    ]);
+  });
+
+  it('leaves path params untouched', () => {
+    const result = syncQueryParams([path('id', '7'), query('q', 'alice')], 'https://api.com/x/:id?q=bob');
+    expect(result).toEqual([
+      { name: 'q', value: 'bob', type: 'query' },
+      { name: 'id', value: '7', type: 'path' }
+    ]);
+  });
+
+  it('keeps values raw (no decode), preserving {{variables}}', () => {
+    const result = syncQueryParams([], 'https://api.com/x?q=a%20b&id={{userId}}');
+    expect(result).toEqual([
+      { name: 'q', value: 'a%20b', type: 'query' },
+      { name: 'id', value: '{{userId}}', type: 'query' }
+    ]);
+  });
+
+  it('keeps a disabled row even when the URL has the same name (dup, like the app)', () => {
+    const result = syncQueryParams(
+      [query('q', 'live'), query('q', 'off', { disabled: true })],
+      'https://api.com/x?q=live'
+    );
+    expect(result).toEqual([
+      { name: 'q', value: 'live', type: 'query' },
+      { name: 'q', value: 'off', type: 'query', disabled: true }
+    ]);
+  });
+
+  it('returns the same reference when nothing changed', () => {
+    const existing = [query('q', 'alice')];
+    expect(syncQueryParams(existing, 'https://api.com/x?q=alice')).toBe(existing);
+  });
+
+  it('handles no query / nullish', () => {
+    const existing = [path('id', '1')];
+    expect(syncQueryParams(existing, 'https://api.com/x/:id')).toBe(existing);
+    expect(syncQueryParams(undefined, 'https://api.com/x')).toEqual([]);
+  });
+});
+
+describe('setUrlQueryParams', () => {
+  const query = (name: string, value = '', extra: object = {}): any => ({ name, value, type: 'query', ...extra });
+  const path = (name: string, value = ''): any => ({ name, value, type: 'path' });
+
+  it('writes enabled query params into the URL', () => {
+    expect(setUrlQueryParams('https://api.com/search', [query('q', 'alice'), query('role', 'admin')])).toBe(
+      'https://api.com/search?q=alice&role=admin'
+    );
+  });
+
+  it('drops disabled query params', () => {
+    expect(setUrlQueryParams('https://api.com/x', [query('q', 'alice'), query('debug', 'true', { disabled: true })])).toBe(
+      'https://api.com/x?q=alice'
+    );
+  });
+
+  it('replaces the existing query string', () => {
+    expect(setUrlQueryParams('https://api.com/x?old=1', [query('new', '2')])).toBe('https://api.com/x?new=2');
+  });
+
+  it('strips the query when there are no enabled query params', () => {
+    expect(setUrlQueryParams('https://api.com/x?old=1', [])).toBe('https://api.com/x');
+  });
+
+  it('preserves the path (incl. :name) and fragment; ignores path params', () => {
+    expect(setUrlQueryParams('https://api.com/users/:id#frag', [path('id', '7'), query('q', 'x')])).toBe(
+      'https://api.com/users/:id?q=x#frag'
+    );
+  });
+
+  it('keeps names/values raw (no encode), preserving {{variables}}', () => {
+    expect(setUrlQueryParams('https://api.com/x', [query('id', '{{userId}}')])).toBe(
+      'https://api.com/x?id={{userId}}'
+    );
   });
 });

--- a/packages/oc-docs/src/utils/pathParams.spec.ts
+++ b/packages/oc-docs/src/utils/pathParams.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parsePathParamNames, syncPathParams, applyPathParams, resolvePathAndQueryParams } from './pathParams';
+import {
+  parsePathParamNames,
+  syncPathParams,
+  applyPathParams,
+  resolvePathAndQueryParams,
+  buildRequestUrl
+} from './pathParams';
 
 describe('parsePathParamNames', () => {
   it('extracts a single path param', () => {
@@ -211,5 +217,139 @@ describe('resolvePathAndQueryParams', () => {
 
   it('returns empty arrays for no params and no URL path segments', () => {
     expect(resolvePathAndQueryParams(undefined, undefined)).toEqual({ path: [], query: [] });
+  });
+});
+
+describe('buildRequestUrl', () => {
+  const path = (name: string, value: string, extra: object = {}): any => ({
+    name,
+    value,
+    type: 'path',
+    ...extra
+  });
+  const query = (name: string, value: string, extra: object = {}): any => ({
+    name,
+    value,
+    type: 'query',
+    ...extra
+  });
+
+  it('appends enabled query params to a URL with no existing query (AC #1)', () => {
+    expect(
+      buildRequestUrl('https://api.com/users/search', [
+        query('q', 'alice'),
+        query('role', 'admin'),
+        query('status', 'active')
+      ])
+    ).toBe('https://api.com/users/search?q=alice&role=admin&status=active');
+  });
+
+  it('excludes disabled query params (AC #1)', () => {
+    expect(
+      buildRequestUrl('https://api.com/users/search', [
+        query('q', 'alice'),
+        query('verbose', 'true', { disabled: true })
+      ])
+    ).toBe('https://api.com/users/search?q=alice');
+  });
+
+  it('substitutes path params into the path (AC #2)', () => {
+    expect(
+      buildRequestUrl('https://jsonplaceholder.typicode.com/posts/:postId', [path('postId', '1')])
+    ).toBe('https://jsonplaceholder.typicode.com/posts/1');
+  });
+
+  it('handles path and query params together', () => {
+    expect(
+      buildRequestUrl('https://api.com/users/:userId/posts', [
+        path('userId', '7'),
+        query('page', '2')
+      ])
+    ).toBe('https://api.com/users/7/posts?page=2');
+  });
+
+  it('returns the URL unchanged when there are no params (AC #4)', () => {
+    expect(buildRequestUrl('https://api.com/health', [])).toBe('https://api.com/health');
+    expect(buildRequestUrl('https://api.com/health', undefined)).toBe('https://api.com/health');
+  });
+
+  it('returns the URL unchanged when only disabled query params exist (AC #4)', () => {
+    expect(
+      buildRequestUrl('https://api.com/health', [query('debug', '1', { disabled: true })])
+    ).toBe('https://api.com/health');
+  });
+
+  it('preserves a query key typed in the URL that the array does not redeclare', () => {
+    expect(
+      buildRequestUrl('https://api.com/search?expand=true', [query('q', 'alice')])
+    ).toBe('https://api.com/search?expand=true&q=alice');
+  });
+
+  it('lets the params array override a same-named URL query key (no duplicate)', () => {
+    expect(
+      buildRequestUrl('https://api.com/search?page=1', [query('page', '5')])
+    ).toBe('https://api.com/search?page=5');
+  });
+
+  it('leaves a URL with an existing query untouched when there are no params (AC #4)', () => {
+    expect(buildRequestUrl('https://api.com/search?foo=bar', [])).toBe(
+      'https://api.com/search?foo=bar'
+    );
+  });
+
+  it('dedupes against a percent-encoded URL key that matches a param name', () => {
+    expect(buildRequestUrl('https://api.com/s?my%20param=old', [query('my param', 'new')])).toBe(
+      'https://api.com/s?my%20param=new'
+    );
+  });
+
+  it('treats a plus-encoded URL key as a space when deduping', () => {
+    expect(buildRequestUrl('https://api.com/s?my+param=old', [query('my param', 'new')])).toBe(
+      'https://api.com/s?my%20param=new'
+    );
+  });
+
+  it('preserves a URL-only key verbatim when encode=false', () => {
+    expect(
+      buildRequestUrl('https://api.com/s?keep=1', [query('q', 'x')], { encode: false })
+    ).toBe('https://api.com/s?keep=1&q=x');
+  });
+
+  it('URL-encodes query names and values by default', () => {
+    expect(buildRequestUrl('https://api.com/s', [query('q', 'a b&c')])).toBe(
+      'https://api.com/s?q=a%20b%26c'
+    );
+  });
+
+  it('does not encode when encode=false', () => {
+    expect(
+      buildRequestUrl('https://api.com/files/:name', [path('name', 'a b'), query('q', 'x y')], {
+        encode: false
+      })
+    ).toBe('https://api.com/files/a b?q=x y');
+  });
+
+  it('leaves a :segment literal when its path param is missing, still appends query', () => {
+    expect(buildRequestUrl('https://api.com/posts/:postId', [query('q', 'x')])).toBe(
+      'https://api.com/posts/:postId?q=x'
+    );
+  });
+
+  it('preserves a fragment after appending query params', () => {
+    expect(buildRequestUrl('https://api.com/docs#section', [query('q', 'x')])).toBe(
+      'https://api.com/docs?q=x#section'
+    );
+  });
+
+  it('keeps {{variable}} templates in the URL untouched', () => {
+    expect(buildRequestUrl('{{host}}/api/users/search', [query('q', 'alice')])).toBe(
+      '{{host}}/api/users/search?q=alice'
+    );
+  });
+
+  it('handles empty / nullish urls', () => {
+    expect(buildRequestUrl('', [query('q', 'x')])).toBe('');
+    expect(buildRequestUrl(undefined, [query('q', 'x')])).toBe('');
+    expect(buildRequestUrl(null, [query('q', 'x')])).toBe('');
   });
 });

--- a/packages/oc-docs/src/utils/pathParams.ts
+++ b/packages/oc-docs/src/utils/pathParams.ts
@@ -186,3 +186,79 @@ export const buildRequestUrl = (
   const queryString = pairs.join('&');
   return `${base}${queryString ? `?${queryString}` : ''}${fragment}`;
 };
+
+const parseUrlQueryParams = (url: string | undefined | null): { name: string; value: string }[] => {
+  if (!url || typeof url !== 'string') return [];
+
+  const beforeHash = url.split('#')[0];
+  const qIndex = beforeHash.indexOf('?');
+  if (qIndex === -1) return [];
+
+  const pairs: { name: string; value: string }[] = [];
+  for (const part of beforeHash.slice(qIndex + 1).split('&')) {
+    if (!part) continue;
+    const eq = part.indexOf('=');
+    const name = eq === -1 ? part : part.slice(0, eq);
+    const value = eq === -1 ? '' : part.slice(eq + 1);
+    if (name) pairs.push({ name, value });
+  }
+  return pairs;
+};
+
+
+export const syncQueryParams = (
+  params: HttpRequestParam[] | undefined,
+  url: string
+): HttpRequestParam[] => {
+  const existing = params ?? [];
+  const urlQuery = parseUrlQueryParams(url);
+  const existingQuery = existing.filter((p) => p?.type !== 'path');
+
+  if (urlQuery.length === 0 && existingQuery.length === 0) {
+    return existing;
+  }
+
+  const existingByName = new Map<string, HttpRequestParam>();
+  for (const p of existingQuery) {
+    if (p?.name && !p.disabled && !existingByName.has(p.name)) existingByName.set(p.name, p);
+  }
+
+  const fromUrl: HttpRequestParam[] = urlQuery.map((q) => {
+    const prev = existingByName.get(q.name);
+    if (!prev) return { name: q.name, value: q.value, type: 'query' as const };
+    if (prev.value === q.value) return prev;
+    return { ...prev, value: q.value };
+  });
+  const keptDisabled = existingQuery.filter((p) => p?.disabled);
+  const nextQuery = [...fromUrl, ...keptDisabled];
+
+  const unchanged =
+    existingQuery.length === nextQuery.length &&
+    existingQuery.every((p, i) => p === nextQuery[i]);
+  if (unchanged) {
+    return existing;
+  }
+
+  const pathParams = existing.filter((p) => p?.type === 'path');
+  return [...nextQuery, ...pathParams];
+};
+
+
+export const setUrlQueryParams = (
+  url: string | undefined | null,
+  params: HttpRequestParam[] | undefined
+): string => {
+  if (!url || typeof url !== 'string') return url ?? '';
+
+  const enabled = (params ?? []).filter((p) => p?.type !== 'path' && !p.disabled && p.name);
+
+  const hashIndex = url.indexOf('#');
+  const fragment = hashIndex === -1 ? '' : url.slice(hashIndex);
+  const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const qIndex = beforeHash.indexOf('?');
+  const base = qIndex === -1 ? beforeHash : beforeHash.slice(0, qIndex);
+
+  const queryString = enabled.map((p) => `${p.name}=${p.value ?? ''}`).join('&');
+
+  return `${base}${queryString ? `?${queryString}` : ''}${fragment}`;
+};

--- a/packages/oc-docs/src/utils/pathParams.ts
+++ b/packages/oc-docs/src/utils/pathParams.ts
@@ -130,3 +130,59 @@ export const applyPathParams = (
 
   return newPath + rest;
 };
+
+/**
+ * Build the URL that is actually sent: substitute `:name` path params into the
+ * path and append enabled query params to the query string.
+ *
+ * - Path params delegate to {@link applyPathParams} (disabled or unmatched ones
+ *   stay literal).
+ * - Only enabled query params are appended; a param replaces the same-named key
+ *   already in the URL, and URL-only keys are kept.
+ * - With no applicable params the URL is returned unchanged.
+ */
+export const buildRequestUrl = (
+  url: string | undefined | null,
+  params: HttpRequestParam[] | undefined,
+  options: { encode?: boolean } = {}
+): string => {
+  if (!url || typeof url !== 'string') return url ?? '';
+
+  const { encode = true } = options;
+  const withPath = applyPathParams(url, params, { encode });
+
+  const queryParams = (params ?? []).filter((p) => p?.type === 'query' && !p.disabled && p.name);
+  if (queryParams.length === 0) return withPath;
+
+
+  const hashIndex = withPath.indexOf('#');
+  const fragment = hashIndex === -1 ? '' : withPath.slice(hashIndex);
+  const beforeHash = hashIndex === -1 ? withPath : withPath.slice(0, hashIndex);
+  const qIndex = beforeHash.indexOf('?');
+  const base = qIndex === -1 ? beforeHash : beforeHash.slice(0, qIndex);
+  const existingQuery = qIndex === -1 ? '' : beforeHash.slice(qIndex + 1);
+
+  const arrayNames = new Set(queryParams.map((p) => p.name));
+  const pairs: string[] = [];
+
+  // Keep URL-only keys;
+  for (const pair of existingQuery.split('&')) {
+    if (!pair) continue;
+    let key = pair.split('=')[0].replace(/\+/g, ' ');
+    try {
+      key = decodeURIComponent(key);
+    } catch {
+      // leave a malformed key as-is
+    }
+    if (!arrayNames.has(key)) pairs.push(pair);
+  }
+
+  for (const p of queryParams) {
+    const name = encode ? encodeURIComponent(p.name) : p.name;
+    const value = encode ? encodeURIComponent(p.value ?? '') : p.value ?? '';
+    pairs.push(`${name}=${value}`);
+  }
+
+  const queryString = pairs.join('&');
+  return `${base}${queryString ? `?${queryString}` : ''}${fragment}`;
+};


### PR DESCRIPTION
### Fixes BRU-3724 

The playground now folds enabled query params and `:name` path params into the URL that is actually sent. 
Previously they were shown and editable but silently ignored, so requests replayed against the base URL.