### PR TITLE
fix(oc-docs): UI improvements in playground, sidebar and main header 

### DIFF
--- a/packages/oc-docs/src/components/AppShell/AppShell.tsx
+++ b/packages/oc-docs/src/components/AppShell/AppShell.tsx
@@ -56,6 +56,9 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
   const { pathname } = useLocation();
 
   const { open: playgroundOpen, dock: playgroundDock, openPlayground } = usePlaygroundUrlState();
+  // Bumped on every Try click so the bottom sheet re-expands from collapsed even
+  // when the requested slug is unchanged (a slug change alone wouldn't signal it).
+  const [playgroundOpenNonce, setPlaygroundOpenNonce] = useState(0);
 
   useEffect(() => {
     setDrawerOpen(false);
@@ -80,6 +83,7 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
 
   const handleOpenPlayground = useCallback(() => {
     openPlayground(resolution?.entry.slug);
+    setPlaygroundOpenNonce((nonce) => nonce + 1);
   }, [openPlayground, resolution]);
 
   return (
@@ -143,7 +147,7 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
         </div>
       </div>
 
-      {playgroundOpen && <Playground />}
+      {playgroundOpen && <Playground openNonce={playgroundOpenNonce} />}
 
       {!isDesktop && (
         <SidebarDrawer open={drawerOpen} onClose={closeDrawer}>

--- a/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.tsx
@@ -97,6 +97,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate, testId = 'sidebar' }) => 
             uuidToSlug={uuidToSlug}
             onNavigate={goTo}
             onToggleFolder={(uuid) => dispatch(toggleItem(uuid))}
+            onExpandFolder={(uuid) => dispatch(expandFolders([uuid]))}
             activeExample={activeExample}
             onExampleClick={goToExample}
           />

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/StyledWrapper.ts
@@ -75,12 +75,16 @@ export const StyledWrapper = styled.div`
   }
 
   .navlink-method {
-    width: 34px;
+    width: 40px;
     flex-shrink: 0;
-    margin-right: -4px;
+    /* inline-block so the badge's own text baseline (not a flex box's synthesised
+       one) sits on the name's baseline via align-self below, reading as level with
+       the request name. Paired with align-self on .navlink-label. */
+    display: inline-block;
+    align-self: baseline;
     font-family: var(--font-mono);
     font-size: 10.5px;
-    line-height: 1.2;
+    line-height: 1;
     font-weight: 700;
     letter-spacing: 0.04em;
     text-transform: uppercase;
@@ -125,6 +129,9 @@ export const StyledWrapper = styled.div`
   .navlink-label {
     flex: 1;
     min-width: 0;
+    /* Share a baseline with the method badge (both opt in, so icon/folder rows
+       stay vertically centred). */
+    align-self: baseline;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/StyledWrapper.ts
@@ -75,7 +75,7 @@ export const StyledWrapper = styled.div`
   }
 
   .navlink-method {
-    width: 40px;
+    width: 2.5rem;
     flex-shrink: 0;
     /* inline-block so the badge's own text baseline (not a flex box's synthesised
        one) sits on the name's baseline via align-self below, reading as level with

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.spec.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.spec.tsx
@@ -25,6 +25,7 @@ const render = (props: Partial<React.ComponentProps<typeof SidebarTree>> = {}) =
       uuidToSlug={uuidToSlug}
       onNavigate={noop}
       onToggleFolder={noop}
+      onExpandFolder={noop}
       {...props}
     />
   );
@@ -63,6 +64,7 @@ describe('SidebarTree', () => {
         uuidToSlug={new Map()}
         onNavigate={noop}
         onToggleFolder={noop}
+        onExpandFolder={noop}
       />
     );
     expect(html).toContain('WS');
@@ -80,6 +82,7 @@ describe('SidebarTree', () => {
         uuidToSlug={new Map([['s1', 'setup']])}
         onNavigate={noop}
         onToggleFolder={noop}
+        onExpandFolder={noop}
       />
     );
     expect(html).toContain('setup.js');
@@ -96,6 +99,7 @@ describe('SidebarTree collectionRoot', () => {
     uuidToSlug: new Map([['u1', 'get-users']]),
     onNavigate: noop,
     onToggleFolder: noop,
+    onExpandFolder: noop,
     activeExample: null
   };
 
@@ -162,6 +166,7 @@ const baseProps = {
   uuidToSlug: new Map<string, string>([['req-1', 'login']]),
   onNavigate: () => {},
   onToggleFolder: () => {},
+  onExpandFolder: () => {},
   activeExample: null
 };
 

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.tsx
@@ -33,6 +33,7 @@ interface SidebarTreeProps {
   uuidToSlug: Map<string, string>;
   onNavigate: (slug: string) => void;
   onToggleFolder: (uuid: string) => void;
+  onExpandFolder: (uuid: string) => void;
   collectionRoot?: CollectionRoot;
   activeExample: ExampleHighlight | null;
   onExampleClick?: (requestUuid: string, index: number) => void;
@@ -45,6 +46,7 @@ const SidebarTree: React.FC<SidebarTreeProps> = ({
   uuidToSlug,
   onNavigate,
   onToggleFolder,
+  onExpandFolder,
   collectionRoot,
   activeExample,
   onExampleClick
@@ -94,7 +96,15 @@ const SidebarTree: React.FC<SidebarTreeProps> = ({
                 }
                 testId="sidebar-item"
                 slug={slug}
-                onClick={() => slug !== undefined && onNavigate(slug)}
+                // Name click navigates and reveals the folder. Expand-only (not
+                // toggle) so re-clicking an already-open folder keeps it open;
+                // the chevron is the only control that collapses. Reveals even
+                // when the folder is already active (auto-reveal only fires on a
+                // slug change, so it can't re-open a manually collapsed folder).
+                onClick={() => {
+                  if (slug !== undefined) onNavigate(slug);
+                  if (uuid) onExpandFolder(uuid);
+                }}
               />
               {expanded && children.length > 0 && (
                 <StyledWrapper style={{ '--guide-left': `${itemLevel * 19 + 14}px` } as React.CSSProperties}>

--- a/packages/oc-docs/src/components/Playground/Playground.tsx
+++ b/packages/oc-docs/src/components/Playground/Playground.tsx
@@ -28,7 +28,12 @@ const playgroundLoadError = (
   </div>
 );
 
-const Playground: React.FC = () => {
+interface PlaygroundProps {
+  /** Bumped on each Try click, so the bottom sheet can re-expand from collapsed. */
+  openNonce?: number;
+}
+
+const Playground: React.FC<PlaygroundProps> = ({ openNonce }) => {
   const dispatch = useAppDispatch();
   const { open, dock, requestSlug, setDock, closePlayground } = usePlaygroundUrlState();
 
@@ -76,7 +81,7 @@ const Playground: React.FC = () => {
 
   if (dock === 'inline') return <InlineDock {...shared}>{body}</InlineDock>;
   if (dock === 'modal') return <ModalDock {...shared}>{body}</ModalDock>;
-  return <BottomSheetDock {...shared}>{body}</BottomSheetDock>;
+  return <BottomSheetDock {...shared} openNonce={openNonce}>{body}</BottomSheetDock>;
 };
 
 export default Playground;

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.tsx
@@ -136,6 +136,7 @@ const PlaygroundBody: React.FC<PlaygroundBodyProps> = ({
   };
 
   const handleToggleFolder = (uuid: string) => dispatch(toggleFolderCollapse(uuid));
+  const handleExpandFolder = (uuid: string) => dispatch(expandFolders([uuid]));
 
   // Highlighting an example is applied directly, not through the URL. Keep the
   // slug on the example's parent request (examples aren't deep-linked), and mark
@@ -214,6 +215,7 @@ const PlaygroundBody: React.FC<PlaygroundBodyProps> = ({
             uuidToSlug={uuidToSlug}
             onNavigate={handleNavigate}
             onToggleFolder={handleToggleFolder}
+            onExpandFolder={handleExpandFolder}
             onOpenEnvironments={openEnvironments}
             environmentsActive={viewMode === 'environments'}
             onOpenCollection={openCollection}

--- a/packages/oc-docs/src/components/Playground/PlaygroundHeader/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundHeader/StyledWrapper.ts
@@ -8,7 +8,7 @@ export const StyledWrapper = styled.div`
   gap: 8px;
   height: 52px;
   padding: 0 14px;
-  border-bottom: 1px solid var(--oc-border-border1);
+  border-bottom: 1px solid var(--oc-border-border0);
   background-color: var(--oc-background-base);
 
   .header-left,

--- a/packages/oc-docs/src/components/Playground/PlaygroundSidebar/PlaygroundSidebar.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundSidebar/PlaygroundSidebar.tsx
@@ -14,6 +14,7 @@ interface PlaygroundSidebarProps {
   uuidToSlug: Map<string, string>;
   onNavigate: (slug: string) => void;
   onToggleFolder: (uuid: string) => void;
+  onExpandFolder: (uuid: string) => void;
   onOpenEnvironments: () => void;
   environmentsActive: boolean;
   onOpenCollection: () => void;
@@ -29,6 +30,7 @@ const PlaygroundSidebar: React.FC<PlaygroundSidebarProps> = ({
   uuidToSlug,
   onNavigate,
   onToggleFolder,
+  onExpandFolder,
   onOpenEnvironments,
   environmentsActive,
   onOpenCollection,
@@ -70,6 +72,7 @@ const PlaygroundSidebar: React.FC<PlaygroundSidebarProps> = ({
             uuidToSlug={uuidToSlug}
             onNavigate={onNavigate}
             onToggleFolder={onToggleFolder}
+            onExpandFolder={onExpandFolder}
             activeExample={activeExample}
             onExampleClick={onExampleClick}
             collectionRoot={{

--- a/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/BottomSheetDock.tsx
+++ b/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/BottomSheetDock.tsx
@@ -27,9 +27,9 @@ const BottomSheetDock: React.FC<BottomSheetDockProps> = ({
   openNonce,
   children,
 }) => {
-  // Opens to 75% of the viewport by default (and re-expands to it from collapsed),
+  // Opens to 60% of the viewport by default (and re-expands to it from collapsed),
   // and can be dragged up to full screen or down to collapse.
-  const defaultHeight = Math.round(window.innerHeight * 0.75);
+  const defaultHeight = Math.round(window.innerHeight * 0.6);
   const { size, dragging, startDrag, setSize } = useDockResize({
     axis: 'y',
     initial: defaultHeight,

--- a/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/BottomSheetDock.tsx
+++ b/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/BottomSheetDock.tsx
@@ -8,10 +8,6 @@ const HEADER_HEIGHT = 52;
 // Treat a drag-down to (roughly) the header height as collapsed, so dragging the
 // sheet down to the header behaves like the collapse button.
 const COLLAPSE_EPSILON = 8;
-// The docs topbar height. The sheet opens up to the topbar's bottom line so the
-// topbar stays visible; the topbar's own border is hidden while it is open
-// (see AppShell) so the seam reads as a single line.
-const TOPBAR_OFFSET = 52;
 
 interface BottomSheetDockProps {
   dock: DockMode;
@@ -28,9 +24,9 @@ const BottomSheetDock: React.FC<BottomSheetDockProps> = ({
   onClose,
   children,
 }) => {
-  // Opens below the topbar by default (topbar stays visible), but can be dragged
-  // up to full screen or down to collapse.
-  const defaultHeight = window.innerHeight - TOPBAR_OFFSET;
+  // Opens to full screen height by default (covering the docs topbar), and can be
+  // dragged down to collapse.
+  const defaultHeight = window.innerHeight;
   const { size, dragging, startDrag, setSize } = useDockResize({
     axis: 'y',
     initial: defaultHeight,

--- a/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/BottomSheetDock.tsx
+++ b/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/BottomSheetDock.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PlaygroundHeader from '../../PlaygroundHeader/PlaygroundHeader';
 import { useDockResize } from '../../../../hooks/useDockResize';
 import type { DockMode } from '../../../../utils/playgroundDock';
@@ -14,6 +14,8 @@ interface BottomSheetDockProps {
   onDockChange: (dock: DockMode) => void;
   onToggleSidebar: () => void;
   onClose: () => void;
+  /** Bumped on each Try click; re-expands the sheet when it is collapsed. */
+  openNonce?: number;
   children: React.ReactNode;
 }
 
@@ -22,11 +24,12 @@ const BottomSheetDock: React.FC<BottomSheetDockProps> = ({
   onDockChange,
   onToggleSidebar,
   onClose,
+  openNonce,
   children,
 }) => {
-  // Opens to full screen height by default (covering the docs topbar), and can be
-  // dragged down to collapse.
-  const defaultHeight = window.innerHeight;
+  // Opens to 75% of the viewport by default (and re-expands to it from collapsed),
+  // and can be dragged up to full screen or down to collapse.
+  const defaultHeight = Math.round(window.innerHeight * 0.75);
   const { size, dragging, startDrag, setSize } = useDockResize({
     axis: 'y',
     initial: defaultHeight,
@@ -37,6 +40,18 @@ const BottomSheetDock: React.FC<BottomSheetDockProps> = ({
   // collapse button just snaps between the header height and the last size.
   const lastExpanded = useRef<number>(defaultHeight);
   const collapsed = size <= HEADER_HEIGHT + COLLAPSE_EPSILON;
+
+  // A Try click re-opens the playground; if the sheet is currently collapsed,
+  // expand it back to the default height. Read size/target through refs so this
+  // fires only on the Try signal, not when the user collapses it themselves.
+  const sizeRef = useRef(size);
+  sizeRef.current = size;
+  const defaultHeightRef = useRef(defaultHeight);
+  defaultHeightRef.current = defaultHeight;
+  useEffect(() => {
+    if (openNonce === undefined) return;
+    if (sizeRef.current <= HEADER_HEIGHT + COLLAPSE_EPSILON) setSize(defaultHeightRef.current);
+  }, [openNonce, setSize]);
 
   const toggleCollapse = () => {
     if (collapsed) {

--- a/packages/oc-docs/src/components/Playground/docks/ModalDock/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/docks/ModalDock/StyledWrapper.ts
@@ -25,7 +25,7 @@ export const StyledWrapper = styled.div`
     border-radius: var(--oc-radius);
     overflow: hidden;
     background-color: var(--oc-background-base);
-    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+    box-shadow: var(--shadow-md);
   }
 
   .modal-content {

--- a/packages/oc-docs/src/components/Playground/docks/ModalDock/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/docks/ModalDock/StyledWrapper.ts
@@ -11,7 +11,8 @@ export const StyledWrapper = styled.div`
   .modal-backdrop {
     position: absolute;
     inset: 0;
-    background-color: color-mix(in srgb, var(--oc-text) 45%, transparent);
+    background-color: rgba(0, 0, 0, var(--oc-modal-backdrop-opacity));
+    backdrop-filter: blur(2px);
   }
 
   .modal-window {
@@ -24,7 +25,7 @@ export const StyledWrapper = styled.div`
     border-radius: var(--oc-radius);
     overflow: hidden;
     background-color: var(--oc-background-base);
-    box-shadow: 0 24px 60px color-mix(in srgb, var(--oc-text) 22%, transparent);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
   }
 
   .modal-content {

--- a/packages/oc-docs/src/components/Topbar/Topbar.spec.tsx
+++ b/packages/oc-docs/src/components/Topbar/Topbar.spec.tsx
@@ -55,9 +55,17 @@ describe('Topbar', () => {
     expect(html).toContain('<span>Open in Bruno</span>');
   });
 
-  it('condenses Open-in-Bruno to the glyph (no label) below the desktop layout', () => {
+  it('keeps the full Open-in-Bruno CTA (with label) on the tablet layout', () => {
     const html = renderToStaticMarkup(
       <Topbar collectionName="Docs" layoutMode="tablet" openInBrunoHref="https://fetch.usebruno.com?url=x" />
+    );
+    expect(html).toContain('data-testid="open-in-bruno"');
+    expect(html).toContain('<span>Open in Bruno</span>'); // tablet has room for the label
+  });
+
+  it('condenses Open-in-Bruno to the glyph (no label) on the mobile layout', () => {
+    const html = renderToStaticMarkup(
+      <Topbar collectionName="Docs" layoutMode="mobile" openInBrunoHref="https://fetch.usebruno.com?url=x" />
     );
     expect(html).toContain('data-testid="open-in-bruno"');   // still shown on a Bruno-capable device
     expect(html).not.toContain('<span>Open in Bruno</span>'); // label hidden, glyph only

--- a/packages/oc-docs/src/components/Topbar/Topbar.tsx
+++ b/packages/oc-docs/src/components/Topbar/Topbar.tsx
@@ -136,10 +136,10 @@ const Topbar: React.FC<TopbarProps> = ({
 
         {/* Open-in-Bruno: shown on any device that can run the Bruno desktop app
             (capability check, hidden on large touch tablets like iPad Pro). It
-            condenses to the Bruno glyph below the desktop layout, e.g. when the
-            inline playground has shrunk the docs area on a desktop. */}
+            condenses to the Bruno glyph only on mobile; tablet and up show the
+            full icon + label since there is room for it. */}
         {canRunBrunoApp && hasCta && (
-          <OpenInBrunoButton href={openInBrunoHref} onClick={onOpenInBruno} iconOnly={!isDesktop} />
+          <OpenInBrunoButton href={openInBrunoHref} onClick={onOpenInBruno} iconOnly={isMobile} />
         )}
       </div>
 

--- a/packages/oc-docs/src/store/slices/playground.spec.ts
+++ b/packages/oc-docs/src/store/slices/playground.spec.ts
@@ -8,7 +8,7 @@ import reducer, {
   setSelectedExampleIndex,
   clearPlaygroundCollection,
   toggleFolderCollapse,
-  expandFolders,
+  expandFolders
 } from './playground';
 import { createOpenCollectionStore } from '../store';
 import type { OpenCollection as OpenCollectionCollection } from '@opencollection/types';

--- a/packages/oc-docs/src/store/slices/playground.spec.ts
+++ b/packages/oc-docs/src/store/slices/playground.spec.ts
@@ -6,9 +6,12 @@ import reducer, {
   selectHydratedCollection,
   setViewMode,
   setSelectedExampleIndex,
-  clearPlaygroundCollection
+  clearPlaygroundCollection,
+  toggleFolderCollapse,
+  expandFolders,
 } from './playground';
 import { createOpenCollectionStore } from '../store';
+import type { OpenCollection as OpenCollectionCollection } from '@opencollection/types';
 
 const makeCollection = () =>
   ({
@@ -63,5 +66,32 @@ describe('playground example view', () => {
     expect(set.selectedExampleIndex).toBe(3);
     const cleared = reducer(set, clearPlaygroundCollection());
     expect(cleared.selectedExampleIndex).toBeNull();
+  });
+});
+
+describe('playground folder collapse', () => {
+  const withFolder = () =>
+    ({
+      info: { name: 'Test', version: '1.0.0' },
+      items: [{ type: 'folder', uuid: 'f1', name: 'Folder', isCollapsed: false, items: [] }]
+    }) as unknown as OpenCollectionCollection;
+  const folder = (store: ReturnType<typeof createOpenCollectionStore>) =>
+    selectHydratedCollection(store.getState())!.items![0] as { isCollapsed?: boolean };
+
+  it('expandFolders reveals a collapsed folder', () => {
+    const store = createOpenCollectionStore();
+    store.dispatch(setPlaygroundCollection(withFolder()));
+    store.dispatch(toggleFolderCollapse('f1'));
+    expect(folder(store).isCollapsed).toBe(true);
+
+    store.dispatch(expandFolders(['f1']));
+    expect(folder(store).isCollapsed).toBe(false);
+  });
+
+  it('expandFolders keeps an already-open folder open (never collapses)', () => {
+    const store = createOpenCollectionStore();
+    store.dispatch(setPlaygroundCollection(withFolder()));
+    store.dispatch(expandFolders(['f1']));
+    expect(folder(store).isCollapsed).toBe(false);
   });
 });


### PR DESCRIPTION
Minor oc-docs UI fixes plus two playground behaviour changes.
JIRA : BRU-3753

## UI fixes
- **Modal (playground modal dock), dark mode:** backdrop was derived from the text colour, so it looked whitish in dark. Now a dark dim with a subtle blur, and the window shadow uses the themed `--shadow-md` token instead of a text-derived one (no more white glow).
- **Sidebar method badges:** the HTTP method column is widened so `PATCH` keeps a gap before the request name, and the badge is baseline-aligned with the name (docs and playground sidebars, both themes).
- **Open in Bruno button:** shows the full icon + label on tablet (was glyph-only below desktop); it condenses to the glyph only on mobile.
- **Playground header:** bottom border uses `--oc-border-border0`.

## Behaviour changes
- **Bottom playground sheet default height:** opens at 60% of the viewport by default (previously it stopped at the docs header). It can still be dragged to full height or collapsed.
- **Re-expand on Try:** clicking "Try" while the bottom sheet is collapsed re-expands it to 60% (works even for the request already loaded).
- **Folder reveal on name click:** clicking a folder's name now navigates and expands it. Expand-only, so it never collapses an open folder, and it reveals a folder even when it is already the active page (previously a manually collapsed active folder could only be re-opened via the chevron). The chevron still toggles. Applies to the docs and playground sidebars.
