### PR TITLE
refactor(oc-docs): use shared test-utils/dom helpers across specs

### DIFF
--- a/packages/oc-docs/src/components/AuthDetails/AuthDetails.spec.tsx
+++ b/packages/oc-docs/src/components/AuthDetails/AuthDetails.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { parse } from 'node-html-parser';
 import { describe, it, expect } from 'vitest';
+import { getByTestId } from '../../test-utils/dom';
 import { AuthDetails } from './AuthDetails';
 import { AUTH_MODE_LABELS } from '../../constants';
 import { SECRET_MASK } from '../../constants';
@@ -11,62 +12,57 @@ const renderAuth = (ui: React.ReactElement) => {
   const root = parse(html);
   // Strip emotion's inline <style> blocks so their CSS text never counts as content.
   root.querySelectorAll('style').forEach((style) => style.remove());
-  const getByTestId = (testId: string) => {
-    const element = root.querySelector(`[data-testid="${testId}"]`);
-    if (!element) throw new Error(`No element with data-testid="${testId}"`);
-    return element;
-  };
-  return { html, getByTestId };
+  return { html, root };
 };
 
 describe('AuthDetails', () => {
   it('renders basic auth: mode + username, masks the password', () => {
-    const { getByTestId, html } = renderAuth(
+    const { root, html } = renderAuth(
       <AuthDetails
         auth={{ type: 'basic', username: 'user@example.com', password: 's3cr3t' }}
         authModeLabels={AUTH_MODE_LABELS}
         testId="auth"
       />
     );
-    expect(getByTestId('auth-mode').text.trim()).toBe('Basic Auth');
-    expect(getByTestId('auth-username').text.trim()).toBe('user@example.com');
-    expect(getByTestId('auth-password').text.trim()).toBe(SECRET_MASK);
+    expect(getByTestId(root, 'auth-mode').text.trim()).toBe('Basic Auth');
+    expect(getByTestId(root, 'auth-username').text.trim()).toBe('user@example.com');
+    expect(getByTestId(root, 'auth-password').text.trim()).toBe(SECRET_MASK);
     expect(html).not.toContain('s3cr3t');
   });
 
   it('masks the bearer token and falls back to the raw type without a label', () => {
-    const { getByTestId, html } = renderAuth(<AuthDetails auth={{ type: 'bearer', token: 'abc123' }} testId="auth" />);
-    expect(getByTestId('auth-mode').text.trim()).toBe('bearer');
-    expect(getByTestId('auth-token').text.trim()).toBe(SECRET_MASK);
+    const { root, html } = renderAuth(<AuthDetails auth={{ type: 'bearer', token: 'abc123' }} testId="auth" />);
+    expect(getByTestId(root, 'auth-mode').text.trim()).toBe('bearer');
+    expect(getByTestId(root, 'auth-token').text.trim()).toBe(SECRET_MASK);
     expect(html).not.toContain('abc123');
   });
 
   it('renders apikey fields and humanizes the placement', () => {
-    const { getByTestId } = renderAuth(
+    const { root } = renderAuth(
       <AuthDetails
         auth={{ type: 'apikey', key: 'X-Api-Key', value: 'k', placement: 'header' }}
         authModeLabels={AUTH_MODE_LABELS}
         testId="auth"
       />
     );
-    expect(getByTestId('auth-mode').text.trim()).toBe('API Key');
-    expect(getByTestId('auth-key').text.trim()).toBe('X-Api-Key');
-    expect(getByTestId('auth-add-to').text.trim()).toBe('Header');
+    expect(getByTestId(root, 'auth-mode').text.trim()).toBe('API Key');
+    expect(getByTestId(root, 'auth-key').text.trim()).toBe('X-Api-Key');
+    expect(getByTestId(root, 'auth-add-to').text.trim()).toBe('Header');
   });
 
   it('humanizes a query-params placement', () => {
-    const { getByTestId } = renderAuth(
+    const { root } = renderAuth(
       <AuthDetails
         auth={{ type: 'apikey', key: 'api_key', value: 'k', placement: 'query' }}
         authModeLabels={AUTH_MODE_LABELS}
         testId="auth"
       />
     );
-    expect(getByTestId('auth-add-to').text.trim()).toBe('Query Params');
+    expect(getByTestId(root, 'auth-add-to').text.trim()).toBe('Query Params');
   });
 
   it('renders AWS Signature v4 fields and masks the secret + session token', () => {
-    const { getByTestId, html } = renderAuth(
+    const { root, html } = renderAuth(
       <AuthDetails
         auth={{
           type: 'awsv4',
@@ -81,18 +77,18 @@ describe('AuthDetails', () => {
         testId="auth"
       />
     );
-    expect(getByTestId('auth-mode').text.trim()).toBe('AWS Signature v4');
-    expect(getByTestId('auth-access-key-id').text.trim()).toBe('AKIAEXAMPLE');
-    expect(getByTestId('auth-service').text.trim()).toBe('execute-api');
-    expect(getByTestId('auth-region').text.trim()).toBe('us-east-1');
-    expect(getByTestId('auth-secret-access-key').text.trim()).toBe(SECRET_MASK);
-    expect(getByTestId('auth-session-token').text.trim()).toBe(SECRET_MASK);
+    expect(getByTestId(root, 'auth-mode').text.trim()).toBe('AWS Signature v4');
+    expect(getByTestId(root, 'auth-access-key-id').text.trim()).toBe('AKIAEXAMPLE');
+    expect(getByTestId(root, 'auth-service').text.trim()).toBe('execute-api');
+    expect(getByTestId(root, 'auth-region').text.trim()).toBe('us-east-1');
+    expect(getByTestId(root, 'auth-secret-access-key').text.trim()).toBe(SECRET_MASK);
+    expect(getByTestId(root, 'auth-session-token').text.trim()).toBe(SECRET_MASK);
     expect(html).not.toContain('secretKeyValue');
     expect(html).not.toContain('sessionTokenValue');
   });
 
   it('renders the full oauth1 field set and masks the private key', () => {
-    const { getByTestId, html } = renderAuth(
+    const { root, html } = renderAuth(
       <AuthDetails
         auth={{
           type: 'oauth1',
@@ -110,17 +106,17 @@ describe('AuthDetails', () => {
         testId="auth"
       />
     );
-    expect(getByTestId('auth-verifier').text.trim()).toBe('v-code');
-    expect(getByTestId('auth-nonce').text.trim()).toBe('n-123');
-    expect(getByTestId('auth-realm').text.trim()).toBe('my-realm');
-    expect(getByTestId('auth-include-body-hash').text.trim()).toBe('Yes');
-    expect(getByTestId('auth-placement').text.trim()).toBe('Body');
-    expect(getByTestId('auth-private-key').text.trim()).toBe(SECRET_MASK);
+    expect(getByTestId(root, 'auth-verifier').text.trim()).toBe('v-code');
+    expect(getByTestId(root, 'auth-nonce').text.trim()).toBe('n-123');
+    expect(getByTestId(root, 'auth-realm').text.trim()).toBe('my-realm');
+    expect(getByTestId(root, 'auth-include-body-hash').text.trim()).toBe('Yes');
+    expect(getByTestId(root, 'auth-placement').text.trim()).toBe('Body');
+    expect(getByTestId(root, 'auth-private-key').text.trim()).toBe(SECRET_MASK);
     expect(html).not.toContain('pem-secret');
   });
 
   it('renders oauth2 authorization-code details: refresh url, state, pkce, token config, settings', () => {
-    const { getByTestId } = renderAuth(
+    const { root } = renderAuth(
       <AuthDetails
         auth={{
           type: 'oauth2',
@@ -139,19 +135,19 @@ describe('AuthDetails', () => {
         testId="auth"
       />
     );
-    expect(getByTestId('auth-flow').text.trim()).toBe('Authorization Code');
-    expect(getByTestId('auth-refresh-token-url').text.trim()).toBe('https://refresh');
-    expect(getByTestId('auth-state').text.trim()).toBe('xyz');
-    expect(getByTestId('auth-pkce').text.trim()).toBe('S256');
-    expect(getByTestId('auth-add-credentials-to').text.trim()).toBe('Basic Auth Header');
-    expect(getByTestId('auth-token-source').text.trim()).toBe('ID Token');
-    expect(getByTestId('auth-token-placement').text.trim()).toBe('Header (Authorization)');
-    expect(getByTestId('auth-auto-fetch-token').text.trim()).toBe('Yes');
-    expect(getByTestId('auth-auto-refresh-token').text.trim()).toBe('No');
+    expect(getByTestId(root, 'auth-flow').text.trim()).toBe('Authorization Code');
+    expect(getByTestId(root, 'auth-refresh-token-url').text.trim()).toBe('https://refresh');
+    expect(getByTestId(root, 'auth-state').text.trim()).toBe('xyz');
+    expect(getByTestId(root, 'auth-pkce').text.trim()).toBe('S256');
+    expect(getByTestId(root, 'auth-add-credentials-to').text.trim()).toBe('Basic Auth Header');
+    expect(getByTestId(root, 'auth-token-source').text.trim()).toBe('ID Token');
+    expect(getByTestId(root, 'auth-token-placement').text.trim()).toBe('Header (Authorization)');
+    expect(getByTestId(root, 'auth-auto-fetch-token').text.trim()).toBe('Yes');
+    expect(getByTestId(root, 'auth-auto-refresh-token').text.trim()).toBe('No');
   });
 
   it('renders oauth2 additional parameters grouped by request phase', () => {
-    const { getByTestId } = renderAuth(
+    const { root } = renderAuth(
       <AuthDetails
         auth={
           {
@@ -168,13 +164,13 @@ describe('AuthDetails', () => {
         testId="auth"
       />
     );
-    const audience = getByTestId('auth-additional-param-authorizationRequest-0');
+    const audience = getByTestId(root, 'auth-additional-param-authorizationRequest-0');
     const audienceRow = audience.parentNode;
     expect(audience.text.trim()).toBe('https://api');
     expect(audienceRow.querySelector('.property-key')?.text.trim()).toBe('audience');
     expect(audienceRow.querySelector('.description')?.text.trim()).toBe('Authorization Request · Query Params');
 
-    const resource = getByTestId('auth-additional-param-accessTokenRequest-0');
+    const resource = getByTestId(root, 'auth-additional-param-accessTokenRequest-0');
     const resourceRow = resource.parentNode;
     expect(resource.text.trim()).toBe('r1');
     expect(resourceRow.querySelector('.property-key')?.text.trim()).toBe('resource');
@@ -182,7 +178,7 @@ describe('AuthDetails', () => {
   });
 
   it('renders Akamai EdgeGrid auth and masks the secret credentials', () => {
-    const { getByTestId, html } = renderAuth(
+    const { root, html } = renderAuth(
       <AuthDetails
         auth={
           {
@@ -201,20 +197,20 @@ describe('AuthDetails', () => {
         testId="auth"
       />
     );
-    expect(getByTestId('auth-mode').text.trim()).toBe('Akamai EdgeGrid');
-    expect(getByTestId('auth-base-url').text.trim()).toBe('https://akaa-base.luna.akamaiapis.net');
-    expect(getByTestId('auth-headers-to-sign').text.trim()).toBe('X-Custom');
-    expect(getByTestId('auth-max-body-size').text.trim()).toBe('2048');
-    expect(getByTestId('auth-access-token').text.trim()).toBe(SECRET_MASK);
-    expect(getByTestId('auth-client-token').text.trim()).toBe(SECRET_MASK);
-    expect(getByTestId('auth-client-secret').text.trim()).toBe(SECRET_MASK);
+    expect(getByTestId(root, 'auth-mode').text.trim()).toBe('Akamai EdgeGrid');
+    expect(getByTestId(root, 'auth-base-url').text.trim()).toBe('https://akaa-base.luna.akamaiapis.net');
+    expect(getByTestId(root, 'auth-headers-to-sign').text.trim()).toBe('X-Custom');
+    expect(getByTestId(root, 'auth-max-body-size').text.trim()).toBe('2048');
+    expect(getByTestId(root, 'auth-access-token').text.trim()).toBe(SECRET_MASK);
+    expect(getByTestId(root, 'auth-client-token').text.trim()).toBe(SECRET_MASK);
+    expect(getByTestId(root, 'auth-client-secret').text.trim()).toBe(SECRET_MASK);
     expect(html).not.toContain('atValue');
     expect(html).not.toContain('ctValue');
     expect(html).not.toContain('csValue');
   });
 
   it('shows the empty message when there is no auth', () => {
-    const { getByTestId } = renderAuth(<AuthDetails emptyMessage="No authentication configured" testId="auth" />);
-    expect(getByTestId('auth-empty').text.trim()).toBe('No authentication configured');
+    const { root } = renderAuth(<AuthDetails emptyMessage="No authentication configured" testId="auth" />);
+    expect(getByTestId(root, 'auth-empty').text.trim()).toBe('No authentication configured');
   });
 });

--- a/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.spec.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/Sidebar.spec.tsx
@@ -6,7 +6,7 @@ import Sidebar from './Sidebar';
 import { createOpenCollectionStore } from '../../../store/store';
 import { setDocsCollection } from '../../../store/slices/docs';
 import { useRenderToDom } from '../../../hooks/useRenderToDom';
-import { query } from '../../../test-utils/dom';
+import { getByTestId } from '../../../test-utils/dom';
 
 const collection = {
   info: { name: 'C' },
@@ -33,7 +33,7 @@ const buildSidebar = () => {
 describe('Sidebar examples', () => {
   it('renders the highlighted example as an active sidebar row', () => {
     const root = useRenderToDom(buildSidebar());
-    const row = query(root, '[data-testid="sidebar-example"]');
+    const row = getByTestId(root, 'sidebar-example');
     expect(row.text).toContain('OK');
     expect(row.getAttribute('class') ?? '').toContain('active');
   });

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.spec.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarTree/SidebarTree.spec.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { Item as OpenCollectionItem } from '@opencollection/types/collection/item';
 import SidebarTree from './SidebarTree';
 import { useRenderToDom } from '../../../../hooks/useRenderToDom';
+import { queryByTestId } from '../../../../test-utils/dom';
 
 const req = (uuid: string, name: string, method: string): OpenCollectionItem =>
   ({ type: 'http', uuid, name, method }) as unknown as OpenCollectionItem;
@@ -172,7 +173,7 @@ const tree = (props: Partial<React.ComponentProps<typeof SidebarTree>> = {}) => 
 describe('SidebarTree examples', () => {
   it('shows an example toggle for a request with examples but keeps rows collapsed by default', () => {
     const root = useRenderToDom(tree());
-    expect(root.querySelector('[data-testid="sidebar-example-toggle"]')).not.toBeNull();
+    expect(queryByTestId(root, 'sidebar-example-toggle')).not.toBeNull();
     expect(root.querySelectorAll('[data-testid="sidebar-example"]')).toHaveLength(0);
   });
 
@@ -196,6 +197,6 @@ describe('SidebarTree examples', () => {
         activeExample={null}
       />
     );
-    expect(root.querySelector('[data-testid="sidebar-example-toggle"]')).toBeNull();
+    expect(queryByTestId(root, 'sidebar-example-toggle')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/components/ExecutionContext/ExecutionContext.spec.tsx
+++ b/packages/oc-docs/src/components/ExecutionContext/ExecutionContext.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { ExecutionContext } from './ExecutionContext';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
-import { query } from '../../test-utils/dom';
+import { query, getByTestId, queryByTestId } from '../../test-utils/dom';
 import type { ScriptChainStep } from '../../utils/request';
 import type { AssertionRow } from '../../utils/assertions';
 import type { TestRow, RawTestScript } from '../../utils/fileUtils';
@@ -40,26 +40,26 @@ const full = (props: Partial<React.ComponentProps<typeof ExecutionContext>> = {}
   />
 );
 
-const tabSelector = (id: string) => `[data-testid="execution-context-tabs-tab-${id}"]`;
-const panelSelector = (id: string) => `[data-testid="execution-context-${id}"]`;
-const flowSelector = '[data-testid="execution-context-flow"]';
+const tabId = (id: string) => `execution-context-tabs-tab-${id}`;
+const panelId = (id: string) => `execution-context-${id}`;
+const flowTestId = 'execution-context-flow';
 
 describe('ExecutionContext', () => {
   describe('tabs variant (default)', () => {
     it('renders a tab per non-empty section, each with its item count', () => {
       const root = useRenderToDom(full());
-      expect(query(query(root, tabSelector('variables')), '.tab-count').text).toBe('2');
-      expect(query(query(root, tabSelector('scripts')), '.tab-count').text).toBe('3');
-      expect(query(query(root, tabSelector('asserts')), '.tab-count').text).toBe('2');
-      expect(query(query(root, tabSelector('tests')), '.tab-count').text).toBe('2');
+      expect(query(getByTestId(root, tabId('variables')), '.tab-count').text).toBe('2');
+      expect(query(getByTestId(root, tabId('scripts')), '.tab-count').text).toBe('3');
+      expect(query(getByTestId(root, tabId('asserts')), '.tab-count').text).toBe('2');
+      expect(query(getByTestId(root, tabId('tests')), '.tab-count').text).toBe('2');
     });
 
     it('mounts only the active tab panel (Variables first)', () => {
       const root = useRenderToDom(full());
-      expect(query(root, panelSelector('variables')).text).toContain('sessionId');
-      expect(root.querySelector(panelSelector('scripts'))).toBeNull();
-      expect(root.querySelector(panelSelector('asserts'))).toBeNull();
-      expect(root.querySelector(panelSelector('tests'))).toBeNull();
+      expect(getByTestId(root, panelId('variables')).text).toContain('sessionId');
+      expect(queryByTestId(root, panelId('scripts'))).toBeNull();
+      expect(queryByTestId(root, panelId('asserts'))).toBeNull();
+      expect(queryByTestId(root, panelId('tests'))).toBeNull();
     });
 
     it('hides tabs that have no items', () => {
@@ -72,52 +72,52 @@ describe('ExecutionContext', () => {
           tests={[]}
         />
       );
-      expect(root.querySelector(tabSelector('variables'))).not.toBeNull();
-      expect(root.querySelector(tabSelector('scripts'))).not.toBeNull();
-      expect(root.querySelector(tabSelector('asserts'))).toBeNull();
-      expect(root.querySelector(tabSelector('tests'))).toBeNull();
+      expect(queryByTestId(root, tabId('variables'))).not.toBeNull();
+      expect(queryByTestId(root, tabId('scripts'))).not.toBeNull();
+      expect(queryByTestId(root, tabId('asserts'))).toBeNull();
+      expect(queryByTestId(root, tabId('tests'))).toBeNull();
     });
 
     it('shows the execution-flow indicator only while the Scripts tab is active', () => {
-      expect(useRenderToDom(full()).querySelector(flowSelector)).toBeNull();
+      expect(queryByTestId(useRenderToDom(full()), flowTestId)).toBeNull();
 
       const scriptsOnly = useRenderToDom(
         <ExecutionContext scriptChain={scriptChain} preVars={[]} postVars={[]} assertions={[]} tests={[]} />
       );
-      expect(query(scriptsOnly, flowSelector).text).toBe('Sandwich execution flow');
+      expect(getByTestId(scriptsOnly, flowTestId).text).toBe('Sandwich execution flow');
 
       const sequential = useRenderToDom(
         <ExecutionContext scriptChain={scriptChain} preVars={[]} postVars={[]} assertions={[]} tests={[]} flow="sequential" />
       );
-      expect(query(sequential, flowSelector).text).toBe('Sequential execution flow');
+      expect(getByTestId(sequential, flowTestId).text).toBe('Sequential execution flow');
     });
 
     it('shows "View complete code" in the header only while the Tests tab is active', () => {
       const testsOnly = useRenderToDom(
         <ExecutionContext scriptChain={[]} preVars={[]} postVars={[]} assertions={[]} tests={tests} testScripts={testScripts} />
       );
-      expect(testsOnly.querySelector('[data-testid="execution-context-view-complete-code"]')).not.toBeNull();
-      expect(useRenderToDom(full()).querySelector('[data-testid="execution-context-view-complete-code"]')).toBeNull();
+      expect(queryByTestId(testsOnly, 'execution-context-view-complete-code')).not.toBeNull();
+      expect(queryByTestId(useRenderToDom(full()), 'execution-context-view-complete-code')).toBeNull();
     });
 
     it('exposes an accessible tablist with the first tab selected', () => {
       const root = useRenderToDom(full());
       expect(root.querySelector('[role="tablist"]')).not.toBeNull();
-      expect(query(root, tabSelector('variables')).getAttribute('role')).toBe('tab');
-      expect(query(root, tabSelector('variables')).getAttribute('aria-selected')).toBe('true');
+      expect(getByTestId(root, tabId('variables')).getAttribute('role')).toBe('tab');
+      expect(getByTestId(root, tabId('variables')).getAttribute('aria-selected')).toBe('true');
     });
   });
 
   describe('docs variant', () => {
     it('stacks every section at once (scripts, variables, asserts, tests)', () => {
       const root = useRenderToDom(full({ variant: 'docs' }));
-      expect(query(root, panelSelector('scripts')).text).toContain('Collection Pre-Request');
-      expect(query(root, panelSelector('scripts')).text).toContain('HTTP');
-      expect(query(root, panelSelector('variables')).text).toContain('sessionId');
-      expect(query(root, panelSelector('asserts')).text).toContain('is defined');
-      expect(query(root, panelSelector('tests')).text).toContain('returns a token');
-      expect(query(root, flowSelector).text).toBe('Sandwich execution flow');
-      expect(root.querySelector('[data-testid="execution-context-view-complete-code"]')).not.toBeNull();
+      expect(getByTestId(root, panelId('scripts')).text).toContain('Collection Pre-Request');
+      expect(getByTestId(root, panelId('scripts')).text).toContain('HTTP');
+      expect(getByTestId(root, panelId('variables')).text).toContain('sessionId');
+      expect(getByTestId(root, panelId('asserts')).text).toContain('is defined');
+      expect(getByTestId(root, panelId('tests')).text).toContain('returns a token');
+      expect(getByTestId(root, flowTestId).text).toBe('Sandwich execution flow');
+      expect(queryByTestId(root, 'execution-context-view-complete-code')).not.toBeNull();
     });
   });
 
@@ -125,6 +125,6 @@ describe('ExecutionContext', () => {
     const root = useRenderToDom(
       <ExecutionContext scriptChain={[]} preVars={[]} postVars={[]} assertions={[]} tests={[]} />
     );
-    expect(root.querySelector('[data-testid="execution-context"]')).toBeNull();
+    expect(queryByTestId(root, 'execution-context')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
+++ b/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { FolderConfiguration } from './FolderConfiguration';
 import type { FolderConfig } from '../../utils/folder';
+import { queryByTestId } from '../../test-utils/dom';
 
 const baseConfig: FolderConfig = {
   headers: [],
@@ -24,13 +25,13 @@ describe('FolderConfiguration', () => {
     };
     const root = useRenderToDom(<FolderConfiguration config={config} />);
 
-    expect(root.querySelector('[data-testid="folder-config-headers"]')).toBeTruthy();
-    expect(root.querySelector('[data-testid="folder-config-script"]')).toBeTruthy();
+    expect(queryByTestId(root, 'folder-config-headers')).toBeTruthy();
+    expect(queryByTestId(root, 'folder-config-script')).toBeTruthy();
     expect(root.querySelector('[data-testid="folder-config-headers"] .property-key')?.text.trim()).toBe('Accept');
 
-    expect(root.querySelector('[data-testid="folder-config-auth"]')).toBeNull();
-    expect(root.querySelector('[data-testid="folder-config-vars"]')).toBeNull();
-    expect(root.querySelector('[data-testid="folder-config-tests"]')).toBeNull();
+    expect(queryByTestId(root, 'folder-config-auth')).toBeNull();
+    expect(queryByTestId(root, 'folder-config-vars')).toBeNull();
+    expect(queryByTestId(root, 'folder-config-tests')).toBeNull();
   });
 
   it('labels the Auth group with an "Inherited from collection" badge when auth is inherited', () => {
@@ -41,7 +42,7 @@ describe('FolderConfiguration', () => {
     };
     const root = useRenderToDom(<FolderConfiguration config={config} authModeLabels={{ bearer: 'Bearer Token' }} />);
 
-    const authGroup = root.querySelector('[data-testid="folder-config-auth"]');
+    const authGroup = queryByTestId(root, 'folder-config-auth');
     expect(authGroup).toBeTruthy();
     expect(authGroup?.querySelector('.config-group-head')?.text).toContain('Inherited from collection');
   });
@@ -59,7 +60,7 @@ describe('FolderConfiguration', () => {
       .querySelectorAll('[data-testid="folder-config-script"] .config-phase-label')
       .map((el) => el.text.trim());
     expect(phases).toEqual(['Pre-Request', 'Post-Response']);
-    expect(root.querySelector('[data-testid="folder-config-tests"]')).toBeTruthy();
+    expect(queryByTestId(root, 'folder-config-tests')).toBeTruthy();
   });
 
   it('renders disabled headers (dimmed) and their descriptions', () => {
@@ -69,7 +70,7 @@ describe('FolderConfiguration', () => {
     };
     const root = useRenderToDom(<FolderConfiguration config={config} />);
 
-    const headers = root.querySelector('[data-testid="folder-config-headers"]');
+    const headers = queryByTestId(root, 'folder-config-headers');
     expect(headers).toBeTruthy();
     expect(headers?.querySelector('.property-key')?.text.trim()).toBe('X-Debug');
     expect(headers?.querySelector('.property-row--disabled')).toBeTruthy();
@@ -84,7 +85,7 @@ describe('FolderConfiguration', () => {
     };
     const root = useRenderToDom(<FolderConfiguration config={config} />);
 
-    const vars = root.querySelector('[data-testid="folder-config-vars"]');
+    const vars = queryByTestId(root, 'folder-config-vars');
     expect(vars).toBeTruthy();
     const phases = vars?.querySelectorAll('.config-phase-label').map((el) => el.text.trim());
     expect(phases).toEqual(['Pre-Request', 'Post-Response']);
@@ -100,7 +101,7 @@ describe('FolderConfiguration', () => {
     };
     const root = useRenderToDom(<FolderConfiguration config={config} />);
 
-    const vars = root.querySelector('[data-testid="folder-config-vars"]');
+    const vars = queryByTestId(root, 'folder-config-vars');
     expect(vars).toBeTruthy();
     const phases = vars?.querySelectorAll('.config-phase-label').map((el) => el.text.trim());
     expect(phases).toEqual(['Post-Response']);

--- a/packages/oc-docs/src/components/InfoTip/InfoTip.spec.tsx
+++ b/packages/oc-docs/src/components/InfoTip/InfoTip.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { parse } from 'node-html-parser';
 import { describe, it, expect } from 'vitest';
-import { query } from '../../test-utils/dom';
+import { getByTestId, queryByTestId } from '../../test-utils/dom';
 import { InfoTip } from './InfoTip';
 
 const render = (ui: React.ReactElement) => {
@@ -14,7 +14,7 @@ const render = (ui: React.ReactElement) => {
 describe('InfoTip', () => {
   it('renders an accessible trigger button labelled with its content', () => {
     const root = render(<InfoTip content="You can write any valid JS expression here" />);
-    const trigger = query(root, '[data-testid="infotip"]');
+    const trigger = getByTestId(root, 'infotip');
     expect(trigger).toBeTruthy();
     expect(trigger.getAttribute('type')).toBe('button');
     expect(trigger.getAttribute('aria-label')).toBe('You can write any valid JS expression here');
@@ -23,7 +23,7 @@ describe('InfoTip', () => {
 
   it('honours a custom test id', () => {
     const root = render(<InfoTip content="Help" testId="expr-help" />);
-    expect(root.querySelector('[data-testid="expr-help"]')).toBeTruthy();
-    expect(root.querySelector('[data-testid="infotip"]')).toBeNull();
+    expect(queryByTestId(root, 'expr-help')).toBeTruthy();
+    expect(queryByTestId(root, 'infotip')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.spec.tsx
@@ -2,19 +2,13 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { parse } from 'node-html-parser';
 import { describe, it, expect } from 'vitest';
-import { query } from '../../../../../../test-utils/dom';
+import { query, getByTestId, queryByTestId } from '../../../../../../test-utils/dom';
 import { AuthTab } from './AuthTab';
 
 const render = (ui: React.ReactElement) => {
   const root = parse(renderToStaticMarkup(ui));
   root.querySelectorAll('style').forEach((style) => style.remove());
-  const byTestId = (testId: string) => root.querySelector(`[data-testid="${testId}"]`);
-  const getByTestId = (testId: string) => {
-    const el = byTestId(testId);
-    if (!el) throw new Error(`No element with data-testid="${testId}"`);
-    return el;
-  };
-  return { root, byTestId, getByTestId };
+  return { root };
 };
 
 const noop = () => {};
@@ -24,8 +18,8 @@ const renderAuth = (auth: unknown, extra: Record<string, unknown> = {}) =>
 
 describe('AuthTab', () => {
   it('offers exactly the six supported auth types and none of the unsupported ones', () => {
-    const { getByTestId } = renderAuth(undefined);
-    const options = getByTestId('auth-mode-select')
+    const { root } = renderAuth(undefined);
+    const options = getByTestId(root, 'auth-mode-select')
       .querySelectorAll('option')
       .map((o) => o.text.trim());
     expect(options).toEqual(['No Auth', 'Basic Auth', 'Bearer Token', 'API Key', 'Digest Auth', 'AWS Signature v4']);
@@ -35,22 +29,20 @@ describe('AuthTab', () => {
   });
 
   it('adds the Inherit option only when showInherit is set', () => {
-    const withInherit = renderAuth(undefined, { showInherit: true })
-      .getByTestId('auth-mode-select')
+    const withInherit = getByTestId(renderAuth(undefined, { showInherit: true }).root, 'auth-mode-select')
       .querySelectorAll('option')
       .map((o) => o.text.trim());
     expect(withInherit).toContain('Inherit');
-    const without = renderAuth(undefined)
-      .getByTestId('auth-mode-select')
+    const without = getByTestId(renderAuth(undefined).root, 'auth-mode-select')
       .querySelectorAll('option')
       .map((o) => o.text.trim());
     expect(without).not.toContain('Inherit');
   });
 
   it('renders no form for None', () => {
-    const { root, byTestId } = renderAuth(undefined);
+    const { root } = renderAuth(undefined);
     expect(root.querySelector('.auth-form')).toBeNull();
-    expect(byTestId('auth-username')).toBeNull();
+    expect(queryByTestId(root, 'auth-username')).toBeNull();
     expect(query(root, '.auth-empty').text.trim()).toBe('No authentication configured.');
   });
 
@@ -60,49 +52,49 @@ describe('AuthTab', () => {
   });
 
   it('renders basic auth with a plain username and a masked, revealable password', () => {
-    const { getByTestId } = renderAuth({ type: 'basic', username: 'admin', password: 's3cr3t' });
-    expect(getByTestId('auth-username').getAttribute('type')).toBe('text');
-    expect(getByTestId('auth-username').getAttribute('value')).toBe('admin');
-    expect(getByTestId('auth-password').getAttribute('type')).toBe('password');
-    expect(getByTestId('auth-password-toggle').getAttribute('aria-label')).toBe('Show value');
+    const { root } = renderAuth({ type: 'basic', username: 'admin', password: 's3cr3t' });
+    expect(getByTestId(root, 'auth-username').getAttribute('type')).toBe('text');
+    expect(getByTestId(root, 'auth-username').getAttribute('value')).toBe('admin');
+    expect(getByTestId(root, 'auth-password').getAttribute('type')).toBe('password');
+    expect(getByTestId(root, 'auth-password-toggle').getAttribute('aria-label')).toBe('Show value');
   });
 
   it('masks the bearer token and exposes a reveal toggle', () => {
-    const { getByTestId } = renderAuth({ type: 'bearer', token: 'abc' });
-    expect(getByTestId('auth-token').getAttribute('type')).toBe('password');
-    expect(getByTestId('auth-token-toggle')).toBeTruthy();
+    const { root } = renderAuth({ type: 'bearer', token: 'abc' });
+    expect(getByTestId(root, 'auth-token').getAttribute('type')).toBe('password');
+    expect(getByTestId(root, 'auth-token-toggle')).toBeTruthy();
   });
 
   it('renders apikey with an unmasked value and a header/query placement select', () => {
-    const { getByTestId } = renderAuth({ type: 'apikey', key: 'X-Api-Key', value: 'k', placement: 'query' });
-    expect(getByTestId('auth-key').getAttribute('type')).toBe('text');
-    expect(getByTestId('auth-value').getAttribute('type')).toBe('text');
-    const placement = getByTestId('auth-placement');
+    const { root } = renderAuth({ type: 'apikey', key: 'X-Api-Key', value: 'k', placement: 'query' });
+    expect(getByTestId(root, 'auth-key').getAttribute('type')).toBe('text');
+    expect(getByTestId(root, 'auth-value').getAttribute('type')).toBe('text');
+    const placement = getByTestId(root, 'auth-placement');
     expect(placement.querySelectorAll('option').map((o) => o.text.trim())).toEqual(['Header', 'Query Params']);
     expect(query(placement, 'option[selected]').text.trim()).toBe('Query Params');
   });
 
   it('defaults the apikey placement to Header when none is stored', () => {
-    const { getByTestId } = renderAuth({ type: 'apikey', key: '', value: '' });
-    expect(query(getByTestId('auth-placement'), 'option[selected]').text.trim()).toBe('Header');
+    const { root } = renderAuth({ type: 'apikey', key: '', value: '' });
+    expect(query(getByTestId(root, 'auth-placement'), 'option[selected]').text.trim()).toBe('Header');
   });
 
   it('renders digest auth with a masked, revealable password', () => {
-    const { getByTestId } = renderAuth({ type: 'digest', username: 'u', password: 'p' });
-    expect(getByTestId('auth-username').getAttribute('type')).toBe('text');
-    expect(getByTestId('auth-password').getAttribute('type')).toBe('password');
-    expect(getByTestId('auth-password-toggle')).toBeTruthy();
+    const { root } = renderAuth({ type: 'digest', username: 'u', password: 'p' });
+    expect(getByTestId(root, 'auth-username').getAttribute('type')).toBe('text');
+    expect(getByTestId(root, 'auth-password').getAttribute('type')).toBe('password');
+    expect(getByTestId(root, 'auth-password-toggle')).toBeTruthy();
   });
 
   it('renders all six AWS Signature v4 fields, masking only the secret access key', () => {
-    const { getByTestId, byTestId } = renderAuth({ type: 'awsv4' });
+    const { root } = renderAuth({ type: 'awsv4' });
     const labels = ['accessKeyId', 'secretAccessKey', 'sessionToken', 'service', 'region', 'profileName'];
-    labels.forEach((field) => expect(byTestId(`auth-${field}`)).toBeTruthy());
-    expect(getByTestId('auth-secretAccessKey').getAttribute('type')).toBe('password');
-    expect(getByTestId('auth-secretAccessKey-toggle')).toBeTruthy();
+    labels.forEach((field) => expect(queryByTestId(root, `auth-${field}`)).toBeTruthy());
+    expect(getByTestId(root, 'auth-secretAccessKey').getAttribute('type')).toBe('password');
+    expect(getByTestId(root, 'auth-secretAccessKey-toggle')).toBeTruthy();
     ['accessKeyId', 'sessionToken', 'service', 'region', 'profileName'].forEach((field) => {
-      expect(getByTestId(`auth-${field}`).getAttribute('type')).toBe('text');
-      expect(byTestId(`auth-${field}-toggle`)).toBeNull();
+      expect(getByTestId(root, `auth-${field}`).getAttribute('type')).toBe('text');
+      expect(queryByTestId(root, `auth-${field}-toggle`)).toBeNull();
     });
   });
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/BulkEdit/BulkEdit.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/BulkEdit/BulkEdit.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { useRenderToDom } from '../../../../../../hooks/useRenderToDom';
-import { query } from '../../../../../../test-utils/dom';
+import { getByTestId } from '../../../../../../test-utils/dom';
 
 vi.mock('../../../../../../ui/CodeEditor/CodeEditor', () => ({
   default: ({ value }: { value: string }) => <pre data-testid="code-editor">{value}</pre>
@@ -20,7 +20,7 @@ describe('BulkEdit', () => {
         onChange={() => {}}
       />
     );
-    const editor = query(root, '[data-testid="code-editor"]');
+    const editor = getByTestId(root, 'code-editor');
     expect(editor.text).toContain('Content-Type:application/json');
     expect(editor.text).toContain('Accept:text/plain');
   });
@@ -35,7 +35,7 @@ describe('BulkEdit', () => {
         onChange={() => {}}
       />
     );
-    const editor = query(root, '[data-testid="code-editor"]');
+    const editor = getByTestId(root, 'code-editor');
     expect(editor.text).toContain('X-Enabled:yes');
     expect(editor.text).toContain('//X-Disabled:no');
   });

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/HeadersTab/HeadersTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/HeadersTab/HeadersTab.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { useRenderToDom } from '../../../../../../hooks/useRenderToDom';
-import { query } from '../../../../../../test-utils/dom';
+import { query, getByTestId, queryByTestId } from '../../../../../../test-utils/dom';
 import { HeadersTab } from './HeadersTab';
 
 const noop = () => {};
@@ -30,12 +30,12 @@ describe('HeadersTab', () => {
     );
     expect(query(root, '.title').text.trim()).toBe('Headers');
     expect(query(root, '.description').text.trim()).toBe('Request headers sent with the call');
-    expect(root.querySelector('[data-testid="bulk-edit-toggle"]')).toBeTruthy();
+    expect(queryByTestId(root, 'bulk-edit-toggle')).toBeTruthy();
   });
 
   it('exposes the Bulk edit toggle button', () => {
     const root = useRenderToDom(<HeadersTab headers={[]} onHeadersChange={noop} />);
-    expect(query(root, '[data-testid="bulk-edit-toggle"]').text.trim()).toBe('Bulk edit');
+    expect(getByTestId(root, 'bulk-edit-toggle').text.trim()).toBe('Bulk edit');
   });
 
   it('flags a header name with spaces and a value with newlines', () => {

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/OverviewTab/OverviewTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/OverviewTab/OverviewTab.spec.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { useRenderToDom } from '../../../../../../hooks/useRenderToDom';
-import { query } from '../../../../../../test-utils/dom';
+import { getByTestId, queryByTestId } from '../../../../../../test-utils/dom';
 import OverviewTab from './OverviewTab';
 
 describe('OverviewTab', () => {
   it('renders markdown docs as HTML inside the markdown-documentation container', () => {
     const root = useRenderToDom(<OverviewTab docs="# Hi" />);
-    const container = query(root, '[data-testid="overview-markdown-documentation"]');
+    const container = getByTestId(root, 'overview-markdown-documentation');
 
     expect(container.getAttribute('class')).toContain('markdown-documentation');
     expect(container.text).toContain('Hi');
@@ -17,8 +17,8 @@ describe('OverviewTab', () => {
 
   it('shows the empty state when no docs are provided', () => {
     const root = useRenderToDom(<OverviewTab />);
-    expect(root.querySelector('[data-testid="overview-markdown-documentation"]')).toBeNull();
-    expect(root.querySelector('[data-testid="overview-empty"]')).toBeTruthy();
-    expect(query(root, '[data-testid="overview-empty-heading"]').text).toContain('No overview content yet');
+    expect(queryByTestId(root, 'overview-markdown-documentation')).toBeNull();
+    expect(queryByTestId(root, 'overview-empty')).toBeTruthy();
+    expect(getByTestId(root, 'overview-empty-heading').text).toContain('No overview content yet');
   });
 });

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ScriptsTab/ScriptsTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ScriptsTab/ScriptsTab.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { useRenderToDom } from '../../../../../../hooks/useRenderToDom';
-import { query } from '../../../../../../test-utils/dom';
+import { query, getByTestId } from '../../../../../../test-utils/dom';
 
 vi.mock('../../../../../../ui/CodeEditor/CodeEditor', () => ({
   default: ({ value }: { value: string }) => <pre data-testid="code-editor">{value}</pre>
@@ -14,8 +14,8 @@ const noop = () => {};
 describe('ScriptsTab', () => {
   it('renders the pre/post sub-tab labels', () => {
     const root = useRenderToDom(<ScriptsTab scripts={{}} onScriptChange={noop} />);
-    expect(query(root, '[data-testid="scripts-tabs-tab-pre-request"]').text.trim()).toBe('Pre request');
-    expect(query(root, '[data-testid="scripts-tabs-tab-post-response"]').text.trim()).toBe('Post response');
+    expect(getByTestId(root, 'scripts-tabs-tab-pre-request').text.trim()).toBe('Pre request');
+    expect(getByTestId(root, 'scripts-tabs-tab-post-response').text.trim()).toBe('Post response');
   });
 
   it('renders the default title and the Tests section', () => {

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/TestsTab/TestsTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/TestsTab/TestsTab.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { useRenderToDom } from '../../../../../../hooks/useRenderToDom';
-import { query } from '../../../../../../test-utils/dom';
+import { query, getByTestId } from '../../../../../../test-utils/dom';
 
 vi.mock('../../../../../../ui/CodeEditor/CodeEditor', () => ({
   default: ({ value }: { value: string }) => <pre data-testid="code-editor">{value}</pre>
@@ -29,6 +29,6 @@ describe('TestsTab', () => {
     const root = useRenderToDom(
       <TestsTab scripts={{ tests: 'expect(res.status).toBe(200);' }} onScriptChange={noop} />
     );
-    expect(query(root, '[data-testid="code-editor"]').text).toContain('expect(res.status).toBe(200);');
+    expect(getByTestId(root, 'code-editor').text).toContain('expect(res.status).toBe(200);');
   });
 });

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/VariablesTab/VariablesTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/VariablesTab/VariablesTab.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { useRenderToDom } from '../../../../../../hooks/useRenderToDom';
-import { query } from '../../../../../../test-utils/dom';
+import { query, queryByTestId } from '../../../../../../test-utils/dom';
 import { VariablesTab } from './VariablesTab';
 
 const noop = () => {};
@@ -78,7 +78,7 @@ describe('VariablesTab', () => {
     );
     expect(sectionTitles(root)).toContain('Post Response');
     expect(inputValues(root)).toContain('res.body.token');
-    expect(root.querySelector('[data-testid="post-response-expr-help"]')).toBeTruthy();
+    expect(queryByTestId(root, 'post-response-expr-help')).toBeTruthy();
   });
 
   it('renders a typed variable value and reflects its type in the type dropdown', () => {

--- a/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { ExampleView } from './ExampleView';
 import { useRenderToDom } from '../../../../../hooks/useRenderToDom';
-import { query } from '../../../../../test-utils/dom';
+import { query, queryByTestId } from '../../../../../test-utils/dom';
 
 const request = { type: 'http', method: 'POST', url: '{{baseUrl}}/api/v1/auth/login' } as any;
 const example = {
@@ -23,8 +23,8 @@ describe('ExampleView', () => {
   it('renders name, request and response panes read-only', () => {
     const root = useRenderToDom(<ExampleView request={request} example={example} />);
     expect(query(root, '.example-view-name').text).toContain('Successful Login');
-    expect(root.querySelector('[data-testid="example-view-request"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="example-view-response"]')).not.toBeNull();
+    expect(queryByTestId(root, 'example-view-request')).not.toBeNull();
+    expect(queryByTestId(root, 'example-view-response')).not.toBeNull();
     expect(root.text).toContain('200');
     // method/url fall back to the request's flat schema when the example omits them
     expect(query(root, '.example-view-url').text).toContain('{{baseUrl}}/api/v1/auth/login');

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.spec.tsx
@@ -12,6 +12,7 @@ import {
   setViewMode
 } from '../../../store/slices/playground';
 import { getItemUuid } from '../../../utils/itemUtils';
+import { queryByTestId } from '../../../test-utils/dom';
 
 const collection = {
   info: { name: 'C' },
@@ -49,6 +50,6 @@ describe('PlaygroundBody example view', () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(root.querySelector('[data-testid="example-view"]')).not.toBeNull();
+    expect(queryByTestId(root, 'example-view')).not.toBeNull();
   });
 });

--- a/packages/oc-docs/src/components/PropertyTable/PropertyTable.spec.tsx
+++ b/packages/oc-docs/src/components/PropertyTable/PropertyTable.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
-import { query } from '../../test-utils/dom';
+import { query, getByTestId } from '../../test-utils/dom';
 import { PropertyTable } from './PropertyTable';
 
 describe('PropertyTable', () => {
@@ -21,7 +21,7 @@ describe('PropertyTable', () => {
 
   it('shows the empty message when there are no rows', () => {
     const root = useRenderToDom(<PropertyTable rows={[]} emptyMessage="Nothing here yet" />);
-    expect(query(root, '[data-testid="property-table-empty"]').text).toBe('Nothing here yet');
+    expect(getByTestId(root, 'property-table-empty').text).toBe('Nothing here yet');
   });
 
   it('renders custom node cells', () => {

--- a/packages/oc-docs/src/components/Request/RequestBody/RequestBody.spec.tsx
+++ b/packages/oc-docs/src/components/Request/RequestBody/RequestBody.spec.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { RequestBody } from './RequestBody';
 import { useRenderToDom } from '../../../hooks/useRenderToDom';
+import { queryByTestId } from '../../../test-utils/dom';
 
 describe('RequestBody', () => {
   it('renders a JSON body as a labelled code block', () => {
     const root = useRenderToDom(<RequestBody body={{ type: 'json', data: '{"email":"a@b.com"}' }} />);
     expect(root.querySelector('.content-type-badge')?.text.trim()).toBe('application/json');
-    const code = root.querySelector('[data-testid="code"]');
+    const code = queryByTestId(root, 'code');
     expect(code).not.toBeNull();
     expect(code?.text).toContain('a@b.com');
   });

--- a/packages/oc-docs/src/components/VariableInfoCard/VariableInfoCard.spec.tsx
+++ b/packages/oc-docs/src/components/VariableInfoCard/VariableInfoCard.spec.tsx
@@ -6,7 +6,7 @@ import { setDocsCollection } from '../../store/slices/docs';
 import { setActiveEnv } from '../../store/slices/env';
 import { VariableResolverProvider } from '../../hooks';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
-import { query } from '../../test-utils/dom';
+import { getByTestId, queryByTestId } from '../../test-utils/dom';
 import { VariableInfoCard } from './VariableInfoCard';
 
 const collection: any = {
@@ -44,10 +44,10 @@ const cardTree = (name: string) => {
   );
 };
 
-const selector = (suffix: string) => `[data-testid="variable-info-card-${suffix}"]`;
+const testId = (suffix: string) => `variable-info-card-${suffix}`;
 
 const part = (root: ReturnType<typeof useRenderToDom>, suffix: string) =>
-  query(root, selector(suffix));
+  getByTestId(root, testId(suffix));
 
 describe('VariableInfoCard', () => {
   it('shows name + scope badge + resolved value for an environment variable', () => {
@@ -66,15 +66,15 @@ describe('VariableInfoCard', () => {
     const root = useRenderToDom(cardTree('bearer_token'));
     expect(part(root, 'value').text).toBe('(Secret)');
     expect(root.toString()).not.toContain('super-secret');
-    expect(root.querySelector(selector('reveal'))).toBeNull();
-    expect(root.querySelector(selector('copy'))).toBeNull();
+    expect(queryByTestId(root, testId('reveal'))).toBeNull();
+    expect(queryByTestId(root, testId('copy'))).toBeNull();
   });
 
   it('shows an (empty) placeholder with no copy control when the value is blank', () => {
     const root = useRenderToDom(cardTree('emptyValue'));
     expect(part(root, 'scope').text).toBe('Environment');
     expect(part(root, 'value').text).toBe('(empty)');
-    expect(root.querySelector(selector('copy'))).toBeNull();
+    expect(queryByTestId(root, testId('copy'))).toBeNull();
   });
 
   it('pretty-prints an object-typed value', () => {
@@ -85,8 +85,8 @@ describe('VariableInfoCard', () => {
 
   it('warns on an invalid variable name and shows no value', () => {
     const root = useRenderToDom(cardTree('bad name'));
-    expect(root.querySelector(selector('warning'))).not.toBeNull();
-    expect(root.querySelector(selector('value'))).toBeNull();
+    expect(queryByTestId(root, testId('warning'))).not.toBeNull();
+    expect(queryByTestId(root, testId('value'))).toBeNull();
   });
 
   it('marks process.env as read-only', () => {
@@ -99,7 +99,7 @@ describe('VariableInfoCard', () => {
     const root = useRenderToDom(cardTree('$randomInt'));
     expect(part(root, 'scope').text).toBe('Dynamic');
     expect(part(root, 'note').text).toContain('random value');
-    expect(root.querySelector(selector('value'))).toBeNull();
+    expect(queryByTestId(root, testId('value'))).toBeNull();
   });
 
   it('notes a time-based dynamic variable with the timestamp wording', () => {
@@ -112,7 +112,7 @@ describe('VariableInfoCard', () => {
     const root = useRenderToDom(cardTree('$notAFunc'));
     expect(part(root, 'scope').text).toBe('Dynamic');
     expect(part(root, 'warning').text).toContain('Unknown dynamic variable');
-    expect(root.querySelector(selector('note'))).toBeNull();
+    expect(queryByTestId(root, testId('note'))).toBeNull();
   });
 
   it('reports an undefined variable with a note', () => {

--- a/packages/oc-docs/src/components/ViewMore/ViewMore.spec.tsx
+++ b/packages/oc-docs/src/components/ViewMore/ViewMore.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
-import { query } from '../../test-utils/dom';
+import { query, queryByTestId } from '../../test-utils/dom';
 import { ViewMore } from './ViewMore';
 
 describe('ViewMore', () => {
@@ -12,6 +12,6 @@ describe('ViewMore', () => {
       </ViewMore>
     );
     expect(query(root, '.view-more-content').text).toContain('Body content');
-    expect(root.querySelector('[data-testid="vm-toggle"]')).toBeNull();
+    expect(queryByTestId(root, 'vm-toggle')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/pages/Environments/Environments.spec.tsx
+++ b/packages/oc-docs/src/pages/Environments/Environments.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import type { OpenCollection } from '@opencollection/types';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
-import { query } from '../../test-utils/dom';
+import { getByTestId, queryByTestId } from '../../test-utils/dom';
 import { Environments } from './Environments';
 
 const groupLabels = (root: ReturnType<typeof useRenderToDom>) =>
@@ -32,7 +32,7 @@ describe('Environments', () => {
 
     const root = useRenderToDom(<Environments collection={collection} />);
 
-    expect(root.querySelector('[data-testid="environments-title"]')?.text.trim()).toBe('Environments');
+    expect(queryByTestId(root, 'environments-title')?.text.trim()).toBe('Environments');
     expect(root.querySelector('[role="tablist"]')).toBeTruthy();
     expect(root.querySelectorAll('[role="tab"]').map((t) => t.text.trim())).toEqual(['Development', 'Prod']);
     expect(root.querySelector('[role="tabpanel"]')).toBeTruthy();
@@ -41,7 +41,7 @@ describe('Environments', () => {
     expect(cellText(root, '.environment-name')).toContain('baseUrl');
     expect(cellText(root, '.environment-value')).toContain('https://api.dev');
     expect(cellText(root, '.environment-name')).toContain('authToken');
-    expect(root.querySelector('[data-testid="environment-secret-value"]')).toBeTruthy();
+    expect(queryByTestId(root, 'environment-secret-value')).toBeTruthy();
   });
 
   it('shows a "(Secret)" placeholder for a secret — display-only, no reveal toggle', () => {
@@ -54,8 +54,8 @@ describe('Environments', () => {
 
     const root = useRenderToDom(<Environments collection={collection} />);
 
-    expect(query(root, '[data-testid="environment-secret-value"]').text).toBe('(Secret)');
-    expect(root.querySelector('[data-testid="environment-secret-value-toggle"]')).toBeNull();
+    expect(getByTestId(root, 'environment-secret-value').text).toBe('(Secret)');
+    expect(queryByTestId(root, 'environment-secret-value-toggle')).toBeNull();
   });
 
   it('renders an external secret variables section with the manager label', () => {

--- a/packages/oc-docs/src/pages/Folder/Folder.spec.tsx
+++ b/packages/oc-docs/src/pages/Folder/Folder.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import type { OpenCollection } from '@opencollection/types';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { Folder } from './Folder';
+import { queryByTestId } from '../../test-utils/dom';
 
 const collection = {
   info: { name: 'Hotel Booking API' },
@@ -19,15 +20,15 @@ describe('Folder', () => {
 
     const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
-    expect(root.querySelector('[data-testid="folder-title"]')?.text.trim()).toBe('Authentication');
-    expect(root.querySelector('[data-testid="folder-request-count"]')?.text.trim()).toBe('3 requests');
+    expect(queryByTestId(root, 'folder-title')?.text.trim()).toBe('Authentication');
+    expect(queryByTestId(root, 'folder-request-count')?.text.trim()).toBe('3 requests');
     expect(root.querySelector('[data-testid="folder-section-configuration"] h2')?.text.trim()).toBe('Folder Configuration');
 
-    const authGroup = root.querySelector('[data-testid="folder-config-auth"]');
+    const authGroup = queryByTestId(root, 'folder-config-auth');
     expect(authGroup).toBeTruthy();
     expect(authGroup?.text).toContain('Inherited from collection');
-    expect(root.querySelector('[data-testid="folder-config-script"]')).toBeTruthy();
-    expect(root.querySelector('[data-testid="folder-config-empty"]')).toBeNull();
+    expect(queryByTestId(root, 'folder-config-script')).toBeTruthy();
+    expect(queryByTestId(root, 'folder-config-empty')).toBeNull();
   });
 
   it('renders the documentation markdown in its own section', () => {
@@ -40,7 +41,7 @@ describe('Folder', () => {
     const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
     expect(root.querySelector('[data-testid="folder-section-documentation"] h2')?.text.trim()).toBe('Documentation');
-    const docs = root.querySelector('[data-testid="folder-docs"]');
+    const docs = queryByTestId(root, 'folder-docs');
     expect(docs).toBeTruthy();
     expect(docs?.querySelector('h1')?.text.trim()).toBe('Auth docs');
     expect(docs?.querySelector('strong')?.text.trim()).toBe('markdown');
@@ -51,8 +52,8 @@ describe('Folder', () => {
 
     const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
-    expect(root.querySelector('[data-testid="folder-docs"]')).toBeNull();
-    expect(root.querySelector('[data-testid="folder-section-documentation"]')).toBeNull();
+    expect(queryByTestId(root, 'folder-docs')).toBeNull();
+    expect(queryByTestId(root, 'folder-section-documentation')).toBeNull();
   });
 
   it('renders the empty state when the folder has no configuration', () => {
@@ -60,12 +61,12 @@ describe('Folder', () => {
 
     const root = useRenderToDom(<Folder item={folder} collection={collection} />);
 
-    expect(root.querySelector('[data-testid="folder-title"]')?.text.trim()).toBe('Realtime');
-    expect(root.querySelector('[data-testid="folder-request-count"]')?.text.trim()).toBe('1 request');
+    expect(queryByTestId(root, 'folder-title')?.text.trim()).toBe('Realtime');
+    expect(queryByTestId(root, 'folder-request-count')?.text.trim()).toBe('1 request');
 
-    const empty = root.querySelector('[data-testid="folder-config-empty"]');
+    const empty = queryByTestId(root, 'folder-config-empty');
     expect(empty).toBeTruthy();
     expect(empty?.querySelector('.empty-state-heading')?.text.trim()).toBe('No folder configuration');
-    expect(root.querySelector('[data-testid="folder-config-headers"]')).toBeNull();
+    expect(queryByTestId(root, 'folder-config-headers')).toBeNull();
   });
 });

--- a/packages/oc-docs/src/pages/Request/Request.spec.tsx
+++ b/packages/oc-docs/src/pages/Request/Request.spec.tsx
@@ -6,6 +6,7 @@ import type { Item } from '@opencollection/types/collection/item';
 import { MemoryRouter } from 'react-router-dom';
 import { Request } from './Request';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
+import { queryByTestId } from '../../test-utils/dom';
 
 const collection: OpenCollection = {
   info: { name: 'Auth API', version: '1.0.0' },
@@ -57,11 +58,11 @@ describe('Request page', () => {
       </MemoryRouter>
     );
 
-    expect(root.querySelector('[data-testid="request-breadcrumb"]')?.text).toContain('Authentication');
-    expect(root.querySelector('[data-testid="request-title"]')?.text).toContain('Login');
-    expect(root.querySelector('[data-testid="request-url"]')?.text).toContain('auth/login');
-    expect(root.querySelector('[data-testid="request-try-button"]')?.text).toContain('Try');
-    expect(root.querySelector('[data-testid="request-description"]')?.text).toContain('Authenticate a user');
+    expect(queryByTestId(root, 'request-breadcrumb')?.text).toContain('Authentication');
+    expect(queryByTestId(root, 'request-title')?.text).toContain('Login');
+    expect(queryByTestId(root, 'request-url')?.text).toContain('auth/login');
+    expect(queryByTestId(root, 'request-try-button')?.text).toContain('Try');
+    expect(queryByTestId(root, 'request-description')?.text).toContain('Authenticate a user');
     // {{baseUrl}} in the url renders as an inspectable variable token
     expect(root.querySelector('[data-var-name="baseUrl"]')).not.toBeNull();
 
@@ -69,20 +70,20 @@ describe('Request page', () => {
       expect(root.querySelector(`[data-testid="request-section-${slug}"]`)).not.toBeNull();
     }
 
-    const params = root.querySelector('[data-testid="request-section-params"]');
+    const params = queryByTestId(root, 'request-section-params');
     expect(params?.text).toContain('tenant');
     expect(params?.text).toContain('verbose');
 
-    const snippet = root.querySelector('[data-testid="request-section-code-snippet"]');
+    const snippet = queryByTestId(root, 'request-section-code-snippet');
     expect(snippet?.text).toContain('curl');
     expect(snippet?.text).toContain('/auth/login');
 
-    const exec = root.querySelector('[data-testid="execution-context"]');
+    const exec = queryByTestId(root, 'execution-context');
     expect(exec?.text).toContain('attempt');
     expect(exec?.text).toContain('authToken');
-    expect(root.querySelector('[data-testid="execution-context-tabs-tab-scripts"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="execution-context-tabs-tab-asserts"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="execution-context-tabs-tab-tests"]')).not.toBeNull();
+    expect(queryByTestId(root, 'execution-context-tabs-tab-scripts')).not.toBeNull();
+    expect(queryByTestId(root, 'execution-context-tabs-tab-asserts')).not.toBeNull();
+    expect(queryByTestId(root, 'execution-context-tabs-tab-tests')).not.toBeNull();
   });
 
   it('shows empty states (not bare sections) when nothing is configured, and always shows the code snippet', () => {
@@ -96,18 +97,18 @@ describe('Request page', () => {
       </MemoryRouter>
     );
 
-    expect(root.querySelector('[data-testid="request-title"]')?.text).toContain('Ping');
-    expect(root.querySelector('[data-testid="request-url"]')?.text).toContain('/ping');
+    expect(queryByTestId(root, 'request-title')?.text).toContain('Ping');
+    expect(queryByTestId(root, 'request-url')?.text).toContain('/ping');
     // No params/body/headers/auth -> a single "No request configuration" empty state, not the individual sections.
-    expect(root.querySelector('[data-testid="request-config-empty"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="request-section-params"]')).toBeNull();
+    expect(queryByTestId(root, 'request-config-empty')).not.toBeNull();
+    expect(queryByTestId(root, 'request-section-params')).toBeNull();
     // The code snippet is always shown (on the right).
-    expect(root.querySelector('[data-testid="request-section-code-snippet"]')).not.toBeNull();
+    expect(queryByTestId(root, 'request-section-code-snippet')).not.toBeNull();
     // No examples authored -> the Examples section is hidden entirely (no empty state).
-    expect(root.querySelector('[data-testid="request-section-examples"]')).toBeNull();
+    expect(queryByTestId(root, 'request-section-examples')).toBeNull();
     // No scripts/vars/asserts/tests -> the Execution Context section shows its own empty state.
-    expect(root.querySelector('[data-testid="request-section-execution-context"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="execution-context-empty"]')).not.toBeNull();
+    expect(queryByTestId(root, 'request-section-execution-context')).not.toBeNull();
+    expect(queryByTestId(root, 'execution-context-empty')).not.toBeNull();
   });
 
   it('renders the Auth section for auth declared in the http block (http.auth: inherit)', () => {
@@ -122,10 +123,10 @@ describe('Request page', () => {
       </MemoryRouter>
     );
 
-    const auth = root.querySelector('[data-testid="request-section-auth"]');
+    const auth = queryByTestId(root, 'request-section-auth');
     expect(auth).not.toBeNull();
     expect(auth?.text).toContain('Inherit');
-    expect(root.querySelector('[data-testid="request-section-code-snippet"]')).not.toBeNull();
+    expect(queryByTestId(root, 'request-section-code-snippet')).not.toBeNull();
   });
 
   it('does not apply smart typography to docs prose', () => {
@@ -140,7 +141,7 @@ describe('Request page', () => {
       </MemoryRouter>
     );
 
-    const description = root.querySelector('[data-testid="request-description"]');
+    const description = queryByTestId(root, 'request-description');
     expect(description?.text).toContain('Use -- dashes');
     expect(description?.text).toContain('(c)');
     expect(description?.text).not.toContain('–'); // en-dash

--- a/packages/oc-docs/src/test-utils/dom.ts
+++ b/packages/oc-docs/src/test-utils/dom.ts
@@ -5,3 +5,11 @@ export const query = (root: HTMLElement, selector: string): HTMLElement => {
   if (!el) throw new Error(`No element matches selector: ${selector}`);
   return el;
 };
+
+// Returns the element with the given data-testid, throwing if absent.
+export const getByTestId = (root: HTMLElement, testId: string): HTMLElement =>
+  query(root, `[data-testid="${testId}"]`);
+
+// Returns the element with the given data-testid, or null if absent.
+export const queryByTestId = (root: HTMLElement, testId: string): HTMLElement | null =>
+  root.querySelector(`[data-testid="${testId}"]`);

--- a/packages/oc-docs/src/ui/Field/Input/Input.spec.tsx
+++ b/packages/oc-docs/src/ui/Field/Input/Input.spec.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { parse } from 'node-html-parser';
 import { describe, it, expect } from 'vitest';
 import { Input } from './Input';
-import { query } from '../../../test-utils/dom';
+import { query, getByTestId } from '../../../test-utils/dom';
 
 const noop = () => {};
 
@@ -32,8 +32,8 @@ describe('Input', () => {
   it('masks a secret value and exposes an accessible reveal toggle', () => {
     const root = render(<Input value="secret" onChange={noop} secret testId="my-secret" />);
     expect(query(root, '.oc-input-wrapper').classNames).toContain('oc-input-wrapper--secret');
-    expect(query(root, '[data-testid="my-secret"]').getAttribute('type')).toBe('password');
-    const toggle = query(root, '[data-testid="my-secret-toggle"]');
+    expect(getByTestId(root, 'my-secret').getAttribute('type')).toBe('password');
+    const toggle = getByTestId(root, 'my-secret-toggle');
     expect(toggle.getAttribute('aria-label')).toBe('Show value');
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
   });

--- a/packages/oc-docs/src/ui/Popover/Popover.spec.tsx
+++ b/packages/oc-docs/src/ui/Popover/Popover.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
 import { Popover } from './Popover';
+import { queryByTestId } from '../../test-utils/dom';
 
 describe('Popover', () => {
   it('renders the anchor and mounts no panel while closed (SSR-safe)', () => {
@@ -10,8 +11,8 @@ describe('Popover', () => {
         <button data-testid="anchor">anchor</button>
       </Popover>
     );
-    expect(root.querySelector('[data-testid="anchor"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="panel"]')).toBeNull();
+    expect(queryByTestId(root, 'anchor')).not.toBeNull();
+    expect(queryByTestId(root, 'panel')).toBeNull();
     expect(root.querySelector('[role="dialog"]')).toBeNull();
   });
 

--- a/packages/oc-docs/src/ui/Tabs/Tabs.spec.tsx
+++ b/packages/oc-docs/src/ui/Tabs/Tabs.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { Tabs, type Tab } from './Tabs';
 import { useRenderToDom } from '../../hooks/useRenderToDom';
-import { query } from '../../test-utils/dom';
+import { query, getByTestId, queryByTestId } from '../../test-utils/dom';
 
 const tabs: Tab[] = [
   { id: 'a', label: 'Alpha', count: 2, content: <p data-testid="alpha">alpha content</p> },
@@ -19,35 +19,35 @@ describe('Tabs', () => {
 
   it('shows the label and its count', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} testId="t" />);
-    const tab = query(root, '[data-testid="t-tab-a"]');
+    const tab = getByTestId(root, 't-tab-a');
     expect(tab.text).toContain('Alpha');
     expect(query(tab, '.tab-count').text).toBe('2');
   });
 
   it('activates the first tab by default and mounts only its panel', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} testId="t" />);
-    expect(query(root, '[data-testid="t-tab-a"]').getAttribute('aria-selected')).toBe('true');
-    expect(query(root, '[data-testid="t-tab-b"]').getAttribute('aria-selected')).toBe('false');
-    expect(root.querySelector('[data-testid="alpha"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="beta"]')).toBeNull();
+    expect(getByTestId(root, 't-tab-a').getAttribute('aria-selected')).toBe('true');
+    expect(getByTestId(root, 't-tab-b').getAttribute('aria-selected')).toBe('false');
+    expect(queryByTestId(root, 'alpha')).not.toBeNull();
+    expect(queryByTestId(root, 'beta')).toBeNull();
   });
 
   it('honours a controlled activeTab', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} activeTab="c" testId="t" />);
-    expect(query(root, '[data-testid="t-tab-c"]').getAttribute('aria-selected')).toBe('true');
-    expect(root.querySelector('[data-testid="gamma"]')).not.toBeNull();
-    expect(root.querySelector('[data-testid="alpha"]')).toBeNull();
+    expect(getByTestId(root, 't-tab-c').getAttribute('aria-selected')).toBe('true');
+    expect(queryByTestId(root, 'gamma')).not.toBeNull();
+    expect(queryByTestId(root, 'alpha')).toBeNull();
   });
 
   it('honours defaultActiveTab', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} defaultActiveTab="b" testId="t" />);
-    expect(root.querySelector('[data-testid="beta"]')).not.toBeNull();
+    expect(queryByTestId(root, 'beta')).not.toBeNull();
   });
 
   it('applies roving tabindex (only the active tab is tabbable)', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} testId="t" />);
-    expect(query(root, '[data-testid="t-tab-a"]').getAttribute('tabindex')).toBe('0');
-    expect(query(root, '[data-testid="t-tab-b"]').getAttribute('tabindex')).toBe('-1');
+    expect(getByTestId(root, 't-tab-a').getAttribute('tabindex')).toBe('0');
+    expect(getByTestId(root, 't-tab-b').getAttribute('tabindex')).toBe('-1');
   });
 
   it('renders the active tab’s rightElement, falling back to the shared one', () => {
@@ -64,7 +64,7 @@ describe('Tabs', () => {
 
   it('wires each tab to its panel via aria-controls / aria-labelledby', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} testId="t" />);
-    const tab = query(root, '[data-testid="t-tab-a"]');
+    const tab = getByTestId(root, 't-tab-a');
     const panel = query(root, '[role="tabpanel"]');
     expect(tab.getAttribute('aria-controls')).toBe(panel.getAttribute('id'));
     expect(panel.getAttribute('aria-labelledby')).toBe(tab.getAttribute('id'));
@@ -72,14 +72,14 @@ describe('Tabs', () => {
 
   it('defaults to the underline variant', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} testId="t" />);
-    const wrapper = query(root, '[data-testid="t"]');
+    const wrapper = getByTestId(root, 't');
     expect(wrapper.classList.contains('tabs-variant-underline')).toBe(true);
     expect(wrapper.classList.contains('tabs-variant-button')).toBe(false);
   });
 
   it('applies the button variant class when variant="button"', () => {
     const root = useRenderToDom(<Tabs tabs={tabs} variant="button" testId="t" />);
-    const wrapper = query(root, '[data-testid="t"]');
+    const wrapper = getByTestId(root, 't');
     expect(wrapper.classList.contains('tabs-variant-button')).toBe(true);
     expect(wrapper.classList.contains('tabs-variant-underline')).toBe(false);
   });


### PR DESCRIPTION
## Summary

Centralizes DOM test-query helpers so spec files use shared helpers from `src/test-utils/dom.ts` instead of duplicating them.

- **`test-utils/dom.ts`**: adds `getByTestId(root, testId)` (throws if absent) and `queryByTestId(root, testId)` (returns `null` if absent), alongside the existing `query`.
- **25 spec files refactored** to use the shared helpers:
  - Removed local `getByTestId`/`byTestId` closures (e.g. `AuthTab.spec`, `AuthDetails.spec`).
  - Converted per-spec `data-testid` selector builders to bare-testid builders (`VariableInfoCard.spec`, `ExecutionContext.spec`).
  - Swapped inline `querySelector('[data-testid="…"]')` / `query(root, '[data-testid="…"]')` for `getByTestId` (throwing) or `queryByTestId` (nullable) based on each test's intent.
- Left untouched (out of scope): class/tag/role selectors, compound selectors, template-literal selectors, `querySelectorAll`, and `.getAttribute('data-testid')` assertions.

## Testing
- `npm run test:run`: 777 tests pass. (3 suites fail to load on a missing `bundled-libraries.iife.js` build artifact — confirmed identical failures on the unmodified base, unrelated to this change.)
- `npm run lint`: no new errors/warnings in changed files.

Branched from `main`; no functional/runtime changes — test-only refactor.
