### PR TITLE
feat(oc-docs): allow entering a custom HTTP method in the playground (BRU-3946)

### DIFF
--- a/packages/oc-docs/e2e/components/playground/query-bar.component.ts
+++ b/packages/oc-docs/e2e/components/playground/query-bar.component.ts
@@ -1,0 +1,28 @@
+import type { Locator } from '@playwright/test';
+import { BaseComponent } from '../base.component';
+
+export class QueryBarComponent extends BaseComponent {
+  readonly methodSelect = this.page.getByTestId('method-select');
+  readonly methodLabel = this.methodSelect.locator('.method-select-label');
+  readonly methodDropdown = this.page.getByTestId('method-select-dropdown');
+  readonly methodAddCustom = this.page.getByTestId('method-select-add-custom');
+  readonly methodCustomInput = this.page.getByTestId('method-custom-input');
+
+  methodItem(method: string): Locator {
+    return this.page.getByTestId(`method-select-${method.toLowerCase()}`);
+  }
+
+  async openMethodDropdown(): Promise<void> {
+    await this.methodSelect.click();
+  }
+
+  async enterCustomMode(): Promise<void> {
+    await this.openMethodDropdown();
+    await this.methodAddCustom.click();
+  }
+
+  async selectMethod(method: string): Promise<void> {
+    await this.openMethodDropdown();
+    await this.methodItem(method).click();
+  }
+}

--- a/packages/oc-docs/e2e/playwright/pages.fixture.ts
+++ b/packages/oc-docs/e2e/playwright/pages.fixture.ts
@@ -9,6 +9,7 @@ import { SidebarComponent } from '../components/sidebar.component';
 import { TooltipComponent } from '../components/tooltip.component';
 import { PlaygroundComponent } from '../components/playground.component';
 import { RequestBodyComponent } from '../components/playground/request-body.component';
+import { QueryBarComponent } from '../components/playground/query-bar.component';
 import { EnvEditorComponent } from '../components/environments/env-editor.component';
 import { CollectionSettingsComponent } from '../components/collection-settings/collection-settings.component';
 import { ThemeToggleComponent } from '../components/layout/theme-toggle.component';
