### PR TITLE
fix(oc-docs): Environments in the sidebar is shown even when collection does not contain any environment

### DIFF
--- a/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
@@ -62,10 +62,6 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate, testId = 'sidebar' }) => 
     if (uuids.length) dispatch(expandFolders(uuids));
   }, [activeSlug, model, dispatch]);
 
-  const hasEnvironments = Boolean(
-    (collection as { config?: { environments?: unknown[] } })?.config?.environments?.length
-  );
-
   return (
     <StyledWrapper className="sidebar" data-testid={testId}>
       <div className="sidebar-top-links">
@@ -76,15 +72,15 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate, testId = 'sidebar' }) => 
           testId="sidebar-overview"
           onClick={() => goTo(OVERVIEW_SLUG)}
         />
-        {hasEnvironments && (
-          <SidebarNavLink
-            label="Environments"
-            icon={<GlobeIcon />}
-            active={activeSlug === ENVIRONMENTS_SLUG}
-            testId="sidebar-environments"
-            onClick={() => goTo(ENVIRONMENTS_SLUG)}
-          />
-        )}
+        {/* Always shown, like Overview: with no environments the page renders
+            an empty state, so the section must stay reachable from the sidebar. */}
+        <SidebarNavLink
+          label="Environments"
+          icon={<GlobeIcon />}
+          active={activeSlug === ENVIRONMENTS_SLUG}
+          testId="sidebar-environments"
+          onClick={() => goTo(ENVIRONMENTS_SLUG)}
+        />
       </div>
 
       <div className="sidebar-divider" />

--- a/packages/oc-docs/src/routing/navModel.spec.ts
+++ b/packages/oc-docs/src/routing/navModel.spec.ts
@@ -51,9 +51,9 @@ describe('buildNavModel — ordered sequence', () => {
     ]);
   });
 
-  it('omits the environments entry when the collection has none', () => {
+  it('keeps the environments entry even when the collection has none (the page shows an empty state)', () => {
     const c = collection([req('Ping', 1)], false);
-    expect(slugs(c)).toEqual([OVERVIEW_SLUG, 'ping']);
+    expect(slugs(c)).toEqual([OVERVIEW_SLUG, ENVIRONMENTS_SLUG, 'ping']);
   });
 
   it('sorts requests by seq (mirrors the Bruno app)', () => {

--- a/packages/oc-docs/src/routing/navModel.ts
+++ b/packages/oc-docs/src/routing/navModel.ts
@@ -9,11 +9,6 @@ export const OVERVIEW_SLUG = '';
 /** Built-ins are tilde-prefixed so user content can never collide with them. */
 export const ENVIRONMENTS_SLUG = '~environments';
 
-const hasEnvironments = (collection: OpenCollection): boolean => {
-  const envs = (collection as { config?: { environments?: unknown[] } })?.config?.environments;
-  return Array.isArray(envs) && envs.length > 0;
-};
-
 const isSeqValid = (seq: number | undefined): boolean =>
   typeof seq === 'number' && Number.isFinite(seq) && Number.isInteger(seq) && seq > 0;
 
@@ -133,16 +128,17 @@ export const buildNavModel = (collection: OpenCollection | null | undefined): Na
     depth: -1,
   });
 
-  if (collection && hasEnvironments(collection)) {
-    ordered.push({
-      slug: ENVIRONMENTS_SLUG,
-      type: 'environments',
-      name: 'Environments',
-      item: null,
-      ancestors: [],
-      depth: -1,
-    });
-  }
+  // Environments always gets a nav entry, even when the collection has none:
+  // the page itself renders an empty state ("No environments configured") so
+  // the section stays discoverable in the sidebar. Mirrors the Overview entry.
+  ordered.push({
+    slug: ENVIRONMENTS_SLUG,
+    type: 'environments',
+    name: 'Environments',
+    item: null,
+    ancestors: [],
+    depth: -1,
+  });
 
   walk(collection?.items, '', [], 0, ordered);
 


### PR DESCRIPTION
Shows the Environments sidebar entry even when a collection has no environments configured.