### PR TITLE
chore(oc-docs): rename standalone bundle output to api-docs

### DIFF
--- a/examples/standalone-html/index.html
+++ b/examples/standalone-html/index.html
@@ -14,8 +14,8 @@
 			height: 100vh;
 		}
 	</style>
-	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/index.css">
-	<script src="../../packages/oc-docs/dist-standalone/index.js"></script>
+	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/api-docs.css">
+	<script src="../../packages/oc-docs/dist-standalone/api-docs.js"></script>
 </head>
 
 

--- a/examples/standalone-html/index2.html
+++ b/examples/standalone-html/index2.html
@@ -14,8 +14,8 @@
 			height: 100vh;
 		}
 	</style>
-	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/index.css">
-	<script src="../../packages/oc-docs/dist-standalone/index.js"></script>
+	<link rel="stylesheet" href="../../packages/oc-docs/dist-standalone/api-docs.css">
+	<script src="../../packages/oc-docs/dist-standalone/api-docs.js"></script>
 </head>
 
 

--- a/packages/oc-docs/vite.config.standalone.ts
+++ b/packages/oc-docs/vite.config.standalone.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/standalone.ts'),
       name: 'OpenCollectionPlayground',
-      fileName: (format) => format === 'umd' ? 'index.js' : 'index.esm.js',
+      fileName: (format) => format === 'umd' ? 'api-docs.js' : 'api-docs.esm.js',
       formats: ['umd', 'es']
     },
     cssCodeSplit: false,
@@ -36,7 +36,7 @@ export default defineConfig({
         // Ensure CSS is extracted properly
         assetFileNames: (assetInfo) => {
           if (assetInfo.name && assetInfo.name.endsWith('.css')) {
-            return 'index.css';
+            return 'api-docs.css';
           }
           return assetInfo.name || 'asset';
         }


### PR DESCRIPTION
Rename standalone build output from index.js/index.css to api-docs.js/api-docs.css so the CDN can serve it under the api-docs path.