### PR TITLE
fix(oc-docs): sidebar + playground UI polish

### DIFF
--- a/packages/oc-docs/e2e/tests/layout/page-header.spec.ts
+++ b/packages/oc-docs/e2e/tests/layout/page-header.spec.ts
@@ -17,7 +17,7 @@ test.describe('Page header', () => {
 
     await expect(pageHeader.root).toBeVisible();
     await expect(pageHeader.brandName).toContainText('Bruno Testbench');
-    await expect(pageHeader.brandVersion).toHaveText('1.0.0');
+    await expect(pageHeader.brandVersion).toHaveText('Version : 1.0.0');
 
     // Sticky: header stays at the top after the page scrolls.
     await page.mouse.wheel(0, 600);

--- a/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
@@ -40,6 +40,28 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate, testId = 'sidebar' }) => 
     return map;
   }, [model]);
 
+  // Reveal the scrollbar thumb only while the list is active (mousemove/scroll),
+  // then hide it 1s after activity stops. Toggled via classList so pointer noise
+  // never triggers a re-render.
+  const itemsRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = itemsRef.current;
+    if (!el) return;
+    let timer: ReturnType<typeof setTimeout>;
+    const show = () => {
+      el.classList.add('scrolling');
+      clearTimeout(timer);
+      timer = setTimeout(() => el.classList.remove('scrolling'), 1000);
+    };
+    el.addEventListener('mousemove', show);
+    el.addEventListener('scroll', show, { passive: true });
+    return () => {
+      clearTimeout(timer);
+      el.removeEventListener('mousemove', show);
+      el.removeEventListener('scroll', show);
+    };
+  }, []);
+
   const autoRevealedSlug = useRef<string | null>(null);
   useEffect(() => {
     if (autoRevealedSlug.current === activeSlug) return;
@@ -89,7 +111,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate, testId = 'sidebar' }) => 
 
       <div className="sidebar-divider" />
 
