### PR TITLE
fix(oc-docs): resolve variables in code snippets and raw body when show-vars is on (BRU-3186)

### DIFF
--- a/packages/oc-docs/src/components/CodeSnippetTabs/CodeSnippetTabs.spec.tsx
+++ b/packages/oc-docs/src/components/CodeSnippetTabs/CodeSnippetTabs.spec.tsx
@@ -1,22 +1,55 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { Provider } from 'react-redux';
 import { describe, it, expect } from 'vitest';
+import { createOpenCollectionStore } from '../../store/store';
+import { setDocsCollection } from '../../store/slices/docs';
+import { setActiveEnv, setShowVars } from '../../store/slices/env';
+import { VariableResolverProvider } from '../../hooks';
 import { CodeSnippetTabs } from './CodeSnippetTabs';
+
+const collection: any = {
+  config: { environments: [{ name: 'Dev', variables: [{ name: 'baseUrl', value: 'https://dev.test' }] }] }
+};
+
+const render = (configure?: (s: ReturnType<typeof createOpenCollectionStore>) => void): string => {
+  const store = createOpenCollectionStore();
+  store.dispatch(setDocsCollection(collection));
+  configure?.(store);
+  return renderToStaticMarkup(
+    <Provider store={store}>
+      <VariableResolverProvider>
+        <CodeSnippetTabs
+          method="post"
+          url="{{baseUrl}}/api/v1/auth/login"
+          headers={[{ name: 'Content-Type', value: 'application/json' }]}
+          body={{ type: 'json', data: '{"email":"a@b.com"}' }}
+        />
+      </VariableResolverProvider>
+    </Provider>
+  );
+};
 
 describe('CodeSnippetTabs', () => {
   it('renders language tabs and the default cURL snippet', () => {
-    const html = renderToStaticMarkup(
-      <CodeSnippetTabs
-        method="post"
-        url="{{baseUrl}}/api/v1/auth/login"
-        headers={[{ name: 'Content-Type', value: 'application/json' }]}
-        body={{ type: 'json', data: '{"email":"a@b.com"}' }}
-      />
-    );
+    const html = render();
     expect(html).toContain('cURL');
     expect(html).toContain('Javascript');
     expect(html).toContain('Python');
     expect(html).toContain('curl --request POST');
+  });
+
+  it('leaves {{variable}} placeholders raw when show-vars is off', () => {
+    const html = render();
     expect(html).toContain('{{baseUrl}}/api/v1/auth/login');
+  });
+
+  it('resolves {{variable}} in the snippet against the active env when show-vars is on', () => {
+    const html = render((s) => {
+      s.dispatch(setActiveEnv('Dev'));
+      s.dispatch(setShowVars(true));
+    });
+    expect(html).toContain('https://dev.test/api/v1/auth/login');
+    expect(html).not.toContain('{{baseUrl}}');
   });
 });

--- a/packages/oc-docs/src/components/CodeSnippetTabs/CodeSnippetTabs.tsx
+++ b/packages/oc-docs/src/components/CodeSnippetTabs/CodeSnippetTabs.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import type { HttpRequestBody, HttpRequestBodyVariant, HttpRequestHeader } from '@opencollection/types/requests/http';
 import type { Auth } from '@opencollection/types/common/auth';
 import { Code } from '../Code/Code';
+import { useResolvedVariables } from '../../hooks';
 import { CopyButton} from '../../ui/CopyButton/CopyButton';
 import { SectionLabel } from '../SectionLabel/SectionLabel';
 import { Modal } from '../../ui/Modal/Modal';
