### PR TITLE
Collection Docs Playground: API Key auth query placement is not applied

### DIFF
--- a/packages/oc-docs/src/runner/RequestExecutor.spec.ts
+++ b/packages/oc-docs/src/runner/RequestExecutor.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { RequestExecutor, applyApiKeyToUrl } from './RequestExecutor';
+
+describe('applyApiKeyToUrl', () => {
+  it('appends the api key as a query param when placement is query', () => {
+    const auth = { type: 'apikey', key: 'api_key', value: 'secret123', placement: 'query' };
+    expect(applyApiKeyToUrl('https://api.example.com/data', auth)).toBe(
+      'https://api.example.com/data?api_key=secret123'
+    );
+  });
+
+  it('keeps existing query params when appending', () => {
+    const auth = { type: 'apikey', key: 'api_key', value: 'secret123', placement: 'query' };
+    expect(applyApiKeyToUrl('https://api.example.com/data?foo=bar', auth)).toBe(
+      'https://api.example.com/data?foo=bar&api_key=secret123'
+    );
+  });
+
+  it('leaves the url untouched when placement is not query', () => {
+    const auth = { type: 'apikey', key: 'api_key', value: 'secret123', placement: 'header' };
+    expect(applyApiKeyToUrl('https://api.example.com/data', auth)).toBe(
+      'https://api.example.com/data'
+    );
+  });
+
+  it('leaves the url untouched when it cannot be parsed', () => {
+    const auth = { type: 'apikey', key: 'api_key', value: 'secret123', placement: 'query' };
+    expect(applyApiKeyToUrl('api.example.com/data', auth)).toBe('api.example.com/data');
+  });
+});
+
+describe('RequestExecutor', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('sends the api key in the request url when placement is query', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      url: 'https://api.example.com/data',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => JSON.stringify({ ok: true })
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await new RequestExecutor().executeRequest({
+      name: 'apikey query',
+      type: 'http',
+      http: {
+        method: 'GET',
+        url: 'https://api.example.com/data',
+        auth: { type: 'apikey', key: 'api_key', value: 'secret123', placement: 'query' }
+      }
+    } as any);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/data?api_key=secret123');
+  });
+});

--- a/packages/oc-docs/src/runner/RequestExecutor.ts
+++ b/packages/oc-docs/src/runner/RequestExecutor.ts
@@ -5,11 +5,28 @@ import { buildRequestUrl } from '../utils/pathParams';
 import { classifyRequestError, DEFAULT_TIMEOUT_MS } from './classifyRequestError';
 import stripJsonComments from 'strip-json-comments';
 
+export const applyApiKeyToUrl = (url: string, auth: Record<string, unknown> | undefined): string => {
+  if (auth?.type !== 'apikey' || auth.placement !== 'query' || !auth.key) {
+    return url;
+  }
+
+  try {
+    const urlObj = new URL(url);
+    urlObj.searchParams.set(String(auth.key), String(auth.value ?? ''));
+    return urlObj.toString();
+  } catch {
+    return url;
+  }
+};
+
 export class RequestExecutor {
   async executeRequest(request: HttpRequest, options: { timeout?: number } = {}): Promise<RunRequestResponse> {
     const startTime = Date.now();
     const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
-    const requestUrl = buildRequestUrl(getRequestUrl(request), getHttpParams(request));
+    const requestUrl = applyApiKeyToUrl(
+      buildRequestUrl(getRequestUrl(request), getHttpParams(request)),
+      getRequestAuth(request)
+    );
 
     try {
       const fetchOptions = await this.buildFetchOptions(request, timeoutMs);


### PR DESCRIPTION
**Description**
API Key auth is applied only when its placement is header. When placement is query, the key is silently not added to the request, so the request is sent without it.