-      <div className="sidebar-items">
+      <div className="sidebar-items" ref={itemsRef}>
         {collection?.items?.length ? (
           <SidebarTree
             items={collection.items}

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/SidebarNavLink.spec.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/SidebarNavLink.spec.tsx
@@ -45,11 +45,14 @@ describe('SidebarNavLink', () => {
     expect(html).toContain('data-testid="sidebar-item"');
   });
 
-  it('marks the label as monospace for script rows', () => {
-    expect(renderToStaticMarkup(<SidebarNavLink label="setup.js" mono />)).toContain('navlink-label mono');
+  it('renders a JS badge in the method column for script rows, label stays default font', () => {
+    const html = renderToStaticMarkup(<SidebarNavLink label="setup.js" script />);
+    expect(html).toContain('navlink-method');
+    expect(html).toContain('>JS<');
+    expect(html).not.toContain('navlink-label mono');
   });
 
-  it('indents by level', () => {
-    expect(renderToStaticMarkup(<SidebarNavLink label="Nested" level={2} />)).toContain('padding-left:36px');
+  it('indents by level (chevron + gap step of 19px)', () => {
+    expect(renderToStaticMarkup(<SidebarNavLink label="Nested" level={2} />)).toContain('padding-left:46px');
   });
 });

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/SidebarNavLink.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/SidebarNavLink.tsx
@@ -11,7 +11,8 @@ interface SidebarNavLinkProps {
   icon?: React.ReactNode;
   chevron?: React.ReactNode;
   muted?: boolean;
-  mono?: boolean;
+  /** Renders a `JS` badge (accent colour) in the method column, for script files. */
+  script?: boolean;
   onClick?: () => void;
   title?: string;
   slug?: string;
@@ -26,7 +27,7 @@ const SidebarNavLink: React.FC<SidebarNavLinkProps> = ({
   icon,
   chevron,
   muted = false,
-  mono = false,
+  script = false,
   onClick,
   title,
   slug,
@@ -38,6 +39,10 @@ const SidebarNavLink: React.FC<SidebarNavLinkProps> = ({
     <span className="navlink-leading navlink-method" style={{ color: getMethodColorVar(method) }}>
       {getShortMethod(method)}
     </span>
+  ) : script ? (
+    <span className="navlink-leading navlink-method" style={{ color: 'var(--oc-colors-accent)' }}>
+      JS
+    </span>
   ) : icon ? (
     <span className="navlink-leading navlink-icon">{icon}</span>
   ) : null;
@@ -47,14 +52,17 @@ const SidebarNavLink: React.FC<SidebarNavLinkProps> = ({
   return (
     <StyledWrapper
       className={classes}
-      style={{ paddingLeft: `${level * 14 + 8}px` }}
+      // Indent step matches chevron (12px) + gap (7px) so a child's leading glyph
+      // sits directly under its parent's label. Right margin keeps the highlight
+      // short of the edge: 8px for root rows, 4px for nested rows.
+      style={{ paddingLeft: `${level * 19 + 8}px`, marginRight: level === 0 ? '8px' : '4px' }}
       data-testid={testId}
       data-slug={slug}
     >
       {chevron}
       <button type="button" className="navlink-main" title={title ?? label} onClick={onClick}>
         {leading}
-        <span className={`navlink-label${mono ? ' mono' : ''}`}>{label}</span>
+        <span className="navlink-label">{label}</span>
       </button>
     </StyledWrapper>
   );

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/StyledWrapper.ts
@@ -4,7 +4,6 @@ export const StyledWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 7px;
-  width: 100%;
   box-sizing: border-box;
   user-select: none;
   border-radius: var(--oc-radius);

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.spec.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.spec.tsx
@@ -72,7 +72,7 @@ describe('SidebarTree', () => {
     expect(html).toContain('GQL');
   });
 
-  it('renders script files as monospace with a .js suffix and no method label', () => {
+  it('renders script files with a .js suffix and a JS badge (default font label)', () => {
     const script = { type: 'script', uuid: 's1', name: 'setup' } as unknown as OpenCollectionItem;
     const html = renderToStaticMarkup(
       <SidebarTree
@@ -84,7 +84,8 @@ describe('SidebarTree', () => {
       />
     );
     expect(html).toContain('setup.js');
-    expect(html).toContain('navlink-label mono');
+    expect(html).not.toContain('navlink-label mono');
+    expect(html).toContain('>JS<');
   });
 });
 

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.tsx
@@ -77,7 +77,7 @@ const SidebarTree: React.FC<SidebarTreeProps> = ({
                 onClick={() => slug !== undefined && onNavigate(slug)}
               />
               {expanded && children.length > 0 && (
-                <StyledWrapper style={{ '--guide-left': `${itemLevel * 14 + 14}px` } as React.CSSProperties}>
+                <StyledWrapper style={{ '--guide-left': `${itemLevel * 19 + 14}px` } as React.CSSProperties}>
                   {renderItems(children, itemLevel + 1)}
                 </StyledWrapper>
               )}
@@ -96,7 +96,7 @@ const SidebarTree: React.FC<SidebarTreeProps> = ({
             level={itemLevel}
             active={active}
             method={method}
-            mono={script}
+            script={script}
             muted
             testId="sidebar-item"
             slug={slug}

--- a/packages/oc-docs/src/components/Docs/Sidebar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Docs/Sidebar/StyledWrapper.ts
@@ -8,17 +8,23 @@ export const StyledWrapper = styled.div`
   background-color: var(--oc-background-base);
   color: var(--oc-sidebar-color);
 
-  ::-webkit-scrollbar {
+  /* Clean thin scrollbar: transparent track (no background column) and no border
+     (no divider line beside it). The thumb is hidden by default and shown while
+     the list is active (.scrolling class, cleared 1s after activity stops). */
+  .sidebar-items::-webkit-scrollbar {
     width: 6px;
   }
-  ::-webkit-scrollbar-track {
+  .sidebar-items::-webkit-scrollbar-track {
     background: transparent;
+    border: none;
   }
-  ::-webkit-scrollbar-thumb {
+  .sidebar-items::-webkit-scrollbar-thumb {
     background-color: transparent;
+    border: none;
     border-radius: 20px;
+    transition: background-color 0.4s ease;
   }
-  &:hover ::-webkit-scrollbar-thumb {
+  .sidebar-items.scrolling::-webkit-scrollbar-thumb {
     background-color: var(--oc-scrollbar-color);
   }
 

--- a/packages/oc-docs/src/components/Playground/DockSwitcher/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/DockSwitcher/StyledWrapper.ts
@@ -5,14 +5,14 @@ export const StyledWrapper = styled.div`
   align-items: center;
   gap: 2px;
   padding: 3px;
-  border: 1px solid var(--oc-background-surface2);
+  border: 1px solid var(--oc-border-border0);
   border-radius: var(--oc-radius);
-  background-color: var(--oc-background-surface0);
+  background-color: var(--oc-background-surface-bright);
 
   button {
     width: 26px;
     height: 24px;
-    color: var(--text-secondary);
+    color: var(--oc-colors-text-subtext0);
     border-radius: var(--oc-radius);
   }
 
@@ -27,7 +27,7 @@ export const StyledWrapper = styled.div`
   }
 
   button.active {
-    color: var(--oc-colors-accent);
+    color: var(--oc-primary-solid);
     background-color: var(--oc-background-base);
     box-shadow: 0 1px 2px color-mix(in srgb, var(--oc-text) 12%, transparent);
   }

--- a/packages/oc-docs/src/components/Playground/PlaygroundHeader/PlaygroundHeader.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundHeader/PlaygroundHeader.tsx
@@ -27,6 +27,7 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({
   <StyledWrapper data-testid={testId}>
     <div className="header-left">
       <IconButton
+        className="header-sidebar-toggle"
         label="Toggle playground sidebar"
         title="Toggle sidebar"
         data-testid="playground-sidebar-toggle"
@@ -52,7 +53,7 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({
           <ChevronDownIcon />
         </IconButton>
       )}
-      <IconButton label="Close playground" title="Close" data-testid="playground-close" onClick={onClose}>
+      <IconButton className="header-close" label="Close playground" title="Close" data-testid="playground-close" onClick={onClose}>
         <CloseIcon />
       </IconButton>
     </div>

--- a/packages/oc-docs/src/components/Playground/PlaygroundHeader/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundHeader/StyledWrapper.ts
@@ -8,7 +8,7 @@ export const StyledWrapper = styled.div`
   gap: 8px;
   height: 52px;
   padding: 0 14px;
-  border-bottom: 1px solid var(--oc-border-border0);
+  border-bottom: 1px solid var(--oc-border-border1);
   background-color: var(--oc-background-base);
 
   .header-left,
@@ -33,6 +33,23 @@ export const StyledWrapper = styled.div`
     font-size: 14px;
     font-weight: 600;
     color: var(--text-primary);
+  }
+
+  /* Muted grey for the sidebar-toggle + collapse + close controls (Figma:
+     subtext0 #9b9b9b); two-class selectors win over IconButton's default. */
+  .header-left .header-sidebar-toggle,
+  .header-right .header-collapse,
+  .header-right .header-close {
+    color: var(--oc-colors-text-subtext0);
+  }
+
+  /* Subtle near-white hover; keeps the grey icon (overrides IconButton's
+     default hover colour/background). */
+  .header-left .header-sidebar-toggle:hover,
+  .header-right .header-collapse:hover,
+  .header-right .header-close:hover {
+    color: var(--oc-colors-text-subtext0);
+    background: var(--oc-background-surface-bright);
   }
 
   .header-collapse svg {

--- a/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/StyledWrapper.ts
@@ -7,7 +7,7 @@ export const StyledWrapper = styled.div`
   flex-direction: column;
   width: 100%;
   min-height: 0;
-  border-top: 1px solid var(--oc-border-border2);
+  border-top: 1px solid var(--oc-border-border0);
   background-color: var(--oc-background-base);
 
   &.dragging {
@@ -33,13 +33,13 @@ export const StyledWrapper = styled.div`
     width: 40px;
     height: 4px;
     border-radius: 999px;
-    background-color: var(--oc-colors-text-subtext0);
+    background-color: var(--oc-border-border0);
     transition: background-color 0.15s ease;
   }
 
   .resize-handle:hover::after,
   &.dragging .resize-handle::after {
-    background-color: var(--oc-colors-text-subtext2);
+    background-color: var(--oc-border-border1);
   }
 
   .dock-content {

--- a/packages/oc-docs/src/components/Playground/docks/InlineDock/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/docks/InlineDock/StyledWrapper.ts
@@ -7,7 +7,7 @@ export const StyledWrapper = styled.div`
   flex-direction: column;
   height: 100%;
   min-width: 0;
-  border-left: 1px solid var(--oc-border-border2);
+  border-left: 1px solid var(--oc-border-border0);
   background-color: var(--oc-background-base);
 
   &.dragging {
@@ -33,13 +33,8 @@ export const StyledWrapper = styled.div`
     width: 4px;
     height: 40px;
     border-radius: 999px;
-    background-color: var(--oc-colors-text-subtext0);
+    background-color: var(--oc-border-border1);
     transition: background-color 0.15s ease;
-  }
-
-  .resize-handle:hover::after,
-  &.dragging .resize-handle::after {
-    background-color: var(--oc-colors-text-subtext2);
   }
 
   .dock-body {

--- a/packages/oc-docs/src/components/Topbar/Brand/Brand.spec.tsx
+++ b/packages/oc-docs/src/components/Topbar/Brand/Brand.spec.tsx
@@ -4,16 +4,16 @@ import { describe, it, expect } from 'vitest';
 import Brand from './Brand';
 
 describe('Brand', () => {
-  it('shows the collection name and the version verbatim', () => {
+  it('shows the collection name and the version with a "Version : " prefix', () => {
     const html = renderToStaticMarkup(<Brand collectionName="Hotel Booking API" version="1.0.0" />);
     expect(html).toContain('Hotel Booking API');
-    expect(html).toContain('>1.0.0<');
+    expect(html).toContain('>Version : 1.0.0<');
     expect(html).not.toContain('v1.0.0');
   });
 
-  it('shows a user-authored "v" prefix exactly as given', () => {
+  it('keeps a user-authored "v" prefix on the version value verbatim', () => {
     const html = renderToStaticMarkup(<Brand collectionName="X" version="v2.3" />);
-    expect(html).toContain('>v2.3<');
+    expect(html).toContain('>Version : v2.3<');
     expect(html).not.toContain('vv2.3');
   });
 

--- a/packages/oc-docs/src/components/Topbar/Brand/Brand.tsx
+++ b/packages/oc-docs/src/components/Topbar/Brand/Brand.tsx
@@ -54,7 +54,7 @@ const Brand: React.FC<BrandProps> = ({
           </span>
           {version && (
             <span className="topbar-brand-version" data-testid={`${testId}-version`}>
-              {version}
+              {`Version : ${version}`}
             </span>
           )}
         </span>

--- a/packages/oc-docs/src/components/Topbar/Topbar.spec.tsx
+++ b/packages/oc-docs/src/components/Topbar/Topbar.spec.tsx
@@ -18,7 +18,7 @@ describe('Topbar', () => {
   it('renders the brand name and version', () => {
     const html = renderToStaticMarkup(<Topbar collectionName="Hotel Booking API" version="1.0.0" />);
     expect(html).toContain('Hotel Booking API');
-    expect(html).toContain('>1.0.0<');
+    expect(html).toContain('>Version : 1.0.0<');
     expect(html).not.toContain('v1.0.0');
   });
 

--- a/packages/oc-docs/src/styles/index.css
+++ b/packages/oc-docs/src/styles/index.css
@@ -558,6 +558,8 @@ tr.themed-row:nth-child(even) {
    SCROLLBARS
    ================================================================ */
 
+/* Clean thin scrollbar for playground scroll areas: transparent track (no
+   background column) and no border (no divider line beside the thumb). */
 .oc-playground ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -565,10 +567,12 @@ tr.themed-row:nth-child(even) {
 
 .oc-playground ::-webkit-scrollbar-track {
   background: transparent;
+  border: none;
 }
 
 .oc-playground ::-webkit-scrollbar-thumb {
   background-color: var(--oc-scrollbar-color);
+  border: none;
   border-radius: 20px;
 }
 

--- a/packages/oc-docs/src/styles/theme.generated.css
+++ b/packages/oc-docs/src/styles/theme.generated.css
@@ -27,11 +27,12 @@
   --oc-primary-subtle: hsl(33, 69%, 56%);
   --oc-accents-primary: hsl(33, 80%, 46%);
   --oc-background-base: #ffffff;
-  --oc-background-mantle: #fafafa;
+  --oc-background-mantle: #f8f8f8;
   --oc-background-crust: #f6f6f6;
   --oc-background-surface2: #e5e5e5;
   --oc-background-surface1: #eaeaea;
   --oc-background-surface0: #f1f1f1;
+  --oc-background-surface-bright: #fafafa;
   --oc-status-info-background: rgba(52,106,178,0.15);
   --oc-status-info-text: hsl(214, 55%, 45%);
   --oc-status-info-border: hsl(214, 55%, 45%);
@@ -351,6 +352,7 @@
   --oc-background-surface0: #26292b;
   --oc-background-surface1: #444444;
   --oc-background-surface2: #666666;
+  --oc-background-surface-bright: #26292b;
   --oc-status-info-background: rgba(139,194,249,0.15);
   --oc-status-info-text: hsl(210, 90%, 76%);
   --oc-status-info-border: hsl(210, 90%, 76%);

--- a/packages/oc-docs/src/theme/tokens/dark.ts
+++ b/packages/oc-docs/src/theme/tokens/dark.ts
@@ -134,7 +134,9 @@ export const dark: Theme = {
     crust: '#333333',
     surface0: p.background.SURFACE0,
     surface1: colors.GRAY_3,
-    surface2: colors.GRAY_4
+    surface2: colors.GRAY_4,
+    // Raised surface; keeps the dark switcher track identical to surface0.
+    surfaceBright: p.background.SURFACE0
   },
 
   status: {

--- a/packages/oc-docs/src/theme/tokens/light.ts
+++ b/packages/oc-docs/src/theme/tokens/light.ts
@@ -127,7 +127,9 @@ export const light: Theme = {
     crust: p.background.CRUST,
     surface2: p.background.SURFACE2,
     surface1: p.background.SURFACE1,
-    surface0: p.background.SURFACE0
+    surface0: p.background.SURFACE0,
+    // Near-white raised surface (Figma: playground view-switcher track fill).
+    surfaceBright: '#fafafa'
   },
 
   status: {


### PR DESCRIPTION
Sidebar/header (JS badge, version prefix, idle-fade scrollbar, highlight right-gap, child-under-parent alignment) and playground (switcher colors, header control colors, dock separators) visual fixes to match Figma/Bruno.