@@ -32,6 +33,7 @@ const LANGUAGES = [
 ] as const;
 
 export const CodeSnippetTabs: React.FC<CodeSnippetTabsProps> = ({ method, url, headers, body, auth, className, testId = 'request-code-snippet' }) => {
+  const { showVars, resolve } = useResolvedVariables();
   const [active, setActive] = useState<string>(LANGUAGES[0].id);
   const [modalActive, setModalActive] = useState<string>(LANGUAGES[0].id);
   const [expanded, setExpanded] = useState(false);
@@ -47,10 +49,13 @@ export const CodeSnippetTabs: React.FC<CodeSnippetTabsProps> = ({ method, url, h
   const snippets = useMemo(() => {
     const input: SnippetInput = { method, url, headers: snippetHeaders, body, auth };
     return LANGUAGES.reduce<Record<string, string>>((acc, lang) => {
-      acc[lang.id] = lang.generate(input);
+      const generated = lang.generate(input);
+      // Resolve `{{var}}` in the whole snippet when show-vars is on (covers the
+      // url, headers and body in one pass; secrets stay as placeholders).
+      acc[lang.id] = showVars ? resolve(generated) : generated;
       return acc;
     }, {});
-  }, [method, url, snippetHeaders, body, auth]);
+  }, [method, url, snippetHeaders, body, auth, showVars, resolve]);
 
   const openModal = () => {
     setModalActive(active);

--- a/packages/oc-docs/src/components/Request/RequestBody/RequestBody.spec.tsx
+++ b/packages/oc-docs/src/components/Request/RequestBody/RequestBody.spec.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { Provider } from 'react-redux';
 import { describe, it, expect } from 'vitest';
+import { createOpenCollectionStore } from '../../../store/store';
+import { setDocsCollection } from '../../../store/slices/docs';
+import { setActiveEnv, setShowVars } from '../../../store/slices/env';
+import { VariableResolverProvider } from '../../../hooks';
 import { RequestBody } from './RequestBody';
 
 describe('RequestBody', () => {
@@ -60,6 +65,25 @@ describe('RequestBody', () => {
     expect(html).toContain('application/json');
     expect(html).toContain('/b.xml');
     expect(html).toContain('selected');
+  });
+
+  it('resolves {{variable}} in a raw/JSON body code block when show-vars is on', () => {
+    const collection: any = {
+      config: { environments: [{ name: 'Dev', variables: [{ name: 'baseUrl', value: 'https://dev.test' }] }] }
+    };
+    const store = createOpenCollectionStore();
+    store.dispatch(setDocsCollection(collection));
+    store.dispatch(setActiveEnv('Dev'));
+    store.dispatch(setShowVars(true));
+    const html = renderToStaticMarkup(
+      <Provider store={store}>
+        <VariableResolverProvider>
+          <RequestBody body={{ type: 'json', data: '{"url":"{{baseUrl}}/x"}' }} />
+        </VariableResolverProvider>
+      </Provider>
+    );
+    expect(html).toContain('https://dev.test/x');
+    expect(html).not.toContain('{{baseUrl}}');
   });
 
   it('renders nothing for an empty/none body', () => {

--- a/packages/oc-docs/src/components/Request/RequestBody/RequestBody.tsx
+++ b/packages/oc-docs/src/components/Request/RequestBody/RequestBody.tsx
@@ -4,6 +4,7 @@ import { Code } from '../../Code/Code';
 import { ContentTypeBadge } from '../../ContentTypeBadge/ContentTypeBadge';
 import { PropertyTable, type PropertyRow } from '../../PropertyTable/PropertyTable';
 import { VariableText } from '../../VariableText/VariableText';
+import { useResolvedVariables } from '../../../hooks';
 import { getBodyView, type BodyTableRow } from '../../../utils/request';
 import { StyledWrapper } from './StyledWrapper';
 
@@ -27,13 +28,16 @@ const BodyPartValue: React.FC<{ row: BodyTableRow }> = ({ row }) => (
 );
 
 export const RequestBody: React.FC<RequestBodyProps> = ({ body, showContentType = true, className, hideRowBorders = false }) => {
+  const { showVars, resolve } = useResolvedVariables();
   const view = getBodyView(body);
   if (view.render === 'none') return null;
 
   return (
     <StyledWrapper className={['request-body', className].filter(Boolean).join(' ')}>
       {showContentType && <ContentTypeBadge label={view.contentTypeLabel} />}
-      {view.render === 'code' && <Code code={view.code} language={view.language} showLineNumbers />}
+      {view.render === 'code' && (
+        <Code code={showVars ? resolve(view.code) : view.code} language={view.language} showLineNumbers />
+      )}
       {view.render === 'table' && (
         <PropertyTable
           hideRowBorders={hideRowBorders}


### PR DESCRIPTION
Show-vars now resolves `{{var}}` inside code snippets (cURL/JS/Python) and raw/JSON request bodies, not just URLs; secrets stay masked and unknown vars stay literal.