### PR TITLE
Added disabled badge for not enabled fields

### DIFF
--- a/packages/oc-docs/e2e/components/overview/collection-configuration.component.ts
+++ b/packages/oc-docs/e2e/components/overview/collection-configuration.component.ts
@@ -1,22 +1,25 @@
-import type { Locator } from '@playwright/test';
-import { BaseComponent } from '../base.component';
-import { SecretValueComponent } from '../secret-value.component';
+import type { Locator } from "@playwright/test";
+import { BaseComponent } from "../base.component";
+import { SecretValueComponent } from "../secret-value.component";
 
 export class ConfigurationSection extends BaseComponent {
-  readonly root = this.page.getByTestId('collection-config');
+  readonly root = this.page.getByTestId("collection-config");
 
-  readonly copyButton = this.root.getByTestId('collection-config-tests-copy');
+  readonly copyButton = this.root.getByTestId("collection-config-tests-copy");
 
-  readonly secret = new SecretValueComponent(this.page, 'collection-config-auth-secret');
+  readonly secret = new SecretValueComponent(
+    this.page,
+    "collection-config-auth-secret",
+  );
 
-  readonly disabledBadge = this.root.getByTestId('disabled-badge');
-
-  disabledRowValue(): Locator {
-    return this.disabledBadge.locator('..').getByTestId('property-value');
-  }
+  readonly disabledRows = this.root
+    .getByTestId("property-value-line")
+    .filter({ has: this.page.getByTestId("disabled-badge") });
 
   subHeading(name: string): Locator {
-    return this.root.getByTestId('collection-config-subheading').filter({ hasText: name });
+    return this.root
+      .getByTestId("collection-config-subheading")
+      .filter({ hasText: name });
   }
 
   async copyToClipboard(): Promise<void> {

--- a/packages/oc-docs/e2e/components/overview/collection-configuration.component.ts
+++ b/packages/oc-docs/e2e/components/overview/collection-configuration.component.ts
@@ -9,7 +9,7 @@ export class ConfigurationSection extends BaseComponent {
 
   readonly secret = new SecretValueComponent(this.page, 'collection-config-auth-secret');
 
-  readonly disabledBadge = this.root.getByTestId('disabled-badge').first();
+  readonly disabledBadge = this.root.getByTestId('disabled-badge');
 
   disabledRowValue(): Locator {
     return this.disabledBadge.locator('..').getByTestId('property-value');

--- a/packages/oc-docs/e2e/components/overview/collection-configuration.component.ts
+++ b/packages/oc-docs/e2e/components/overview/collection-configuration.component.ts
@@ -9,6 +9,12 @@ export class ConfigurationSection extends BaseComponent {
 
   readonly secret = new SecretValueComponent(this.page, 'collection-config-auth-secret');
 
+  readonly disabledBadge = this.root.getByTestId('disabled-badge').first();
+
+  disabledRowValue(): Locator {
+    return this.disabledBadge.locator('..').getByTestId('property-value');
+  }
+
   subHeading(name: string): Locator {
     return this.root.getByTestId('collection-config-subheading').filter({ hasText: name });
   }

--- a/packages/oc-docs/e2e/tests/overview/overview.spec.ts
+++ b/packages/oc-docs/e2e/tests/overview/overview.spec.ts
@@ -87,30 +87,37 @@ test.describe('Collection Overview', () => {
     });
   });
 
-  test('mobile: the Disabled chip stays pinned at the row end without overflowing', async ({ overviewPage, page }) => {
+  test('mobile: every Disabled chip stays pinned at the row end without overflowing', async ({ overviewPage, page }) => {
     await page.setViewportSize({ width: 360, height: 800 });
     const { configuration } = overviewPage;
 
-    await expect(configuration.disabledBadge).toBeVisible();
+    const rows = configuration.disabledRows;
+    const count = await rows.count();
+    expect(count).toBeGreaterThan(0);
 
-    const chip = await boundingBoxOf(configuration.disabledBadge);
-    const value = await boundingBoxOf(configuration.disabledRowValue());
     const card = await boundingBoxOf(configuration.root);
 
-    await test.step('the chip sits at the end — to the right of the value', () => {
-      expect(chip.x).toBeGreaterThanOrEqual(value.x + value.width);
-    });
+    for (let i = 0; i < count; i += 1) {
+      const row = rows.nth(i);
+      const value = row.getByTestId('property-value');
+      const chip = await boundingBoxOf(row.getByTestId('disabled-badge'));
+      const valueBox = await boundingBoxOf(value);
 
-    await test.step('the chip stays within the config card, never clipped or overflowing', () => {
-      expect(chip.x + chip.width).toBeLessThanOrEqual(card.x + card.width);
-    });
-
-    await test.step('the value keeps its truncation styling, so a long value ellipsizes rather than pushing the chip off', async () => {
-      const style = await configuration.disabledRowValue().evaluate((el) => {
-        const cs = getComputedStyle(el);
-        return { overflow: cs.overflow, textOverflow: cs.textOverflow, whiteSpace: cs.whiteSpace };
+      await test.step(`row ${i}: the chip sits at the end — to the right of the value`, () => {
+        expect(chip.x).toBeGreaterThanOrEqual(valueBox.x + valueBox.width);
       });
-      expect(style).toEqual({ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
-    });
+
+      await test.step(`row ${i}: the chip stays within the config card, never clipped or overflowing`, () => {
+        expect(chip.x + chip.width).toBeLessThanOrEqual(card.x + card.width);
+      });
+
+      await test.step(`row ${i}: the value keeps its truncation styling, so a long value ellipsizes rather than pushing the chip off`, async () => {
+        const style = await value.evaluate((el) => {
+          const cs = getComputedStyle(el);
+          return { overflow: cs.overflow, textOverflow: cs.textOverflow, whiteSpace: cs.whiteSpace };
+        });
+        expect(style).toEqual({ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
+      });
+    }
   });
 });

--- a/packages/oc-docs/e2e/tests/overview/overview.spec.ts
+++ b/packages/oc-docs/e2e/tests/overview/overview.spec.ts
@@ -1,4 +1,11 @@
 import { test, expect } from '../../playwright';
+import type { Locator } from '@playwright/test';
+
+const boundingBoxOf = async (locator: Locator) => {
+  const box = await locator.boundingBox();
+  if (box === null) throw new Error('expected the element to have a bounding box');
+  return box;
+};
 
 test.describe('Collection Overview', () => {
   test.beforeEach(async ({ overviewPage }) => {
@@ -77,6 +84,33 @@ test.describe('Collection Overview', () => {
         await configuration.copyToClipboard();
         await expect(configuration.copyButton).toHaveAttribute('aria-label', 'Copied');
       });
+    });
+  });
+
+  test('mobile: the Disabled chip stays pinned at the row end without overflowing', async ({ overviewPage, page }) => {
+    await page.setViewportSize({ width: 360, height: 800 });
+    const { configuration } = overviewPage;
+
+    await expect(configuration.disabledBadge).toBeVisible();
+
+    const chip = await boundingBoxOf(configuration.disabledBadge);
+    const value = await boundingBoxOf(configuration.disabledRowValue());
+    const card = await boundingBoxOf(configuration.root);
+
+    await test.step('the chip sits at the end — to the right of the value', () => {
+      expect(chip.x).toBeGreaterThanOrEqual(value.x + value.width);
+    });
+
+    await test.step('the chip stays within the config card, never clipped or overflowing', () => {
+      expect(chip.x + chip.width).toBeLessThanOrEqual(card.x + card.width);
+    });
+
+    await test.step('the value keeps its truncation styling, so a long value ellipsizes rather than pushing the chip off', async () => {
+      const style = await configuration.disabledRowValue().evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return { overflow: cs.overflow, textOverflow: cs.textOverflow, whiteSpace: cs.whiteSpace };
+      });
+      expect(style).toEqual({ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
     });
   });
 });

--- a/packages/oc-docs/src/components/DisabledBadge/DisabledBadge.spec.tsx
+++ b/packages/oc-docs/src/components/DisabledBadge/DisabledBadge.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { useRenderToDom } from '../../hooks/useRenderToDom';
+import { query } from '../../test-utils/dom';
+import { DisabledBadge } from './DisabledBadge';
+
+describe('DisabledBadge', () => {
+  it('renders a "Disabled" chip', () => {
+    const root = useRenderToDom(<DisabledBadge />);
+    expect(query(root, '.disabled-badge').text.trim()).toBe('Disabled');
+  });
+});

--- a/packages/oc-docs/src/components/DisabledBadge/DisabledBadge.tsx
+++ b/packages/oc-docs/src/components/DisabledBadge/DisabledBadge.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { StyledWrapper } from './StyledWrapper';
+
+export const DisabledBadge: React.FC = () => (
+  <StyledWrapper className="disabled-badge" data-testid="disabled-badge">Disabled</StyledWrapper>
+);
+
+export default DisabledBadge;

--- a/packages/oc-docs/src/components/DisabledBadge/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/DisabledBadge/StyledWrapper.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  color: var(--text-muted);
+  background: var(--badge-bg);
+  border: 0.0625rem solid var(--border-color);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+`;

--- a/packages/oc-docs/src/components/ExecutionContext/AssertList/AssertList.spec.tsx
+++ b/packages/oc-docs/src/components/ExecutionContext/AssertList/AssertList.spec.tsx
@@ -25,8 +25,8 @@ describe('AssertList', () => {
     expect(root.querySelector('.assert-expr')?.text.trim()).toBe('res.body.token is defined');
   });
 
-  it('marks a disabled assertion with the is-disabled class', () => {
+  it('marks a disabled assertion with the Disabled chip', () => {
     const root = useRenderToDom(<AssertList assertions={[disabled]} />);
-    expect(root.querySelector('.assert-item.is-disabled')).not.toBeNull();
+    expect(root.querySelector('.disabled-badge')).not.toBeNull();
   });
 });

--- a/packages/oc-docs/src/components/ExecutionContext/AssertList/AssertList.tsx
+++ b/packages/oc-docs/src/components/ExecutionContext/AssertList/AssertList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ScopeTag } from '../ScopeTag/ScopeTag';
+import { DisabledBadge } from '../../DisabledBadge/DisabledBadge';
 import { VariableText } from '../../VariableText/VariableText';
 import { TruncatedText } from '../../TruncatedText/TruncatedText';
 import { Description } from '../../Description/Description';
@@ -25,7 +26,7 @@ export const AssertList: React.FC<AssertListProps> = ({ assertions }) => {
       {assertions.map((assert, index) => {
         const text = assertionText(assert);
         return (
-          <div key={`${assert.expression}-${index}`} className={`assert-item ${assert.disabled ? 'is-disabled' : ''}`}>
+          <div key={`${assert.expression}-${index}`} className="assert-item">
             <div className="assert-row">
               <ScopeTag scope={assert.level} />
               <code className="assert-expr">
@@ -33,6 +34,7 @@ export const AssertList: React.FC<AssertListProps> = ({ assertions }) => {
                   <VariableText value={text} />
                 </TruncatedText>
               </code>
+              {assert.disabled ? <DisabledBadge /> : null}
             </div>
             <Description text={assert.description} />
           </div>

--- a/packages/oc-docs/src/components/ExecutionContext/AssertList/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/ExecutionContext/AssertList/StyledWrapper.ts
@@ -7,9 +7,6 @@ export const StyledWrapper = styled.div`
   .assert-item:not(:first-child) {
     border-top: 0.0625rem solid var(--oc-border-border0);
   }
-  .assert-item.is-disabled {
-    opacity: 0.55;
-  }
   .assert-row {
     display: flex;
     align-items: center;

--- a/packages/oc-docs/src/components/ExecutionContext/VariablesPanel/VariablesPanel.spec.tsx
+++ b/packages/oc-docs/src/components/ExecutionContext/VariablesPanel/VariablesPanel.spec.tsx
@@ -44,12 +44,12 @@ describe('VariablesPanel', () => {
     expect(html).toContain('JWT access token');
   });
 
-  it('marks a disabled variable so it can be visually dimmed', () => {
+  it('marks a disabled variable with the Disabled chip', () => {
     const html = renderToStaticMarkup(
       <VariablesPanel preVars={[{ name: 'legacy', value: 'v1', disabled: true }]} postVars={[]} />
     );
     expect(html).toContain('legacy');
-    expect(html).toContain('property-row--disabled'); // PropertyTable's disabled-row class
+    expect(html).toContain('disabled-badge');
   });
 
   describe('stacked variant (overview)', () => {

--- a/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
+++ b/packages/oc-docs/src/components/FolderConfiguration/FolderConfiguration.spec.tsx
@@ -62,7 +62,7 @@ describe('FolderConfiguration', () => {
     expect(root.querySelector('[data-testid="folder-config-tests"]')).toBeTruthy();
   });
 
-  it('renders disabled headers (dimmed) and their descriptions', () => {
+  it('renders disabled headers with a Disabled chip and their descriptions', () => {
     const config: FolderConfig = {
       ...baseConfig,
       headers: [{ name: 'X-Debug', value: 'on', disabled: true, description: 'toggles debug logging' }]
@@ -72,7 +72,7 @@ describe('FolderConfiguration', () => {
     const headers = root.querySelector('[data-testid="folder-config-headers"]');
     expect(headers).toBeTruthy();
     expect(headers?.querySelector('.property-key')?.text.trim()).toBe('X-Debug');
-    expect(headers?.querySelector('.property-row--disabled')).toBeTruthy();
+    expect(headers?.querySelector('.disabled-badge')).toBeTruthy();
     expect(headers?.text).toContain('toggles debug logging');
   });
 

--- a/packages/oc-docs/src/components/OverviewCollectionConfiguration/CollectionConfiguration.spec.tsx
+++ b/packages/oc-docs/src/components/OverviewCollectionConfiguration/CollectionConfiguration.spec.tsx
@@ -29,7 +29,7 @@ describe('CollectionConfiguration', () => {
     expect(html).toContain('Accept');
     expect(html).toContain('application/json');
     expect(html).toContain('X-Disabled');
-    expect(html).toContain('property-row--disabled');
+    expect(html).toContain('disabled-badge');
 
     // Auth mode resolved via the supplied labels; username shown, password masked
     expect(html).toContain('Basic Auth');

--- a/packages/oc-docs/src/components/PropertyTable/PropertyTable.tsx
+++ b/packages/oc-docs/src/components/PropertyTable/PropertyTable.tsx
@@ -51,7 +51,7 @@ export const PropertyTable: React.FC<PropertyTableProps> = ({ rows, emptyMessage
           <div className="property-row" key={`${row.label}-${index}`}>
             <dt className="property-key"><TruncatedText text={row.label} /></dt>
             <dd className="property-value-cell" data-testid={testId && row.testId ? `${testId}-${row.testId}` : undefined}>
-              <div className="property-value-line">
+              <div className="property-value-line" data-testid="property-value-line">
                 <div className="property-value-main" data-testid="property-value"><ValueCell row={row} testId={testId} /></div>
                 {row.type ? <span className="property-type">{row.type}</span> : null}
                 {row.disabled ? <DisabledBadge /> : null}

--- a/packages/oc-docs/src/components/PropertyTable/PropertyTable.tsx
+++ b/packages/oc-docs/src/components/PropertyTable/PropertyTable.tsx
@@ -3,6 +3,7 @@ import { SecretValue } from '../../ui/SecretValue/SecretValue';
 import { VariableText } from '../VariableText/VariableText';
 import { TruncatedText } from '../TruncatedText/TruncatedText';
 import { Description } from '../Description/Description';
+import { DisabledBadge } from '../DisabledBadge/DisabledBadge';
 import { StyledWrapper } from './StyledWrapper';
 
 export interface PropertyRow {
@@ -47,15 +48,13 @@ export const PropertyTable: React.FC<PropertyTableProps> = ({ rows, emptyMessage
     ) : (
       <dl className="property-box">
         {rows.map((row, index) => (
-          <div
-            className={['property-row', row.disabled ? 'property-row--disabled' : ''].filter(Boolean).join(' ')}
-            key={`${row.label}-${index}`}
-          >
+          <div className="property-row" key={`${row.label}-${index}`}>
             <dt className="property-key"><TruncatedText text={row.label} /></dt>
             <dd className="property-value-cell" data-testid={testId && row.testId ? `${testId}-${row.testId}` : undefined}>
               <div className="property-value-line">
-                <div className="property-value-main"><ValueCell row={row} testId={testId} /></div>
+                <div className="property-value-main" data-testid="property-value"><ValueCell row={row} testId={testId} /></div>
                 {row.type ? <span className="property-type">{row.type}</span> : null}
+                {row.disabled ? <DisabledBadge /> : null}
               </div>
             </dd>
             <Description text={row.description} />

--- a/packages/oc-docs/src/components/PropertyTable/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/PropertyTable/StyledWrapper.ts
@@ -41,9 +41,6 @@ export const StyledWrapper = styled.div`
   &.property-table--no-row-borders .property-box {
     border: none;
   }
-  .property-row--disabled {
-    opacity: 0.55;
-  }
 
   .property-key {
     font-family: var(--font-sans);
@@ -71,6 +68,10 @@ export const StyledWrapper = styled.div`
     align-items: baseline;
     gap: 0.5rem;
     min-width: 0;
+  }
+  .property-value-line .disabled-badge {
+    margin-left: auto;
+    align-self: center;
   }
   .property-value-main {
     min-width: 0;

--- a/packages/oc-docs/src/pages/Environments/Environments.tsx
+++ b/packages/oc-docs/src/pages/Environments/Environments.tsx
@@ -8,6 +8,7 @@ import { EnvironmentLabel } from '../../components/EnvironmentLabel/EnvironmentL
 import { VariableText } from '../../components/VariableText/VariableText';
 import { TruncatedText } from '../../components/TruncatedText/TruncatedText';
 import { Description } from '../../components/Description/Description';
+import { DisabledBadge } from '../../components/DisabledBadge/DisabledBadge';
 import { ViewMore } from '../../components/ViewMore/ViewMore';
 import { EmptyState } from '../../ui/EmptyState/EmptyState';
 import { PageWrapper } from '../../components/PageWrapper/PageWrapper';
@@ -23,7 +24,17 @@ const COLUMNS: TableColumn[] = [
 
 const emptyCell = <span className="environment-empty">(empty)</span>;
 
-const nameCell = (name: string): React.ReactNode => <TruncatedText className="environment-name" text={name} />;
+const nameCell = (name: string, disabled?: boolean): React.ReactNode => {
+  const label = <TruncatedText className="environment-name" text={name} />;
+  return disabled ? (
+    <span className="environment-name-cell">
+      {label}
+      <DisabledBadge />
+    </span>
+  ) : (
+    label
+  );
+};
 
 const valueCell = (value: string): React.ReactNode =>
   value ? (
@@ -76,10 +87,9 @@ export const Environments: React.FC<EnvironmentsProps> = ({ collection }) => {
         rows: variables.map((row) => ({
           id: `var-${row.name}`,
           rowHeaderKey: 'name',
-          disabled: row.disabled,
           testId: 'environment-variable-row',
           cells: {
-            name: nameCell(row.name),
+            name: nameCell(row.name, row.disabled),
             value: valueCell(row.value),
             type: typeCell(row.dataType)
           },
@@ -97,10 +107,9 @@ export const Environments: React.FC<EnvironmentsProps> = ({ collection }) => {
         rows: secretVariables.map((row) => ({
           id: `secret-${row.name}`,
           rowHeaderKey: 'name',
-          disabled: row.disabled,
           testId: 'environment-secret-variable-row',
           cells: {
-            name: nameCell(row.name),
+            name: nameCell(row.name, row.disabled),
             value: secretCell(),
             type: typeCell(row.dataType)
           },
@@ -119,10 +128,9 @@ export const Environments: React.FC<EnvironmentsProps> = ({ collection }) => {
         rows: externalSecrets.variables.map((row) => ({
           id: `ext-${row.name}`,
           rowHeaderKey: 'name',
-          disabled: row.disabled,
           testId: 'environment-external-secret-row',
           cells: {
-            name: nameCell(row.name),
+            name: nameCell(row.name, row.disabled),
             value: valueCell(row.secretName),
             type: typeCell(row.dataType)
           }

--- a/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
+++ b/packages/oc-docs/src/pages/Environments/StyledWrapper.ts
@@ -56,6 +56,17 @@ export const StyledWrapper = styled.div`
     margin-bottom: 0.625rem;
   }
 
+  .environment-name-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+    max-width: 100%;
+  }
+  .environment-name-cell .environment-name {
+    min-width: 0;
+  }
+
   .environment-name {
     font-family: 'Fira Code', var(--font-mono);
     font-weight: 500;

--- a/packages/oc-docs/src/sampleCollection.ts
+++ b/packages/oc-docs/src/sampleCollection.ts
@@ -53,6 +53,7 @@ request:
       value: "collection_pre_var_value"
     - name: "collection-var"
       value: "collection-var-value"
+      disabled: true
   auth:
     type: "bearer"
     token: "{{bearer_auth_token}}"

--- a/packages/oc-docs/src/ui/Table/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/Table/StyledWrapper.ts
@@ -134,9 +134,6 @@ export const StyledWrapper = styled.div`
   .table-description-cell {
     padding: 0 0.875rem 0.5rem;
   }
-  .table-row--disabled {
-    opacity: 0.55;
-  }
 
   .table-cell {
     padding: 0.5rem 0.875rem; /* 8px 14px */

--- a/packages/oc-docs/src/ui/Table/Table.tsx
+++ b/packages/oc-docs/src/ui/Table/Table.tsx
@@ -12,7 +12,6 @@ export interface TableRow {
   id: string;
   cells: Record<string, React.ReactNode>;
   rowHeaderKey?: string;
-  disabled?: boolean;
   testId?: string;
   description?: React.ReactNode;
 }
@@ -67,15 +66,12 @@ const Cells: React.FC<{ row: TableRow; columns: TableColumn[] }> = ({ row, colum
 const Rows: React.FC<{ rows: TableRow[]; columns: TableColumn[] }> = ({ rows, columns }) =>
   rows.map((row) => (
     <React.Fragment key={row.id}>
-      <tr
-        className={['table-row', row.disabled ? 'table-row--disabled' : ''].filter(Boolean).join(' ')}
-        data-testid={row.testId}
-      >
+      <tr className="table-row" data-testid={row.testId}>
         <Cells row={row} columns={columns} />
       </tr>
       {row.description && (
         <tr
-          className={['table-row-description', row.disabled ? 'table-row--disabled' : ''].filter(Boolean).join(' ')}
+          className="table-row-description"
           data-testid={row.testId ? `${row.testId}-description` : undefined}
         >
           <td colSpan={columns.length} className="table-description-cell">


### PR DESCRIPTION
Added disabled badge at places where the items are not enabled from the bruno app. 

BRU - 3753

<img width="2008" height="836" alt="image" src="https://github.com/user-attachments/assets/6799e44a-af21-49f9-9450-daf6a7674604" />

<img width="2702" height="1808" alt="image" src="https://github.com/user-attachments/assets/58e90927-5362-4721-8a59-fa6e70871481" />
