### PR TITLE
fix: Fix the collapsed editor on the response body

### DIFF
--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ResponseBodyTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ResponseBodyTab.tsx
@@ -31,7 +31,7 @@ const ResponseBodyTab: React.FC<ResponseBodyTabProps> = ({ response }) => {
   }
   
   return (
-    <div className="h-full py-4" style={{ display: 'flex', flexDirection: 'column' }}>
+    <div className="h-full py-4">
       <CodeEditor
         value={responseText}
         onChange={() => {}} // Read-only

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
@@ -133,6 +133,7 @@ const ResponsePane: React.FC<ResponsePaneProps> = ({ response, isLoading }) => {
   return (
     <div className="h-full" style={{ backgroundColor: 'var(--bg-primary)' }}>
       <Tabs
+        className='h-full'
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={setActiveTab}

--- a/packages/oc-docs/src/ui/Tabs/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/Tabs/StyledWrapper.ts
@@ -125,6 +125,7 @@ export const StyledWrapper = styled.div`
     margin-top: 1rem;
     min-width: 0;
     animation: oc-tab-panel-in 0.2s var(--oc-tab-ease) 0.04s backwards;
+    flex: 1;
   }
   .tab-panel:focus {
     outline: none;


### PR DESCRIPTION
# Description

The tabs content is not expanding to it's full height on the response tab in requests page, and hence the code editor is collapsed.

## Before
<img width="1454" height="837" alt="image" src="https://github.com/user-attachments/assets/5c78cc53-2a89-4e06-bd66-b5bdc22d8ff2" />


## After
<img width="1708" height="990" alt="image" src="https://github.com/user-attachments/assets/3e0053d1-ed16-4799-ab55-e735d4e1c5e7" />

