### PR TITLE
feat: Add support for SPARQL body type (BRU-3727)

### DIFF
--- a/packages/oc-docs/src/components/PlaygroundDrawer/DrawerContent/Views/Common/BodyTab.tsx
+++ b/packages/oc-docs/src/components/PlaygroundDrawer/DrawerContent/Views/Common/BodyTab.tsx
@@ -85,6 +85,7 @@ export const BodyTab: React.FC<BodyTabProps> = ({
             <option value="text">Text</option>
             <option value="xml">XML</option>
             <option value="form-urlencoded">Form URL Encoded</option>
+            <option value='sparql'>SPARQL</option>
           </select>
         </div>
       </div>
@@ -107,7 +108,15 @@ export const BodyTab: React.FC<BodyTabProps> = ({
               });
             }
           }}
-          language={body.type === 'json' ? 'jsonc' : body.type === 'xml' ? 'xml' : 'text'}
+          language={
+            body.type === 'json'
+              ? 'jsonc'
+              : body.type === 'xml'
+                ? 'xml'
+                : body.type === 'sparql'
+                  ? 'sparql'
+                  : 'text'
+          }
           height="300px"
         />
       ) : Array.isArray(body) || (body?.type === 'form-urlencoded' && Array.isArray(body?.data)) ? (


### PR DESCRIPTION
# Description

Adds a new option in the Body format dropdown: SPARQL

# Changes

1. Add option `SPARQL` to the list of options
2. Update the language format being passed to the Monaco Editor

# Ticket
https://usebruno.atlassian.net/browse/BRU-3727

# Screenshots
<img width="727" height="461" alt="image" src="https://github.com/user-attachments/assets/6061ea0e-09eb-48a6-bc42-66d7800435d4" />

<img width="742" height="523" alt="image" src="https://github.com/user-attachments/assets/b606cdd2-0508-441e-a3ca-69c620bc61c0" />
