### PR TITLE
fix(oc-docs): percent-encode special characters in page slugs

### DIFF
--- a/packages/oc-docs/e2e/tests/routing/routing.spec.ts
+++ b/packages/oc-docs/e2e/tests/routing/routing.spec.ts
@@ -61,6 +61,24 @@ test.describe('page-based navigation', () => {
     await expect(page.getByRole('heading', { name: 'Setup Script', level: 1 })).toBeVisible();
   });
 
+  test('a folder whose name has special characters resolves via its encoded slug', async ({ page }) => {
+    // "Customers/%$" -> the slash/percent/dollar are percent-encoded, so the
+    // folder keeps its own page instead of colliding or collapsing.
+    await page.goto(page$('customers%2F%25%24'));
+    const active = page.getByTestId('page');
+    await expect(active).toHaveAttribute('data-page-slug', 'customers%2F%25%24');
+    await expect(active).toHaveAttribute('data-page-type', 'folder');
+    await expect(page.getByTestId('folder-title')).toHaveText('Customers/%$');
+  });
+
+  test('a request inside a special-character folder deep-links (encoded parent + separator)', async ({ page }) => {
+    await page.goto(page$('customers%2F%25%24/list-customers'));
+    const active = page.getByTestId('page');
+    await expect(active).toHaveAttribute('data-page-slug', 'customers%2F%25%24/list-customers');
+    await expect(active).toHaveAttribute('data-page-type', 'request');
+    await expect(page.getByTestId('request-title')).toHaveText('List customers');
+  });
+
   test('unknown slug redirects to the overview', async ({ page }) => {
     await page.goto(page$('does/not/exist'));
     await expect(page.getByTestId('page')).toHaveAttribute('data-page-type', 'overview');

--- a/packages/oc-docs/src/e2eFixtures/foldersCollection.ts
+++ b/packages/oc-docs/src/e2eFixtures/foldersCollection.ts
@@ -95,5 +95,23 @@ export const foldersFixtureCollection = {
       seq: 6,
       script: "bru.setVar('requestedAt', Date.now());\nconsole.log('Hotel API docs loaded');",
     },
+    {
+      name: 'Customers/%$',
+      type: 'folder',
+      seq: 7,
+      items: [
+        { name: 'List customers', type: 'http', seq: 1, method: 'GET', url: '{{host}}/customers' },
+        { name: 'Create customer', type: 'http', seq: 2, method: 'POST', url: '{{host}}/customers' },
+        { name: 'Retrieve customer', type: 'http', seq: 3, method: 'GET', url: '{{host}}/customers/:id' },
+      ],
+    },
+    {
+      name: 'Café & Résumés',
+      type: 'folder',
+      seq: 8,
+      items: [
+        { name: 'List entrées', type: 'http', seq: 1, method: 'GET', url: '{{host}}/entrees' },
+      ],
+    },
   ],
 } as unknown as OpenCollection;

--- a/packages/oc-docs/src/routing/navModel.spec.ts
+++ b/packages/oc-docs/src/routing/navModel.spec.ts
@@ -46,7 +46,7 @@ describe('buildNavModel — ordered sequence', () => {
       'authentication/login',
       'authentication/register',
       'hotels',
-      'hotels/browse-search',
+      'hotels/browse-%26-search',
       'ping',
     ]);
   });
