### PR TITLE
fix(oc-docs): make endpoint search match object-form descriptions

### DIFF
--- a/packages/oc-docs/src/components/Search/searchIndex.spec.ts
+++ b/packages/oc-docs/src/components/Search/searchIndex.spec.ts
@@ -40,6 +40,17 @@ describe('buildSearchRecords', () => {
     expect(recs[0].description).toContain('List hotels');
   });
 
+  it('indexes an object-form info.description ({ content }) as searchable text', () => {
+    const entry = requestEntry({ uuid: 'u1' });
+    (entry.item as { info: { description: unknown } }).info.description = {
+      content: 'Cancels a reservation',
+      type: 'text/markdown',
+    };
+    const recs = buildSearchRecords([entry]);
+    expect(recs[0].description).toContain('Cancels a reservation');
+    expect(recs[0].description).not.toContain('[object Object]');
+  });
+
   it('excludes folders and built-in pages from records', () => {
     const folder: NavEntry = {
       slug: 'hotels', type: 'folder', name: 'Hotels', item: { uuid: 'f1' } as never,

--- a/packages/oc-docs/src/components/Search/searchIndex.ts
+++ b/packages/oc-docs/src/components/Search/searchIndex.ts
@@ -10,7 +10,7 @@
  */
 
 import type { NavEntry } from '../../routing/types';
-import { getItemDocs, getRequestUrl, getHttpParams } from '../../utils/schemaHelpers';
+import { getItemDocs, getItemDescription, getRequestUrl, getHttpParams } from '../../utils/schemaHelpers';
 import { getItemUuid } from '../../utils/itemUtils';
 import { fuzzyScore } from '../../utils/fuzzyMatch';
 
@@ -47,7 +47,7 @@ const paramsToText = (item: NavEntry['item']): string => {
 
 const descriptionOf = (item: NavEntry['item']): string => {
   const docs = getItemDocs(item) || '';
-  const infoDesc = (item as { info?: { description?: string } } | null)?.info?.description || '';
+  const infoDesc = getItemDescription(item);
   return [infoDesc, docs].filter(Boolean).join(' ');
 };
 


### PR DESCRIPTION
Issue : Users were not able to search via description.
Search read info.description as a string, so object-form ({ content }) descriptions became [object Object] in the index and never matched, reused getItemDescription so both string and object forms are searchable.