### PR TITLE
fix(oc-docs): use the --oc-text token for the overlay sidebar shadow (BRU-2547)

### DIFF
--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
@@ -45,7 +45,7 @@ export const StyledWrapper = styled.div`
     bottom: 0;
     z-index: 5;
     background-color: var(--oc-background-base);
-    box-shadow: 2px 0 8px color-mix(in srgb, black 12%, transparent);
+    box-shadow: 2px 0 8px color-mix(in srgb, var(--oc-text) 12%, transparent);
   }
 
   &[data-overlay-sidebar='true'] .view {


### PR DESCRIPTION
The inline dock overlay-sidebar shadow hardcoded `color-mix(in srgb, black 12%, transparent)` instead of the theme token every sibling dock uses (ModalDock, DockSwitcher). Swap `black` for `var(--oc-text)` so it themes correctly and follows the no-hardcoded-colors rule.