### PR TITLE
feat(oc-docs): migrate response formatter + preview from bruno-app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1372,6 +1372,24 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@microlink/react-json-view": {
+      "version": "1.31.23",
+      "resolved": "https://registry.npmjs.org/@microlink/react-json-view/-/react-json-view-1.31.23.tgz",
+      "integrity": "sha512-Qjt7uUpYPDAQiu0LgxyRSuwAgMBwIXtJZ6HSbjTAx6TXu0DdZ/BVIFD5A27z/NcXS2q2zVQgAIxut3WbUdDwRg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-base16-styling": "~0.10.0",
+        "react-lifecycles-compat": "~3.0.4",
+        "react-textarea-autosize": "~8.5.9"
+      },
+      "engines": {
+        "node": ">=17"
+      },
+      "peerDependencies": {
+        "react": ">= 15",
+        "react-dom": ">= 15"
+      }
+    },
     "node_modules/@mintlify/httpsnippet": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@mintlify/httpsnippet/-/httpsnippet-1.0.10.tgz",
@@ -2672,7 +2690,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash-es": {
@@ -3730,11 +3747,23 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3747,8 +3776,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -5747,7 +5785,6 @@
       "version": "4.17.22",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
       "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -7300,6 +7337,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-base16-styling": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.10.0.tgz",
+      "integrity": "sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.17.0",
+        "color": "^4.2.3",
+        "csstype": "^3.1.3",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -7317,6 +7366,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -7415,6 +7470,23 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reactflow": {
@@ -7859,6 +7931,21 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -8459,6 +8546,51 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -9853,6 +9985,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@faker-js/faker": "^9.7.0",
+        "@microlink/react-json-view": "^1.31.22",
         "@mintlify/httpsnippet": "^1.0.10",
         "@monaco-editor/react": "^4.7.0",
         "@opencollection/types": "0.11.0",

--- a/packages/oc-docs/package.json
+++ b/packages/oc-docs/package.json
@@ -59,6 +59,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@faker-js/faker": "^9.7.0",
+    "@microlink/react-json-view": "^1.31.22",
     "@mintlify/httpsnippet": "^1.0.10",
     "@monaco-editor/react": "^4.7.0",
     "@opencollection/types": "0.11.0",

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ResponseBodyTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ResponseBodyTab.tsx
@@ -1,47 +1,47 @@
 import React from 'react';
 import CodeEditor from '../../../../../ui/CodeEditor/CodeEditor';
+import { ResponseBodyFormat } from '../../../../../utils/response';
+import { RunRequestResponse } from '../../../../../runner';
+import { QueryResultPreview } from '../../../QueryResult/QueryResult';
+import { formatToPreviewMode } from '../../../QueryResult/QueryResultPreview/previewMode';
 
 interface ResponseBodyTabProps {
-  response: any;
+  response: RunRequestResponse;
+  selectedFormat: ResponseBodyFormat;
+  showPreview: boolean;
 }
 
