### PR TITLE
fix(oc-docs): don't send api key query param when the value is empty

### DIFF
--- a/packages/oc-docs/src/runner/RequestExecutor.spec.ts
+++ b/packages/oc-docs/src/runner/RequestExecutor.spec.ts
@@ -27,6 +27,13 @@ describe('applyApiKeyToUrl', () => {
     const auth = { type: 'apikey', key: 'api_key', value: 'secret123', placement: 'query' };
     expect(applyApiKeyToUrl('api.example.com/data', auth)).toBe('api.example.com/data');
   });
+
+  it('leaves the url untouched when the value is empty', () => {
+    const auth = { type: 'apikey', key: 'api_key', value: '', placement: 'query' };
+    expect(applyApiKeyToUrl('https://api.example.com/data', auth)).toBe(
+      'https://api.example.com/data'
+    );
+  });
 });
 
 describe('RequestExecutor', () => {

--- a/packages/oc-docs/src/runner/RequestExecutor.ts
+++ b/packages/oc-docs/src/runner/RequestExecutor.ts
@@ -6,7 +6,7 @@ import { classifyRequestError, DEFAULT_TIMEOUT_MS } from './classifyRequestError
 import stripJsonComments from 'strip-json-comments';
 
 export const applyApiKeyToUrl = (url: string, auth: Record<string, unknown> | undefined): string => {
-  if (auth?.type !== 'apikey' || auth.placement !== 'query' || !auth.key) {
+  if (auth?.type !== 'apikey' || auth.placement !== 'query' || !auth.key || !auth.value) {
     return url;
   }
 


### PR DESCRIPTION
API key auth with `placement: query` appended a dangling `?key=` when the value was empty