@@ -91,7 +91,7 @@ describe('buildNavModel — slugs & metadata', () => {
   it('builds full path-based slugs from the folder hierarchy', () => {
     const model = buildNavModel(sample());
     expect(model.bySlug.has('authentication/login')).toBe(true);
-    expect(model.bySlug.has('hotels/browse-search')).toBe(true);
+    expect(model.bySlug.has('hotels/browse-%26-search')).toBe(true);
   });
 
   it('exposes ancestors (folder chain above the node)', () => {

--- a/packages/oc-docs/src/routing/slug.spec.ts
+++ b/packages/oc-docs/src/routing/slug.spec.ts
@@ -2,25 +2,37 @@ import { describe, it, expect } from 'vitest';
 import { slugifySegment, dedupeSiblingSlugs } from './slug';
 
 describe('slugifySegment', () => {
-  it('kebab-cases a plain name', () => {
+  it('kebab-cases a plain name (spaces become single dashes)', () => {
     expect(slugifySegment('Create Booking')).toBe('create-booking');
-  });
-
-  it('lowercases and collapses non-alphanumerics to single dashes', () => {
-    expect(slugifySegment('Browse & Search')).toBe('browse-search');
-  });
-
-  it('trims leading and trailing dashes', () => {
-    expect(slugifySegment('  /Login/  ')).toBe('login');
+    expect(slugifySegment('List  customers')).toBe('list-customers');
   });
 
   it('keeps existing hyphens and underscores', () => {
     expect(slugifySegment('refresh_token-v2')).toBe('refresh_token-v2');
   });
 
-  it('falls back for empty / unnamed input', () => {
+  it('trims leading and trailing whitespace/dashes', () => {
+    expect(slugifySegment('  Login  ')).toBe('login');
+    expect(slugifySegment('-Login-')).toBe('login');
+  });
+
+  it('percent-encodes special characters (kept unique, not collapsed)', () => {
+    expect(slugifySegment('Customers/%$')).toBe('customers%2F%25%24');
+    expect(slugifySegment('Q&A')).toBe('q%26a');
+    expect(slugifySegment('Browse & Search')).toBe('browse-%26-search');
+  });
+
+  it('distinguishes names that differ only by their special characters', () => {
+    expect(slugifySegment('customers/$')).not.toBe(slugifySegment('customers/&'));
+  });
+
+  it('percent-encodes non-ASCII (accents / unicode) with UTF-8 bytes', () => {
+    expect(slugifySegment('résumé')).toBe('r%C3%A9sum%C3%A9');
+  });
+
+  it('falls back to "unnamed" only when there is nothing to encode', () => {
     expect(slugifySegment('')).toBe('unnamed');
-    expect(slugifySegment('***')).toBe('unnamed');
+    expect(slugifySegment('   ')).toBe('unnamed');
   });
 });
 

--- a/packages/oc-docs/src/routing/slug.ts
+++ b/packages/oc-docs/src/routing/slug.ts
@@ -1,11 +1,18 @@
-/** Convert a single item/folder name into a kebab-case URL segment; falls back to 'unnamed'. */
+/**
+ * Convert a single item/folder name into a URL segment.
+ *
+ * Whitespace becomes a `-` (kebab), letters/digits/`_`/`-` are kept as-is
+ * (lowercased), and any other character is percent-encoded so the segment
+ * stays unique and losslessly represented rather than collapsing to `unnamed`.
+ * Keeping spaces as `-` means normal multi-word names stay readable
+ * (`Create Booking` -> `create-booking`) and only true symbols get encoded.
+ */
 export const slugifySegment = (name: string): string => {
-  const slug = (name || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/g, '-')
+  // Whitespace -> `-` first (so multi-word names stay readable as kebab rather
+  // than `%20`); encodeURIComponent then handles every other special character.
+  const slug = encodeURIComponent((name || '').toLowerCase().replace(/\s+/g, '-'))
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
-
   return slug || 'unnamed';
 };
 


### PR DESCRIPTION
**Problem**

Folder/request names with special characters were breaking the page URL. A folder like `Customers/%$` collapsed to `unnamed` (and `unnamed-2`, `unnamed-3` for more of them), so different folders could end up with the same URL and you couldn't deep-link to them.

**Fix**

Percent-encode the name when building the slug: spaces become `-`, everything else goes through `encodeURIComponent`.

- `Create Booking` → `create-booking`
- `Customers/%$` → `customers%2F%25%24`
- `Q&A` → `q%26a`, `résumé` → `r%C3%A9sum%C3%A9`
- `customers/$` and `customers/&` now get different slugs instead of colliding

Every name stays unique and deep-linkable (slashes, symbols, accents, emoji, CJK all work). The real name is still shown in the UI (title/breadcrumb/sidebar) — only the URL is encoded. Works with our HashRouter since routing does a whole-string slug lookup and doesn't decode. Same approach GitHub/GitLab use for special chars in paths.