-const ResponseBodyTab: React.FC<ResponseBodyTabProps> = ({ response }) => {
-  const formatJson = (data: any) => {
-    try {
-      return JSON.stringify(data, null, 2);
-    } catch {
-      return String(data);
-    }
-  };
+const ResponseBodyTab: React.FC<ResponseBodyTabProps> = ({ response, selectedFormat, showPreview }) => {
+  // The runner parses JSON responses into objects; the editor needs a string.
+  const editorValue =
+    response?.data == null
+      ? ''
+      : typeof response.data === 'string'
+        ? response.data
+        : JSON.stringify(response.data, null, 2);
 
-  const responseText = typeof response.data === 'string' ? response.data : formatJson(response.data);
-  const contentType = response.headers?.['content-type'] || response.headers?.['Content-Type'] || '';
-  let language = 'text';
-  
-  if (contentType.includes('application/json') || contentType.includes('text/json')) {
-    language = 'json';
-  } else if (contentType.includes('text/html')) {
-    language = 'html';
-  } else if (contentType.includes('text/xml') || contentType.includes('application/xml')) {
-    language = 'xml';
-  } else if (contentType.includes('text/css')) {
-    language = 'css';
-  } else if (contentType.includes('text/javascript') || contentType.includes('application/javascript')) {
-    language = 'javascript';
-  }
-  
+  // The tab-panel is height-constrained; own the scroll here so a tall body
+  // (e.g. a large JSON tree) scrolls within the response area instead of
+  // overflowing and being clipped.
   return (
-    <div className="h-full py-4">
-      <CodeEditor
-        value={responseText}
-        onChange={() => {}} // Read-only
-        language={language}
-        height="100%"
-        readOnly={true}
-      />
+    <div className="h-full overflow-auto">
+      {showPreview ? (
+        <QueryResultPreview
+          data={response?.data}
+          previewMode={formatToPreviewMode(selectedFormat)}
+          baseUrl={response?.url}
+        />
+      ) : (
+        <CodeEditor
+          value={editorValue}
+          onChange={() => {}} // Read-only
+          language={selectedFormat}
+          height="100%"
+          readOnly={true}
+        />
+      )}
     </div>
   );
 };
 
 export default ResponseBodyTab;
-

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponseFormatter/index.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponseFormatter/index.tsx
@@ -1,0 +1,100 @@
+import type { FC } from 'react';
+import MenuDropdown, { type MenuDropdownItem, type MenuDropdownItems } from '../../../../../../../ui/MenuDropdown';
+import { ResponseBodyFormat } from '../../../../../../../utils/response';
+
+interface ResponseFormatSelectorProps {
+  handleSelection?: (value: ResponseBodyFormat) => void;
+  selectedFormat?: ResponseBodyFormat;
+  /** Whether the response is shown as a rendered preview vs the raw editor. */
+  showPreview?: boolean;
+  /** Called when the preview toggle is flipped. */
+  onPreviewToggle?: (next: boolean) => void;
+}
+
+/** "Preview" label + switch rendered as the dropdown header (above the formats). */
+const PreviewToggleHeader: FC<{ checked: boolean; onChange: (next: boolean) => void }> = ({
+  checked,
+  onChange
+}) => (
+  <div className="flex items-center justify-between" style={{ padding: '4px 4px', gap: 24, minWidth: 190 }}>
+    <span style={{ fontSize: 13, color: 'var(--oc-text)' }}>Preview</span>
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label="Toggle preview"
+      onClick={() => onChange(!checked)}
+      style={{
+        position: 'relative',
+        width: 34,
+        height: 18,
+        flexShrink: 0,
+        padding: 0,
+        border: 'none',
+        borderRadius: 9,
+        cursor: 'pointer',
+        background: checked ? 'var(--oc-accents-primary)' : 'var(--oc-background-surface2)',
+        transition: 'background 0.15s ease'
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          top: 2,
+          left: checked ? 18 : 2,
+          width: 14,
+          height: 14,
+          borderRadius: '50%',
+          background: 'var(--oc-background-base)',
+          transition: 'left 0.15s ease'
+        }}
+      />
+    </button>
+  </div>
+);
+
+const FORMAT_GROUPS: Array<{options: Array<{id: ResponseBodyFormat, value: ResponseBodyFormat, text: string}>}> = [
+  {
+    options: [
+      { id: 'json', value: 'json', text: 'JSON' },
+      { id: 'html', value: 'html', text: 'HTML' },
+      { id: 'xml', value: 'xml', text: 'XML' },
+      { id: 'javascript', value: 'javascript', text: 'Javascript' }
+    ]
+  },
+  {
+    options: [
+      { id: 'raw', value: 'raw', text: 'Raw' },
+      { id: 'hex', value: 'hex', text: 'Hex' },
+      { id: 'base64', value: 'base64', text: 'Base64' }
+    ]
+  }
+];
+
+const ResponseFormatSelector: FC<ResponseFormatSelectorProps> = ({
+  handleSelection,
+  selectedFormat,
+  showPreview = false,
+  onPreviewToggle
+}) => {
+  const items: MenuDropdownItems = FORMAT_GROUPS.map((group) => ({
+    options: group.options.map(({ id, value, text }) => ({
+      id,
+      label: text,
+      onClick: () => handleSelection?.(value)
+    }))
+  }));
+
+  return (
+    <MenuDropdown
+      items={items}
+      selectedItemId={selectedFormat}
+      itemToText={(item: MenuDropdownItem) => item.label}
+      placement="bottom-start"
+      header={<PreviewToggleHeader checked={showPreview} onChange={(next) => onPreviewToggle?.(next)} />}
+      testId="response-format-selector"
+    />
+  );
+};
+
+export default ResponseFormatSelector;

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponseFormatter/useResponseFormatter.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponseFormatter/useResponseFormatter.ts
@@ -1,0 +1,27 @@
+import { useCallback, useMemo, useState } from 'react';
+import { RunRequestResponse } from '../../../../../../../runner';
+import { ResponseBodyFormat, useInitialResponseFormat } from '../../../../../../../utils/response';
+
+export function useResponseFormatter(response: RunRequestResponse) {
+  const { format, view } = useInitialResponseFormat(response?.headers);
+  const [userSelectedFormat, setUserSelectedFormat] = useState<ResponseBodyFormat>();
+  const [showPreview, setShowPreview] = useState(view === 'preview');
+
+  const handleFormatChange = useCallback((format: ResponseBodyFormat) => {
+    setUserSelectedFormat(format);
+  }, []);
+
+  const handleViewChange = useCallback((showPreview: boolean) => {
+    setShowPreview(showPreview);
+  }, []);
+
+  return useMemo(() => {
+    const selectedFormat = userSelectedFormat ?? format;
+    return {
+      selectedFormat,
+      showPreview,
+      handleFormatChange,
+      handleViewChange
+    };
+  }, [handleFormatChange, handleViewChange, format, userSelectedFormat, showPreview]);
+}

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
@@ -4,15 +4,20 @@ import ResponseBodyTab from '../../Common/ResponseBodyTab';
 import ResponseHeadersTab from '../../Common/ResponseHeadersTab';
 import TestResultsTab from '../../Common/TestResultsTab';
 import ErrorBanner from '../../../../../../ui/ErrorBanner/ErrorBanner';
+import ResponseFormatSelector from './ResponseFormatter';
+import { useResponseFormatter } from './ResponseFormatter/useResponseFormatter';
+import { RunRequestResponse } from '../../../../../../runner';
+import type { ResponseBodyFormat } from '../../../../../../utils/response';
 import { StyledWrapper } from './StyledWrapper';
 
 interface ResponsePaneProps {
-  response: any;
+  response: RunRequestResponse;
   isLoading: boolean;
 }
 
 const ResponsePane: React.FC<ResponsePaneProps> = ({ response, isLoading }) => {
   const [activeTab, setActiveTab] = useState('response');
+  const { selectedFormat, showPreview, handleFormatChange, handleViewChange } = useResponseFormatter(response);
 
   const getStatusColor = (status?: number) => {
     if (!status) return 'var(--oc-request-tab-panel-response-status)';
@@ -56,13 +61,15 @@ const ResponsePane: React.FC<ResponsePaneProps> = ({ response, isLoading }) => {
     <div className="p-4">
       <ErrorBanner
         title={response.errorTitle || 'Request Failed'}
-        message={response.error}
+        message={response.error ?? ''}
       />
     </div>
   );
 
   const renderResponseBody = () =>
-    response.error ? renderErrorBanner() : <ResponseBodyTab response={response} />;
+    response.error ? renderErrorBanner() : (
+      <ResponseBodyTab response={response} selectedFormat={selectedFormat} showPreview={showPreview} />
+    );
   const renderHeaders = () => <ResponseHeadersTab headers={response.headers} />;
   const renderTestResults = () => (
     <TestResultsTab 
@@ -99,6 +106,12 @@ const ResponsePane: React.FC<ResponsePaneProps> = ({ response, isLoading }) => {
 
   const statusInfo = (
     <div className="flex items-center gap-3 flex-wrap text-xs">
+      <ResponseFormatSelector
+        selectedFormat={selectedFormat}
+        handleSelection={(value: ResponseBodyFormat) => handleFormatChange(value)}
+        showPreview={showPreview}
+        onPreviewToggle={handleViewChange}
+      />
       <div className="flex items-center gap-2">
         <span style={{ color: 'var(--text-secondary)' }}>Status:</span>
         <span 

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResult.tsx
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResult.tsx
@@ -1,0 +1,2 @@
+export { default as QueryResultPreview } from './QueryResultPreview/QueryResultPreview';
+export type { PreviewMode, QueryResultPreviewProps } from './QueryResultPreview/QueryResultPreview';

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/HtmlPreview.tsx
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/HtmlPreview.tsx
@@ -1,0 +1,59 @@
+import { memo, useMemo } from 'react';
+
+export interface HtmlPreviewProps {
+  data: unknown;
+  /** Base URL injected as `<base href>` so relative links/resources resolve. */
+  baseUrl?: string;
+}
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
+const toHtmlString = (data: unknown): string => {
+  if (data === null || data === undefined) return String(data);
+  if (typeof data === 'object') {
+    try {
+      return JSON.stringify(data);
+    } catch {
+      return String(data);
+    }
+  }
+  return String(data);
+};
+
+/**
+ * Renders an HTML response inside a sandboxed iframe. Unlike bruno-app (which
+ * uses an Electron `<webview>`), this runs in the browser, so a sandboxed
+ * iframe with `srcDoc` is used. Scripts are disabled (no `allow-scripts`) so
+ * untrusted response HTML cannot execute.
+ */
+const HtmlPreview = memo(({ data, baseUrl = '' }: HtmlPreviewProps) => {
+  const srcDoc = useMemo(() => {
+    const html = toHtmlString(data);
+    const baseTag = `<base href="${escapeHtml(baseUrl)}">`;
+    return html.includes('<head>')
+      ? html.replace('<head>', `<head>${baseTag}`)
+      : `<head>${baseTag}</head>${html}`;
+  }, [data, baseUrl]);
+
+  return (
+    <div className="h-full bg-white webview-container">
+      <iframe
+        title="HTML preview"
+        className="w-full h-full bg-white"
+        style={{ border: 'none' }}
+        sandbox="allow-same-origin"
+        srcDoc={srcDoc}
+      />
+    </div>
+  );
+});
+
+HtmlPreview.displayName = 'HtmlPreview';
+
+export default HtmlPreview;

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/JsonPreview.tsx
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/JsonPreview.tsx
@@ -1,0 +1,84 @@
+import React, { Suspense, lazy } from 'react';
+import ErrorBanner from '../../../../ui/ErrorBanner/ErrorBanner';
+import { useAppSelector } from '../../../../store/hooks';
+
+// react-json-view touches browser globals at module load, so a static import
+// crashes under SSR (the server bundle and the renderToStaticMarkup unit tests).
+// Load it lazily and render it only in the browser (the tree is client-only —
+// it appears after a request runs).
+const ReactJson = lazy(() => import('@microlink/react-json-view'));
+
+export interface JsonPreviewProps {
+  data: unknown;
+}
+
+interface ParsedJson {
+  value: object | null;
+  error: string | null;
+}
+
+// Accepts an object/array directly, or a JSON string to parse.
+const parseJson = (input: unknown): ParsedJson => {
+  if (typeof input === 'object' && input !== null) {
+    return { value: input, error: null };
+  }
+
+  if (typeof input === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(input);
+      if (typeof parsed === 'object' && parsed !== null) {
+        return { value: parsed, error: null };
+      }
+      return {
+        value: null,
+        error: 'Data cannot be rendered as a JSON tree. Expected a JSON object or array.'
+      };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { value: null, error: `Invalid JSON format: ${message}` };
+    }
+  }
+
+  return { value: null, error: 'Invalid input. Expected a JSON object, array, or valid JSON string.' };
+};
+
+/** Renders response data as an interactive, collapsible JSON tree. */
+const JsonPreview: React.FC<JsonPreviewProps> = ({ data }) => {
+  const themeMode = useAppSelector((s) => s.theme.mode);
+  const { value, error } = parseJson(data);
+
+  if (error || value === null) {
+    return (
+      <div className="px-2">
+        <ErrorBanner
+          title="Cannot preview as JSON"
+          message={error ?? 'Data is null or undefined. Expected a valid JSON object or array.'}
+        />
+      </div>
+    );
+  }
+
+  if (typeof window === 'undefined') return null;
+
+  return (
+    <Suspense fallback={null}>
+      <ReactJson
+        src={value}
+        theme={themeMode === 'dark' ? 'monokai' : 'rjv-default'}
+        collapsed={2}
+        groupArraysAfterLength={10}
+        displayDataTypes={false}
+        displayObjectSize
+        enableClipboard
+        name={false}
+        style={{
+          backgroundColor: 'transparent',
+          fontSize: '0.75rem',
+          fontFamily: 'var(--font-mono)',
+        }}
+      />
+    </Suspense>
+  );
+};
+
+export default JsonPreview;

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/QueryResultPreview.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/QueryResultPreview.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import { formatToPreviewMode } from './previewMode';
+import TextPreview from './TextPreview';
+import HtmlPreview from './HtmlPreview';
+
+describe('formatToPreviewMode', () => {
+  it('maps formats to preview modes', () => {
+    expect(formatToPreviewMode('html')).toBe('web');
+    expect(formatToPreviewMode('json')).toBe('json');
+    expect(formatToPreviewMode('xml')).toBe('xml');
+    expect(formatToPreviewMode('javascript')).toBe('text');
+    expect(formatToPreviewMode('raw')).toBe('text');
+    expect(formatToPreviewMode('base64')).toBe('text');
+    expect(formatToPreviewMode('hex')).toBe('text');
+  });
+});
+
+describe('TextPreview', () => {
+  it('stringifies object data', () => {
+    const html = renderToStaticMarkup(<TextPreview data={{ a: 1 }} />);
+    expect(html).toContain('{&quot;a&quot;:1}');
+  });
+});
+
+describe('HtmlPreview', () => {
+  it('renders a sandboxed iframe with an injected base href and no scripts', () => {
+    const html = renderToStaticMarkup(<HtmlPreview data="<body>hi</body>" baseUrl="https://api.example.com/" />);
+    expect(html).toContain('<iframe');
+    expect(html).toContain('sandbox="allow-same-origin"');
+    expect(html).not.toContain('allow-scripts');
+    expect(html).toContain('base href=');
+  });
+});

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/QueryResultPreview.tsx
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/QueryResultPreview.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import HtmlPreview from './HtmlPreview';
+import JsonPreview from './JsonPreview';
+import TextPreview from './TextPreview';
+import XmlPreview from './XmlPreview/XmlPreview';
+import type { PreviewMode } from './previewMode';
+
+export type { PreviewMode } from './previewMode';
+
+export interface QueryResultPreviewProps {
+  /** The response body to preview. */
+  data: unknown;
+  /** How to render the data. */
+  previewMode: PreviewMode;
+  /** Base URL used to resolve relative links/resources in the HTML preview. */
+  baseUrl?: string;
+}
+
+/**
+ * Renders a response body preview. Ported from bruno-app's QueryResultPreview,
+ * scoped to the modes feasible in a browser (HTML via sandboxed iframe, JSON,
+ * XML, and plain text). Editor rendering stays in ResponseBodyTab's CodeEditor.
+ */
+const QueryResultPreview: React.FC<QueryResultPreviewProps> = ({ data, previewMode, baseUrl }) => {
+  switch (previewMode) {
+    case 'web':
+      return <HtmlPreview data={data} baseUrl={baseUrl ?? ''} />;
+    case 'json':
+      return <JsonPreview data={data} />;
+    case 'xml':
+      return <XmlPreview data={data} />;
+    case 'text':
+      return <TextPreview data={data} />;
+    default:
+      return (
+        <div className="p-4 flex flex-col items-center justify-center h-full text-center">
+          <div className="text-lg font-semibold mb-2" style={{ color: 'var(--oc-text)' }}>
+            No Preview Available
+          </div>
+          <div className="text-sm" style={{ color: 'var(--oc-colors-text-muted)' }}>
+            Sorry, no preview is available for this content type.
+          </div>
+        </div>
+      );
+  }
+};
+
+export default QueryResultPreview;

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/TextPreview.tsx
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/TextPreview.tsx
@@ -1,0 +1,32 @@
+import { memo, useMemo } from 'react';
+
+export interface TextPreviewProps {
+  data: unknown;
+}
+
+/** Renders arbitrary response data as plain, wrapped monospace text. */
+const TextPreview = memo(({ data }: TextPreviewProps) => {
+  const displayData = useMemo(() => {
+    if (data === null || data === undefined) {
+      return String(data);
+    }
+    if (typeof data === 'object') {
+      try {
+        return JSON.stringify(data);
+      } catch {
+        return String(data);
+      }
+    }
+    return String(data);
+  }, [data]);
+
+  return (
+    <div className="p-4 font-mono text-[13px] whitespace-pre-wrap break-words overflow-auto overflow-x-hidden w-full max-w-full h-full">
+      {displayData}
+    </div>
+  );
+});
+
+TextPreview.displayName = 'TextPreview';
+
+export default TextPreview;

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/XmlPreview/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/XmlPreview/StyledWrapper.ts
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+
+/**
+ * XML tree styling. Ported from bruno-app's XmlPreview styled-components
+ * wrapper, with theme tokens mapped onto oc-docs `--oc-*` CSS variables.
+ */
+export const StyledWrapper = styled.div`
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 20px;
+  padding: 16px;
+  overflow: auto;
+  color: var(--oc-text);
+
+  .xml-container {
+    color: var(--oc-text);
+  }
+
+  .xml-node-name {
+    color: var(--oc-codemirror-tokens-property);
+    font-weight: 500;
+  }
+
+  .xml-separator {
+    color: var(--oc-codemirror-tokens-operator);
+    margin: 0 8px;
+  }
+
+  .xml-value {
+    color: var(--oc-codemirror-tokens-string);
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .xml-empty-value {
+    color: var(--oc-codemirror-tokens-comment);
+  }
+
+  .xml-count {
+    color: var(--oc-codemirror-tokens-comment);
+    margin-left: 8px;
+  }
+
+  .xml-toggle-button,
+  .xml-array-toggle-button {
+    margin-right: 8px;
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--oc-codemirror-tokens-atom);
+    flex-shrink: 0;
+    border-radius: 4px;
+    background: transparent;
+    border: 0;
+    transition: background-color 0.2s;
+
+    &:hover {
+      background-color: var(--oc-console-button-hover-bg);
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/XmlPreview/XmlPreview.tsx
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/XmlPreview/XmlPreview.tsx
@@ -1,0 +1,353 @@
+import React, { useState, useMemo } from 'react';
+import ErrorBanner from '../../../../../ui/ErrorBanner/ErrorBanner';
+import { StyledWrapper } from './StyledWrapper';
+
+/** Recursive shape produced by parsing an XML string into a JS object. */
+export type XmlValue = string | number | null | XmlObject | XmlValue[];
+export interface XmlObject {
+  [key: string]: XmlValue;
+}
+
+export interface XmlPreviewProps {
+  /** The XML content to preview. Must be an XML string. */
+  data: unknown;
+  defaultExpanded?: boolean;
+}
+
+// The expected "data" prop must be an XML string.
+export default function XmlPreview({ data, defaultExpanded = true }: XmlPreviewProps) {
+  const parsed = useMemo<{ value: XmlObject | null; error: string | null }>(() => {
+    if (typeof data !== 'string') {
+      return { value: null, error: 'Invalid input. Expected an XML string.' };
+    }
+    const result = parseXMLString(data);
+    if (result === null) {
+      return { value: null, error: 'Failed to parse XML string. Invalid XML format.' };
+    }
+    return { value: result, error: null };
+  }, [data]);
+
+  if (parsed.error) {
+    return (
+      <div className="px-2">
+        <ErrorBanner title="Cannot preview as XML" message={parsed.error} />
+      </div>
+    );
+  }
+
+  const parsedData = parsed.value;
+
+  if (parsedData === null) {
+    return (
+      <div className="px-2">
+        <ErrorBanner
+          title="Cannot preview as XML"
+          message="Data cannot be rendered as a tree. Expected a valid XML string."
+        />
+      </div>
+    );
+  }
+
+  // If root is an object with a single key, unwrap it to show the actual root element.
+  let rootNode: XmlValue = parsedData;
+  let rootNodeName = '';
+
+  const keys = Object.keys(parsedData).filter((k) => k !== '$' && k !== '@_' && k !== '#text');
+  if (keys.length === 1) {
+    rootNodeName = keys[0];
+    rootNode = parsedData[keys[0]];
+  } else if (keys.length === 0) {
+    return (
+      <div className="px-2">
+        <ErrorBanner title="Cannot preview as XML" message="Cannot render XML tree. Root object is empty." />
+      </div>
+    );
+  }
+
+  return (
+    <StyledWrapper>
+      <div className="xml-container">
+        <XmlNode node={rootNode} nodeName={rootNodeName} defaultExpanded={defaultExpanded} />
+      </div>
+    </StyledWrapper>
+  );
+}
+
+interface XmlArrayNodeProps {
+  arrayKey: string;
+  items: XmlValue[];
+  depth: number;
+  defaultExpanded?: boolean;
+}
+
+// Component for rendering array entries with expand/collapse functionality.
+const XmlArrayNode: React.FC<XmlArrayNodeProps> = ({ arrayKey, items, depth, defaultExpanded = true }) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const toggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpanded((v) => !v);
+  };
+
+  return (
+    <div style={{ paddingLeft: `${(depth + 1) * 20}px` }}>
+      <div className="flex items-center mb-1">
+        <button onClick={toggle} className="xml-array-toggle-button" tabIndex={-1} aria-expanded={expanded}>
+          {expanded ? '▼' : '▶'}
+        </button>
+        <span className="xml-node-name">{arrayKey}</span>
+        <span className="xml-count">[{items.length}]</span>
+      </div>
+      {expanded && (
+        <div className="array-content">
+          {items.map((item, itemIdx) => (
+            <XmlNode
+              key={`${arrayKey}-${itemIdx}`}
+              node={item}
+              nodeName={`${itemIdx}`}
+              defaultExpanded={false}
+              depth={depth + 2}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface XmlNodeProps {
+  node: XmlValue;
+  nodeName?: string;
+  defaultExpanded?: boolean;
+  depth?: number;
+}
+
+const XmlNode: React.FC<XmlNodeProps> = ({ node, nodeName = '', defaultExpanded = true, depth = 0 }) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  let displayNodeName = nodeName;
+
+  if (Array.isArray(node)) {
+    // For repeated XML elements with same name (e.g. <item>...</item><item>...</item>)
+    return (
+      <>
+        {node.map((item, idx) => (
+          <XmlNode key={idx} node={item} nodeName={displayNodeName} defaultExpanded={false} depth={depth} />
+        ))}
+      </>
+    );
+  }
+
+  const childEntries = getChildrenEntries(node);
+  const childCount = getChildCount(node);
+  const isLeaf = isTextNode(node) || (typeof node === 'object' && childCount === 0);
+
+  const toggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpanded((v) => !v);
+  };
+
+  // For leaf nodes with text content.
+  if (isLeaf && isTextNode(node)) {
+    const value = String(node);
+    return (
+      <div className="flex items-start mb-1" style={{ paddingLeft: `${depth * 20}px` }}>
+        {displayNodeName && (
+          <>
+            <span className="xml-node-name">{displayNodeName}</span>
+            <span className="xml-separator">:</span>
+          </>
+        )}
+        <span className="xml-value">{value}</span>
+      </div>
+    );
+  }
+
+  // For empty leaf nodes (attributes without values, etc).
+  if (isLeaf && !isTextNode(node)) {
+    // A node with both attributes and text falls through to expandable rendering.
+    if (!(typeof node === 'object' && node !== null && '_text' in node)) {
+      return (
+        <div className="flex items-center mb-1" style={{ paddingLeft: `${depth * 20}px` }}>
+          {displayNodeName && (
+            <>
+              <span className="xml-node-name">{displayNodeName}</span>
+              <span className="xml-separator">:</span>
+              <span className="xml-empty-value">{'{}'}</span>
+            </>
+          )}
+        </div>
+      );
+    }
+  }
+
+  // For expandable nodes - show as tree structure.
+  // If no node name at root level, render children directly.
+  if (!displayNodeName && depth === 0) {
+    if (childEntries.length > 0) {
+      return (
+        <div>
+          {childEntries.map(([key, value], idx) => (
+            <XmlNode key={key + idx} node={value} nodeName={key} defaultExpanded={defaultExpanded} depth={0} />
+          ))}
+        </div>
+      );
+    }
+    return null;
+  }
+
+  // If no display name at non-root level, use a fallback.
+  if (!displayNodeName) {
+    displayNodeName = '(unnamed)';
+  }
+
+  return (
+    <div style={{ paddingLeft: `${depth * 20}px` }}>
+      <div className="flex items-center mb-1">
+        <button onClick={toggle} className="xml-toggle-button" tabIndex={-1} aria-expanded={expanded}>
+          {expanded ? '▼' : '▶'}
+        </button>
+
+        <span className="xml-node-name">{displayNodeName}</span>
+
+        {childCount > 0 && <span className="xml-count">{`{${childCount}}`}</span>}
+      </div>
+
+      {expanded && childEntries.length > 0 && (
+        <div>
+          {childEntries.map(([key, value], idx) => {
+            // Attributes are stored with an underscore prefix.
+            const isAttribute = key.startsWith('_');
+
+            if (isAttribute) {
+              const displayValue = value === '' ? 'value' : String(value);
+              return (
+                <div
+                  key={key + idx}
+                  className="flex items-start mb-1"
+                  style={{ paddingLeft: `${(depth + 1) * 20}px` }}
+                >
+                  <span className="xml-node-name">{key}</span>
+                  <span className="xml-separator">:</span>
+                  <span className={value === '' ? 'xml-empty-value' : 'xml-value'}>{displayValue}</span>
+                </div>
+              );
+            }
+
+            if (Array.isArray(value)) {
+              return (
+                <XmlArrayNode key={`${key}-${idx}`} arrayKey={key} items={value} depth={depth} defaultExpanded />
+              );
+            }
+
+            return (
+              <XmlNode key={key + idx} node={value} nodeName={key} defaultExpanded={false} depth={depth + 1} />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Parse an XML string into a nested JS object.
+function parseXMLString(xmlString: string): XmlObject | null {
+  try {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlString, 'text/xml');
+
+    // Check for parsing errors.
+    const parserError = xmlDoc.querySelector('parsererror');
+    if (parserError) {
+      return null;
+    }
+
+    const rootElement = xmlDoc.documentElement;
+    if (!rootElement) return null;
+
+    const parsed = xmlToObject(rootElement);
+    return parsed !== null && parsed !== '' ? { [rootElement.nodeName]: parsed } : null;
+  } catch {
+    return null;
+  }
+}
+
+// Convert an XML DOM element into a nested JS object.
+function xmlToObject(node: Element): XmlValue {
+  const result: XmlObject = {};
+
+  // Attributes are stored directly with an underscore prefix.
+  if (node.attributes && node.attributes.length > 0) {
+    for (let i = 0; i < node.attributes.length; i++) {
+      const attr = node.attributes[i];
+      result[`_${attr.name}`] = attr.value || '';
+    }
+  }
+
+  const childNodes = Array.from(node.childNodes);
+  const elementChildren = childNodes.filter((child): child is Element => child.nodeType === 1);
+  const textChildren = childNodes.filter(
+    (child) => child.nodeType === 3 && (child.textContent ?? '').trim() !== ''
+  );
+
+  // Only text children and no element children: return the text content.
+  if (elementChildren.length === 0 && textChildren.length > 0) {
+    const textContent = textChildren
+      .map((t) => (t.textContent ?? '').trim())
+      .join(' ')
+      .trim();
+    if (Object.keys(result).length > 0) {
+      result['_text'] = textContent;
+      return result;
+    }
+    return textContent || null;
+  }
+
+  // Process element children.
+  if (elementChildren.length > 0) {
+    const childMap: XmlObject = {};
+    elementChildren.forEach((child) => {
+      const childName = child.nodeName; // Preserve original casing
+      const childValue = xmlToObject(child);
+
+      const isRepeated =
+        elementChildren.filter((c) => c.nodeName.toLowerCase() === childName.toLowerCase()).length > 1;
+
+      if (childValue !== null || isRepeated) {
+        const existing = childMap[childName];
+        if (existing !== undefined) {
+          // Multiple children with the same name - convert to array.
+          if (Array.isArray(existing)) {
+            existing.push(childValue);
+          } else {
+            childMap[childName] = [existing, childValue];
+          }
+        } else {
+          childMap[childName] = childValue;
+        }
+      }
+    });
+
+    Object.assign(result, childMap);
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function isTextNode(node: XmlValue): node is string | number | null {
+  return typeof node === 'string' || typeof node === 'number' || node === null;
+}
+
+function getChildrenEntries(node: XmlValue): Array<[string, XmlValue]> {
+  // Given an XML-like JS object, return [key, value] for all properties
+  // (attributes with `_` prefix and child elements).
+  if (typeof node !== 'object' || node === null) return [];
+  return Object.entries(node);
+}
+
+function getChildCount(node: XmlValue): number {
+  if (Array.isArray(node)) {
+    return node.length;
+  }
+  return getChildrenEntries(node).length;
+}

--- a/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/previewMode.ts
+++ b/packages/oc-docs/src/components/Playground/QueryResult/QueryResultPreview/previewMode.ts
@@ -1,0 +1,20 @@
+import type { ResponseBodyFormat } from '../../../../utils/response';
+
+/** Web-feasible preview modes (binary previews require a data buffer, which the
+ *  docs playground response does not carry). */
+export type PreviewMode = 'web' | 'json' | 'xml' | 'text';
+
+/** Maps a selected response format to the preview mode used to render it. */
+export const formatToPreviewMode = (format: ResponseBodyFormat): PreviewMode => {
+  switch (format) {
+    case 'html':
+      return 'web';
+    case 'json':
+      return 'json';
+    case 'xml':
+      return 'xml';
+    // javascript, base64, raw, hex
+    default:
+      return 'text';
+  }
+};

--- a/packages/oc-docs/src/utils/response.ts
+++ b/packages/oc-docs/src/utils/response.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import { RunRequestResponse } from '../runner';
+
+export function useInitialResponseFormat(headers: RunRequestResponse['headers']): ResponseBodyFormatViewData {
+  return useMemo<ResponseBodyFormatViewData>(() => {
+    if (headers == null) {
+      return { format: 'raw', view: 'preview' };
+    }
+    const key = Object.keys(headers).find((header) => header.toLowerCase() === 'content-type');
+    const contentType = key ? headers[key] : 'raw';
+    return getDefaultResponseFormat(contentType);
+  }, [headers]);
+}
+
+// Normalize & extract MIME type from full header
+const extractMimeType = (contentType = '') => {
+  const cleaned = String(contentType).trim().toLowerCase();
+  const match = cleaned.match(/^[^;]+/); // strip "; charset=utf-8"
+  return match ? match[0] : cleaned;
+};
+
+export type ResponseBodyFormat = 'html' | 'json' | 'xml' | 'javascript' | 'base64' | 'raw' | 'hex';
+
+export type ResponseBodyView = 'preview' | 'editor';
+
+export interface ResponseBodyFormatViewData {
+  format: ResponseBodyFormat;
+  view: ResponseBodyView;
+}
+
+export function getDefaultResponseFormat(contentType: string): ResponseBodyFormatViewData {
+  const mime = extractMimeType(contentType);
+
+  const rules = [
+    // ====== HTML ======
+    { test: /^text\/html$/, result: { format: 'html', view: 'preview' } },
+
+    // ====== JSON (including custom +json types) ======
+    {
+      test: /^application\/(json|.+\+json)$/,
+      result: { format: 'json', view: 'editor' }
+    },
+    {
+      test: /^text\/(json|.+\+json)$/,
+      result: { format: 'json', view: 'editor' }
+    },
+
+    // ====== XML (including custom +xml types) ======
+    {
+      test: /^application\/(xml|.+\+xml)$/,
+      result: { format: 'xml', view: 'editor' }
+    },
+    {
+      test: /^text\/(xml|.+\+xml)$/,
+      result: { format: 'xml', view: 'editor' }
+    },
+
+    // ====== JavaScript ======
+    {
+      test: /^(application|text)\/javascript$/,
+      result: { format: 'javascript', view: 'editor' }
+    },
+
+    // ====== Images, audio, video, PDFs → preview (base64) ======
+    { test: /^image\//, result: { format: 'base64', view: 'preview' } },
+    { test: /^audio\//, result: { format: 'base64', view: 'preview' } },
+    { test: /^video\//, result: { format: 'base64', view: 'preview' } },
+    {
+      test: /^application\/pdf$/,
+      result: { format: 'base64', view: 'preview' }
+    },
+
+    // ====== Any other text types ======
+    { test: /^text\//, result: { format: 'raw', view: 'editor' } }
+  ];
+
+  for (const rule of rules) {
+    if (rule.test.test(mime)) {
+      return rule.result as ResponseBodyFormatViewData;
+    }
+  }
+
+  // ====== Fallback ======
+  return { format: 'raw', view: 'editor' };
+}


### PR DESCRIPTION
## Summary

Migrates the response-formatter UI from bruno-app into `oc-docs` and wires it into the playground response pane.

- **MenuDropdown** — faithful port of bruno-app's dropdown (Tippy-backed, keyboard nav, grouped/flat items, submenus, controlled/uncontrolled state), fully typed. Adds an `itemToText`-driven default trigger so it can display the selected item without a `children` trigger.
- **QueryResultPreview** — ported for the web-feasible subset: HTML (sandboxed `<iframe>`, replacing the Electron `<webview>`), JSON (`@microlink/react-json-view`), XML tree, and text. Binary previews (image/pdf/audio/video) are omitted because the docs response has no data buffer.
- **Response format selector** — rebuilt on `MenuDropdown` with grouped formats and a **Preview toggle** in the dropdown header; `useResponseFormatter` split into its own module.
- **ResponseBodyTab** — renders the preview when the toggle is on, otherwise the read-only editor.

## Notable decisions

- Used **`@microlink/react-json-view`** instead of bruno's `react-json-view` (peer `react <= 17`), which silently downgraded oc-docs to React 17 in this monorepo; a global override isn't viable since `oc-spec-site` is on React 19. The fork is API-identical with peer `react >= 15`.
- Added a `tsconfig` `paths` entry so `@tabler/icons` type declarations resolve (its `exports` map has no `types` condition).

## Follow-ups

Deferred work is tracked in `packages/oc-docs/improvements.md` (binary previews, dropping tippy/tabler, reusable Toggle, etc.).

## Verification

- `tsc --noEmit`: 0 errors
- `eslint --max-warnings 0`: clean
- `vitest`: passing (MenuDropdown + QueryResultPreview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
