### PR TITLE
fix:increased line height for env_table

### DIFF
--- a/packages/oc-docs/src/components/Examples/ExampleCard/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Examples/ExampleCard/StyledWrapper.ts
@@ -124,7 +124,7 @@ export const StyledWrapper = styled.div`
     font-family: var(--font-sans);
     font-weight: 400;
     font-size: 0.75rem;
-    line-height: 1;
+    line-height: 1.3;
     letter-spacing: 0;
     color: var(--oc-overlay-overlay1);
     white-space: nowrap;

--- a/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
+++ b/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
@@ -56,7 +56,7 @@ export const StyledWrapper = styled.div`
     font-family: 'Fira Code', var(--font-mono);
     font-weight: 500;
     font-size: 0.75rem;
-    line-height: 1;
+    line-height: 1.3;
     letter-spacing: 0;
     color: var(--oc-primary-strong);
     overflow: hidden;
@@ -68,7 +68,7 @@ export const StyledWrapper = styled.div`
     font-family: 'Fira Code', var(--font-mono);
     font-weight: 400;
     font-size: 0.75rem;
-    line-height: 1;
+    line-height: 1.3;
     letter-spacing: 0;
     color: var(--text-primary); /* #343434 */
     overflow: hidden;
@@ -99,7 +99,7 @@ export const StyledWrapper = styled.div`
     font-family: var(--font-sans);
     font-weight: 400;
     font-size: 0.75rem;
-    line-height: 1;
+    line-height: 1.3;
     letter-spacing: 0;
     color: var(--text-secondary); /* #666666 */
   }


### PR DESCRIPTION
In environment table letters like g and p get clipped ,improved line height to accommodate those