### PR TITLE
fix(oc-docs): show the collection version verbatim in the header

### DIFF
--- a/packages/oc-docs/e2e/tests/layout/page-header.spec.ts
+++ b/packages/oc-docs/e2e/tests/layout/page-header.spec.ts
@@ -17,7 +17,7 @@ test.describe('Page header', () => {
 
     await expect(pageHeader.root).toBeVisible();
     await expect(pageHeader.brandName).toContainText('Bruno Testbench');
-    await expect(pageHeader.brandVersion).toHaveText('v1.0.0');
+    await expect(pageHeader.brandVersion).toHaveText('1.0.0');
 
     // Sticky: header stays at the top after the page scrolls.
     await page.mouse.wheel(0, 600);

--- a/packages/oc-docs/src/components/Topbar/Brand/Brand.spec.tsx
+++ b/packages/oc-docs/src/components/Topbar/Brand/Brand.spec.tsx
@@ -4,15 +4,16 @@ import { describe, it, expect } from 'vitest';
 import Brand from './Brand';
 
 describe('Brand', () => {
-  it('shows the collection name and a v-prefixed version', () => {
+  it('shows the collection name and the version verbatim', () => {
     const html = renderToStaticMarkup(<Brand collectionName="Hotel Booking API" version="1.0.0" />);
     expect(html).toContain('Hotel Booking API');
-    expect(html).toContain('v1.0.0');
+    expect(html).toContain('>1.0.0<');
+    expect(html).not.toContain('v1.0.0');
   });
 
-  it('does not double the v prefix', () => {
+  it('shows a user-authored "v" prefix exactly as given', () => {
     const html = renderToStaticMarkup(<Brand collectionName="X" version="v2.3" />);
-    expect(html).toContain('v2.3');
+    expect(html).toContain('>v2.3<');
     expect(html).not.toContain('vv2.3');
   });
 
@@ -35,6 +36,6 @@ describe('Brand', () => {
     expect(html).toContain('data-testid="brand-initials"');
     expect(html).toContain('Docs');
     expect(html).not.toContain('Hotel Booking API');
-    expect(html).not.toContain('v1.0.0');
+    expect(html).not.toContain('1.0.0');
   });
 });

--- a/packages/oc-docs/src/components/Topbar/Brand/Brand.tsx
+++ b/packages/oc-docs/src/components/Topbar/Brand/Brand.tsx
@@ -31,12 +31,6 @@ const renderLogo = (logo: React.ReactNode, collectionName: string): React.ReactN
   return logo;
 };
 
-/** Display version with a leading "v" (idempotent: "1.0.0" → "v1.0.0", "v2" → "v2"). */
-const formatVersion = (version: string): string => {
-  const trimmed = version.trim();
-  return /^v/i.test(trimmed) ? trimmed : `v${trimmed}`;
-};
-
 const Brand: React.FC<BrandProps> = ({
   collectionName,
   version,
@@ -60,7 +54,7 @@ const Brand: React.FC<BrandProps> = ({
           </span>
           {version && (
             <span className="topbar-brand-version" data-testid={`${testId}-version`}>
-              {formatVersion(version)}
+              {version}
             </span>
           )}
         </span>

--- a/packages/oc-docs/src/components/Topbar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Topbar/StyledWrapper.ts
@@ -8,7 +8,7 @@ export const StyledWrapper = styled.header`
   box-sizing: border-box;
   font-family: var(--font-sans);
   background: var(--oc-background-base);
-  border-bottom: 1px solid var(--oc-border-border2);
+  border-bottom: 1px solid var(--oc-border-border0);
 
   .topbar-bar {
     display: flex;

--- a/packages/oc-docs/src/components/Topbar/Topbar.spec.tsx
+++ b/packages/oc-docs/src/components/Topbar/Topbar.spec.tsx
@@ -18,7 +18,8 @@ describe('Topbar', () => {
   it('renders the brand name and version', () => {
     const html = renderToStaticMarkup(<Topbar collectionName="Hotel Booking API" version="1.0.0" />);
     expect(html).toContain('Hotel Booking API');
-    expect(html).toContain('v1.0.0');
+    expect(html).toContain('>1.0.0<');
+    expect(html).not.toContain('v1.0.0');
   });
 
   it('renders the provided search slot node', () => {


### PR DESCRIPTION
The header appended a "v" prefix when missing, so a collection shipped as "1.0.1" showed "v1.0.1". Render the version exactly as the author shipped it (matches the Overview body, which already shows it raw).

Also collected the border colour of header to #efefef as per figma.