@@ -27,6 +28,7 @@ type Fixtures = {
   tooltip: TooltipComponent;
   playground: PlaygroundComponent;
   requestBody: RequestBodyComponent;
+  queryBar: QueryBarComponent;
   envEditor: EnvEditorComponent;
   collectionSettings: CollectionSettingsComponent;
   pageHeader: PageHeaderComponent;
@@ -71,6 +73,9 @@ export const test = base.extend<Fixtures>({
   },
   requestBody: async ({ page }, use) => {
     await use(new RequestBodyComponent(page));
+  },
+  queryBar: async ({ page }, use) => {
+    await use(new QueryBarComponent(page));
   },
   envEditor: async ({ page }, use) => {
     await use(new EnvEditorComponent(page));

--- a/packages/oc-docs/e2e/tests/playground/query-bar-method.spec.ts
+++ b/packages/oc-docs/e2e/tests/playground/query-bar-method.spec.ts
@@ -64,6 +64,17 @@ test.describe('playground query bar - custom HTTP method', () => {
     await expect(queryBar.methodLabel).toHaveText('POST');
   });
 
+  test('a custom method with internal whitespace commits as a single normalized token', async ({ queryBar }) => {
+    await queryBar.enterCustomMode();
+    await queryBar.methodCustomInput.type('pur ge');
+    await expect(queryBar.methodCustomInput).toHaveValue('PUR GE');
+
+    await queryBar.methodCustomInput.press('Enter');
+
+    await expect(queryBar.methodCustomInput).toHaveCount(0);
+    await expect(queryBar.methodLabel).toHaveText('PURGE');
+  });
+
   test('a lowercase standard verb normalizes to the standard method', async ({ queryBar }) => {
     await queryBar.enterCustomMode();
     await queryBar.methodCustomInput.type('patch');

--- a/packages/oc-docs/e2e/tests/playground/query-bar-method.spec.ts
+++ b/packages/oc-docs/e2e/tests/playground/query-bar-method.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '../../playwright';
+
+const DESKTOP = { width: 1280, height: 900 };
+
+test.describe('playground query bar - custom HTTP method', () => {
+  test.use({ viewport: DESKTOP });
+
+  test.beforeEach(async ({ page, playground }) => {
+    await page.goto('/#/?pg=1&dock=bottom');
+    await expect(playground.runner).toBeVisible();
+    await playground.openRequest('get users');
+    await expect(playground.view).toContainText('get users');
+  });
+
+  test('Add custom reveals a focused custom method input', async ({ queryBar }) => {
+    await expect(queryBar.methodLabel).toHaveText('GET');
+
+    await queryBar.enterCustomMode();
+
+    await expect(queryBar.methodCustomInput).toBeVisible();
+    await expect(queryBar.methodCustomInput).toBeFocused();
+    await expect(queryBar.methodSelect).toHaveCount(0);
+  });
+
+  test('typing a custom method commits it uppercased on Enter', async ({ queryBar }) => {
+    await queryBar.enterCustomMode();
+    await queryBar.methodCustomInput.type('purge');
+    await expect(queryBar.methodCustomInput).toHaveValue('PURGE');
+
+    await queryBar.methodCustomInput.press('Enter');
+
+    await expect(queryBar.methodCustomInput).toHaveCount(0);
+    await expect(queryBar.methodLabel).toHaveText('PURGE');
+  });
+
+  test('Escape cancels custom mode and restores the previous method', async ({ queryBar }) => {
+    await queryBar.enterCustomMode();
+    await queryBar.methodCustomInput.type('purge');
+
+    await queryBar.methodCustomInput.press('Escape');
+
+    await expect(queryBar.methodCustomInput).toHaveCount(0);
+    await expect(queryBar.methodLabel).toHaveText('GET');
+  });
+
+  test('committing an empty method keeps the previous method', async ({ queryBar }) => {
+    await queryBar.enterCustomMode();
+    await queryBar.methodCustomInput.fill('   ');
+
+    await queryBar.methodCustomInput.press('Enter');
+
+    await expect(queryBar.methodCustomInput).toHaveCount(0);
+    await expect(queryBar.methodLabel).toHaveText('GET');
+  });
+
+  test('picking a standard verb after a custom method switches back', async ({ queryBar }) => {
+    await queryBar.enterCustomMode();
+    await queryBar.methodCustomInput.type('purge');
+    await queryBar.methodCustomInput.press('Enter');
+    await expect(queryBar.methodLabel).toHaveText('PURGE');
+
+    await queryBar.selectMethod('POST');
+
+    await expect(queryBar.methodLabel).toHaveText('POST');
+  });
+
+  test('a lowercase standard verb normalizes to the standard method', async ({ queryBar }) => {
+    await queryBar.enterCustomMode();
+    await queryBar.methodCustomInput.type('patch');
+    await expect(queryBar.methodCustomInput).toHaveValue('PATCH');
+
+    await queryBar.methodCustomInput.press('Enter');
+
+    await expect(queryBar.methodLabel).toHaveText('PATCH');
+
+    await queryBar.openMethodDropdown();
+    await expect(queryBar.methodItem('PATCH')).toHaveAttribute('aria-current', 'true');
+  });
+});

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { parse } from 'node-html-parser';
+import { describe, it, expect } from 'vitest';
+import type { HttpRequest } from '@opencollection/types/requests/http';
+import QueryBar from './QueryBar';
+import { getByTestId } from '../../../../../../test-utils/dom';
+
+const noop = () => {};
+
+const render = (method: string) => {
+  const item = { type: 'http', http: { method, url: 'https://api.test/v1' } } as unknown as HttpRequest;
+  const html = renderToStaticMarkup(
+    <QueryBar item={item} onSendRequest={noop} isLoading={false} onItemChange={noop} />
+  );
+  const root = parse(html);
+  root.querySelectorAll('style').forEach((style) => style.remove());
+  return root;
+};
+
+describe('QueryBar method selector', () => {
+  it('shows the item method on the trigger with the method-select test id', () => {
+    const trigger = getByTestId(render('POST'), 'method-select');
+    expect(trigger.querySelector('.method-select-label')?.text).toBe('POST');
+    expect(trigger.getAttribute('aria-label')).toBe('HTTP method');
+  });
+
+  it('colours a standard method with its method colour var', () => {
+    const trigger = getByTestId(render('POST'), 'method-select');
+    expect(trigger.getAttribute('style')).toContain('color:var(--oc-request-methods-post)');
+  });
+
+  it('renders a non-standard method verbatim in the muted colour', () => {
+    const trigger = getByTestId(render('PURGE'), 'method-select');
+    expect(trigger.querySelector('.method-select-label')?.text).toBe('PURGE');
+    expect(trigger.getAttribute('style')).toContain('color:var(--oc-colors-text-muted)');
+  });
+
+  it('keeps the trigger label truncatable and exposes the full method in the title', () => {
+    const method = 'AVERYLONGCUSTOMMETHODNAME';
+    const trigger = getByTestId(render(method), 'method-select');
+    expect(trigger.querySelector('.method-select-label')?.text).toBe(method);
+    expect(trigger.getAttribute('title')).toBe(method);
+  });
+});

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -23,6 +23,8 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
   useEffect(() => {
     setUrl(getRequestUrl(item));
     setMethod(getHttpMethod(item));
+    setIsCustomMode(false);
+    setCustomValue('');
   }, [item]);
 
   useEffect(() => {

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import type { HttpRequest } from '@opencollection/types/requests/http';
 import { StyledWrapper } from './StyledWrapper';
 import MenuDropdown from '../../../../../../ui/MenuDropdown';
-import { getHttpMethod, getRequestUrl, getHttpParams } from '../../../../../../utils/schemaHelpers';
+import { getHttpMethod, getRequestUrl, getHttpParams, normalizeHttpMethod } from '../../../../../../utils/schemaHelpers';
 import { syncPathParams, syncQueryParams } from '../../../../../../utils/pathParams';
 import { methodColorVars, getMethodColorVar } from '../../../../../../theme/methodColors';
 
@@ -74,9 +74,9 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
   };
 
   const commitCustomMethod = () => {
-    const trimmed = customValue.trim().toUpperCase();
-    if (trimmed) {
-      handleMethodChange(trimmed);
+    const normalized = normalizeHttpMethod(customValue);
+    if (normalized) {
+      handleMethodChange(normalized);
     }
     setIsCustomMode(false);
   };

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import type { HttpRequest } from '@opencollection/types/requests/http';
 import { StyledWrapper } from './StyledWrapper';
 import MenuDropdown from '../../../../../../ui/MenuDropdown';
@@ -16,11 +16,21 @@ interface QueryBarProps {
 const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onItemChange }) => {
   const [url, setUrl] = useState(getRequestUrl(item));
   const [method, setMethod] = useState(getHttpMethod(item));
+  const [isCustomMode, setIsCustomMode] = useState(false);
+  const [customValue, setCustomValue] = useState('');
+  const customInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setUrl(getRequestUrl(item));
     setMethod(getHttpMethod(item));
   }, [item]);
+
+  useEffect(() => {
+    if (isCustomMode) {
+      customInputRef.current?.focus();
+      customInputRef.current?.select();
+    }
+  }, [isCustomMode]);
 
   const handleUrlChange = (newUrl: string) => {
     setUrl(newUrl);
@@ -53,6 +63,36 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
 
   const getMethodColor = getMethodColorVar;
 
+  const standardMethods = Object.keys(methodColorVars);
+  const isStandardMethod = standardMethods.includes(method.toUpperCase());
+
+  const enterCustomMode = () => {
+    setCustomValue('');
+    setIsCustomMode(true);
+  };
+
+  const commitCustomMethod = () => {
+    const trimmed = customValue.trim().toUpperCase();
+    if (trimmed) {
+      handleMethodChange(trimmed);
+    }
+    setIsCustomMode(false);
+  };
+
+  const cancelCustomMode = () => {
+    setIsCustomMode(false);
+  };
+
+  const handleCustomKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commitCustomMethod();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancelCustomMode();
+    }
+  };
+
   return (
     <StyledWrapper 
       className="flex items-stretch"
@@ -61,25 +101,55 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
       }}
     >
       <div className="method-select-wrapper">
-        <MenuDropdown
-          selectedItemId={method}
-          placement="bottom-start"
-          items={Object.keys(methodColorVars).map((m) => ({
-            id: m,
-            label: <span style={{ color: getMethodColor(m) }}>{m}</span>,
-            ariaLabel: m,
-            onClick: () => handleMethodChange(m)
-          }))}
-        >
-          <button
-            type="button"
-            className="method-select h-full"
-            aria-label="HTTP method"
-            style={{ color: getMethodColor(method) }}
+        {isCustomMode ? (
+          <input
+            ref={customInputRef}
+            type="text"
+            value={customValue}
+            onChange={(e) => setCustomValue(e.target.value.toUpperCase())}
+            onKeyDown={handleCustomKeyDown}
+            onBlur={commitCustomMethod}
+            className="method-custom-input h-full"
+            style={{
+              color: getMethodColor(customValue),
+              width: `calc(${Math.min(Math.max(customValue.length + 1, 4), 16)}ch + 1rem)`
+            }}
+            aria-label="Custom HTTP method"
+            data-testid="method-custom-input"
+          />
+        ) : (
+          <MenuDropdown
+            selectedItemId={isStandardMethod ? method.toUpperCase() : null}
+            placement="bottom-start"
+            data-testid="method-select"
+            items={standardMethods.map((m) => ({
+              id: m,
+              label: <span style={{ color: getMethodColor(m) }}>{m}</span>,
+              ariaLabel: m,
+              onClick: () => handleMethodChange(m)
+            }))}
+            footer={
+              <button
+                type="button"
+                className="method-add-custom"
+                onClick={enterCustomMode}
+                data-testid="method-select-add-custom"
+              >
+                + Add custom
+              </button>
+            }
           >
-            {method}
-          </button>
-        </MenuDropdown>
+            <button
+              type="button"
+              className="method-select h-full"
+              aria-label="HTTP method"
+              title={method}
+              style={{ color: getMethodColor(method) }}
+            >
+              <span className="method-select-label">{method}</span>
+            </button>
+          </MenuDropdown>
+        )}
       </div>
 
       <input

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -81,27 +81,6 @@ export const StyledWrapper = styled.div`
     text-align: left;
   }
 
-  .method-add-custom {
-    appearance: none;
-    display: block;
-    width: 100%;
-    margin: 0;
-    padding: 0.25rem 0.6rem;
-    background-color: transparent;
-    border: none;
-    outline: none;
-    cursor: pointer;
-    text-align: left;
-    font-family: inherit;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--primary-color);
-
-    &:hover {
-      background-color: color-mix(in srgb, var(--oc-text) 5%, transparent);
-    }
-  }
-
   button.send {
     background-color: var(--primary-color);
     font-size: 11px;

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -60,6 +60,48 @@ export const StyledWrapper = styled.div`
     letter-spacing: 0.02em;
   }
 
+  .method-select-label {
+    display: block;
+    max-width: 15ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .method-custom-input {
+    appearance: none;
+    margin: 0;
+    padding: 0 0.5rem;
+    min-width: 4ch;
+    max-width: calc(16ch + 1rem);
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-align: left;
+  }
+
+  .method-add-custom {
+    appearance: none;
+    display: block;
+    width: 100%;
+    margin: 0;
+    padding: 0.25rem 0.6rem;
+    background-color: transparent;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    text-align: left;
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--primary-color);
+
+    &:hover {
+      background-color: color-mix(in srgb, var(--oc-text) 5%, transparent);
+    }
+  }
+
   button.send {
     background-color: var(--primary-color);
     font-size: 11px;

--- a/packages/oc-docs/src/runner/RequestExecutor.spec.ts
+++ b/packages/oc-docs/src/runner/RequestExecutor.spec.ts
@@ -37,14 +37,34 @@ describe('RequestExecutor', () => {
     vi.restoreAllMocks();
   });
 
-  it('sends the api key in the request url when placement is query', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
+  const okFetchMock = () =>
+    vi.fn().mockResolvedValue({
       status: 200,
       statusText: 'OK',
       url: 'https://api.example.com/data',
       headers: new Headers({ 'content-type': 'application/json' }),
       text: async () => JSON.stringify({ ok: true })
     });
+
+  const runWithBody = async (method: string) => {
+    const fetchMock = okFetchMock();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await new RequestExecutor().executeRequest({
+      name: `${method} with body`,
+      type: 'http',
+      http: {
+        method,
+        url: 'https://api.example.com/data',
+        body: { type: 'json', data: '{"hello":"world"}' }
+      }
+    } as any);
+
+    return (fetchMock.mock.calls[0][1] as RequestInit) ?? {};
+  };
+
+  it('sends the api key in the request url when placement is query', async () => {
+    const fetchMock = okFetchMock();
     global.fetch = fetchMock as unknown as typeof fetch;
 
     await new RequestExecutor().executeRequest({
@@ -58,5 +78,27 @@ describe('RequestExecutor', () => {
     } as any);
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/data?api_key=secret123');
+  });
+
+  it('attaches the body for a custom body-carrying verb like QUERY', async () => {
+    const options = await runWithBody('QUERY');
+    expect(options.method).toBe('QUERY');
+    expect(options.body).toBe('{"hello":"world"}');
+  });
+
+  it('does not attach a body for GET or HEAD (fetch would throw)', async () => {
+    expect((await runWithBody('GET')).body).toBeUndefined();
+    expect((await runWithBody('HEAD')).body).toBeUndefined();
+  });
+
+  it('attaches the body for POST, PUT and PATCH as before', async () => {
+    expect((await runWithBody('POST')).body).toBe('{"hello":"world"}');
+    expect((await runWithBody('PUT')).body).toBe('{"hello":"world"}');
+    expect((await runWithBody('PATCH')).body).toBe('{"hello":"world"}');
+  });
+
+  it('normalizes lowercase / spaced methods before sending', async () => {
+    expect((await runWithBody('get')).method).toBe('GET');
+    expect((await runWithBody('get')).body).toBeUndefined();
   });
 });

--- a/packages/oc-docs/src/runner/RequestExecutor.ts
+++ b/packages/oc-docs/src/runner/RequestExecutor.ts
@@ -1,6 +1,6 @@
 import type { HttpRequest } from '@opencollection/types/requests/http';
 import { RunRequestResponse } from './index';
-import { getHttpMethod, getRequestUrl, getHttpHeaders, getHttpBody, getRequestAuth, getHttpParams } from '../utils/schemaHelpers';
+import { getHttpMethod, getRequestUrl, getHttpHeaders, getHttpBody, getRequestAuth, getHttpParams, normalizeHttpMethod } from '../utils/schemaHelpers';
 import { buildRequestUrl } from '../utils/pathParams';
 import { classifyRequestError, DEFAULT_TIMEOUT_MS } from './classifyRequestError';
 import stripJsonComments from 'strip-json-comments';
@@ -63,15 +63,17 @@ export class RequestExecutor {
   }
 
   private async buildFetchOptions(request: HttpRequest, timeout = DEFAULT_TIMEOUT_MS): Promise<RequestInit> {
-    const method = getHttpMethod(request);
+    const method = normalizeHttpMethod(getHttpMethod(request));
     const options: RequestInit = {
       method,
       headers: this.buildHeaders(request),
       signal: AbortSignal.timeout(timeout)
     };
 
+    // Like Bruno, attach the body whenever one is defined regardless of the verb,
+    // except for the body-less methods GET/HEAD where fetch throws if a body is set.
     const body = getHttpBody(request);
-    if (body && ['POST', 'PUT', 'PATCH'].includes(method)) {
+    if (body && !['GET', 'HEAD'].includes(method)) {
       options.body = await this.buildBody(request);
     }
 

--- a/packages/oc-docs/src/runner/classifyRequestError.spec.ts
+++ b/packages/oc-docs/src/runner/classifyRequestError.spec.ts
@@ -34,6 +34,44 @@ describe('classifyRequestError', () => {
     });
   });
 
+  describe('invalid / unsupported HTTP method', () => {
+    it('classifies an invalid method token (Chrome phrasing)', () => {
+      const result = classifyRequestError(
+        failedToFetch("Failed to execute 'fetch' on 'Window': 'PUR GE' is not a valid HTTP method."),
+        { pageUrl: 'https://docs.example.com/', requestUrl: 'https://api.example.com/users' }
+      );
+      expect(result.type).toBe('invalid-method');
+      expect(result.title).toBe('Invalid HTTP method');
+      expect(result.message).toContain('CONNECT');
+    });
+
+    it('classifies a forbidden verb (unsupported method phrasing)', () => {
+      const result = classifyRequestError(
+        failedToFetch("Failed to execute 'fetch' on 'Window': 'CONNECT' HTTP method is unsupported."),
+        { pageUrl: 'https://docs.example.com/', requestUrl: 'https://api.example.com/users' }
+      );
+      expect(result.type).toBe('invalid-method');
+    });
+
+    it('takes precedence over the opaque-fetch-failure classification', () => {
+      // Chrome's invalid-method message also contains "fetch"; ordering must not
+      // regress into a browser-blocked / unreachable classification.
+      const result = classifyRequestError(
+        failedToFetch("Failed to execute 'fetch' on 'Window': 'TRACE' HTTP method is unsupported."),
+        { pageUrl: 'https://app.example.com/docs', requestUrl: 'https://app.example.com/api' }
+      );
+      expect(result.type).toBe('invalid-method');
+    });
+
+    it('still classifies a genuine network TypeError as an opaque failure', () => {
+      const result = classifyRequestError(failedToFetch('Failed to fetch'), {
+        pageUrl: 'https://docs.example.com/',
+        requestUrl: 'https://api.example.com/users'
+      });
+      expect(result.type).toBe('browser-blocked');
+    });
+  });
+
   describe('mixed content (secure page, insecure URL)', () => {
     it('classifies an https page calling an http URL', () => {
       const result = classifyRequestError(failedToFetch(), {

--- a/packages/oc-docs/src/runner/classifyRequestError.ts
+++ b/packages/oc-docs/src/runner/classifyRequestError.ts
@@ -18,6 +18,7 @@
 
 export type RequestErrorType =
   | 'timeout'
+  | 'invalid-method'
   | 'mixed-content'
   | 'browser-blocked'
   | 'unreachable'
@@ -64,6 +65,20 @@ const isOpaqueFetchFailure = (error: unknown): boolean => {
   return msg.includes('fetch') || msg.includes('load failed') || msg.includes('networkerror');
 };
 
+/**
+ * `fetch` rejects with a `TypeError` when the method is an invalid token
+ * ("'FOO BAR' is not a valid HTTP method") or a forbidden verb the browser
+ * refuses to send (CONNECT/TRACE/TRACK -> "'CONNECT' HTTP method is
+ * unsupported"). These carry "fetch" in the message on Chrome, so this must run
+ * before isOpaqueFetchFailure to avoid being misread as a network/CORS failure.
+ */
+const isInvalidMethodError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  if (error.name !== 'TypeError') return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes('is not a valid http method') || msg.includes('http method is unsupported');
+};
+
 const safeParseUrl = (url?: string): URL | null => {
   if (!url) return null;
   try {
@@ -77,6 +92,15 @@ const TIMEOUT: ClassifiedRequestError = {
   type: 'timeout',
   title: 'Request timed out',
   message: "Request timed out. The server didn't respond in time."
+};
+
+const INVALID_METHOD: ClassifiedRequestError = {
+  type: 'invalid-method',
+  title: 'Invalid HTTP method',
+  message:
+    "The HTTP method isn't accepted by the browser. Some verbs (like CONNECT, TRACE and " +
+    'TRACK) and methods with spaces or special characters are rejected. Try it in the ' +
+    'Bruno desktop app.'
 };
 
 const MIXED_CONTENT: ClassifiedRequestError = {
@@ -107,6 +131,10 @@ export const classifyRequestError = (
 ): ClassifiedRequestError => {
   if (isTimeoutError(error)) {
     return TIMEOUT;
+  }
+
+  if (isInvalidMethodError(error)) {
+    return INVALID_METHOD;
   }
 
   if (isOpaqueFetchFailure(error)) {

--- a/packages/oc-docs/src/theme/methodColors.spec.ts
+++ b/packages/oc-docs/src/theme/methodColors.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { methodColorVars, getMethodColorVar } from './methodColors';
+
+describe('getMethodColorVar', () => {
+  it('maps a standard method to its theme var', () => {
+    expect(getMethodColorVar('GET')).toBe('var(--oc-request-methods-get)');
+    expect(getMethodColorVar('POST')).toBe('var(--oc-request-methods-post)');
+  });
+
+  it('matches methods case-insensitively', () => {
+    expect(getMethodColorVar('get')).toBe(methodColorVars.GET);
+    expect(getMethodColorVar('Post')).toBe(methodColorVars.POST);
+  });
+
+  it('falls back to the muted var for a non-standard method', () => {
+    expect(getMethodColorVar('PURGE')).toBe('var(--oc-colors-text-muted)');
+  });
+
+  it('falls back to the muted var for an empty or missing method', () => {
+    expect(getMethodColorVar('')).toBe('var(--oc-colors-text-muted)');
+    expect(getMethodColorVar()).toBe('var(--oc-colors-text-muted)');
+  });
+});

--- a/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
@@ -192,6 +192,28 @@ export const StyledWrapper = styled.div`
     padding: 0.25rem 0.625rem;
   }
 
+  .dropdown-footer-container .method-add-custom {
+    appearance: none;
+    display: block;
+    width: 100%;
+    margin: 0;
+    padding: 0.25rem 0.6rem;
+    background-color: transparent;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    text-align: left;
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--primary-color);
+    border-radius: 0.375rem;
+
+    &:hover {
+      background-color: var(--oc-dropdown-hover-bg);
+    }
+  }
+
   .dropdown-divider {
     height: 1px;
     background-color: var(--oc-dropdown-separator);

--- a/packages/oc-docs/src/utils/schemaHelpers.spec.ts
+++ b/packages/oc-docs/src/utils/schemaHelpers.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Item as OpenCollectionItem } from '@opencollection/types/collection/item';
-import { getItemDescription, getRequestBadgeLabel } from './schemaHelpers';
+import { getItemDescription, getRequestBadgeLabel, normalizeHttpMethod } from './schemaHelpers';
 
 const item = (data: Record<string, unknown>): OpenCollectionItem => data as unknown as OpenCollectionItem;
 
@@ -39,5 +39,25 @@ describe('getRequestBadgeLabel', () => {
     expect(getRequestBadgeLabel(item({ type: 'folder' }))).toBeUndefined();
     expect(getRequestBadgeLabel(item({ type: 'script' }))).toBeUndefined();
     expect(getRequestBadgeLabel(null)).toBeUndefined();
+  });
+});
+
+describe('normalizeHttpMethod', () => {
+  it('trims edge whitespace and uppercases', () => {
+    expect(normalizeHttpMethod('  post ')).toBe('POST');
+  });
+
+  it('strips internal whitespace so an accidental space is not an invalid token', () => {
+    expect(normalizeHttpMethod('PUR GE')).toBe('PURGE');
+    expect(normalizeHttpMethod('q u e r y')).toBe('QUERY');
+  });
+
+  it('returns an empty string for empty or whitespace-only input', () => {
+    expect(normalizeHttpMethod('')).toBe('');
+    expect(normalizeHttpMethod('   ')).toBe('');
+  });
+
+  it('leaves forbidden-but-valid verbs untouched', () => {
+    expect(normalizeHttpMethod('connect')).toBe('CONNECT');
   });
 });

--- a/packages/oc-docs/src/utils/schemaHelpers.ts
+++ b/packages/oc-docs/src/utils/schemaHelpers.ts
@@ -146,6 +146,16 @@ export const getHttpMethod = (item: HttpRequest | null | undefined): string => {
 };
 
 /**
+ * Normalizes a user-typed HTTP method into a clean token: trims edge whitespace,
+ * uppercases, and strips INTERNAL whitespace so an accidental space (e.g. "PUR GE")
+ * doesn't produce an invalid token the browser rejects. Forbidden verbs like
+ * CONNECT/TRACE/TRACK are valid tokens and pass through untouched — the runner
+ * surfaces those when fetch refuses them.
+ */
+export const normalizeHttpMethod = (method: string): string =>
+  method.trim().replace(/\s+/g, '').toUpperCase();
+
+/**
  * The badge label for a request item: its HTTP method (GET, POST, ...) or the
  * protocol short-label (GQL, GRPC, WS). Returns undefined for anything that
  * carries no badge (folders, scripts, built-in pages). Single source of truth


### PR DESCRIPTION
## What
Adds the ability to enter a **custom HTTP method** in the playground method selector, ported from Bruno's request-method UX.

- A `+ Add custom` item in the method dropdown reveals a text input (replacing the trigger).
- Uppercases on type; **Enter** or **blur** commits; **Escape** cancels; empty/whitespace is ignored (previous method preserved, never persists `''`).
- Value is normalized on commit (trim, strip internal whitespace, uppercase), so `post` collapses to the standard `POST` and an accidental `pur ge` becomes `PURGE`; a non-standard verb renders verbatim in the muted method color.
- The chosen method flows into the request that actually runs (`http.method` → `runner`), not just cosmetics.
- Switching requests exits custom mode (no stale input carried across items).

## Scope (deliberately narrow)
The QueryBar custom-method UI, plus the runtime handling that makes a custom method actually usable (see below). Does **not** touch the pre-existing HTTP_METHODS/protocol list (separate PR).

## Runtime behavior
- **Custom verbs send a body, like Bruno.** The runner previously gated the request body to `POST`/`PUT`/`PATCH`; it now attaches a defined body for any method except the body-less `GET`/`HEAD` (which `fetch` rejects with a body), matching Bruno's method-agnostic, body-mode-driven handling. So a body-carrying custom verb (e.g. `QUERY`) now sends its body.
- **Browser-rejected methods surface a clear error.** `fetch` forbids `CONNECT`/`TRACE`/`TRACK` and rejects invalid tokens (spaces/special chars). These are still enterable; when sent, the runner now classifies them as a dedicated `invalid-method` error ("Invalid HTTP method") — evaluated before the opaque-fetch-failure branch so Chrome's method `TypeError` (which also contains "fetch") isn't misread as a CORS/network failure.

## Tests
- **Unit** (`QueryBar.spec.tsx`, `methodColors.spec.ts`, `schemaHelpers.spec.ts`, `classifyRequestError.spec.ts`, `RequestExecutor.spec.ts`) — SSR-string assertions for the trigger label/color/testids and non-standard verb rendering; `normalizeHttpMethod` trim/strip/uppercase and forbidden-verb passthrough; `invalid-method` classification for `CONNECT`/`TRACE` including precedence over opaque-failure; body gate attaches for `QUERY`/POST/PUT/PATCH and excludes GET/HEAD.
- **E2E** (`query-bar-method.spec.ts`, POM) — reveal+focus, `purge`→`PURGE` commit, `pur ge`→`PURGE` internal-whitespace normalization, Escape cancel, empty-ignored, switch back to standard, lowercase→`PATCH` normalization.
