### PR TITLE
feat(oc-docs): Mobile view for playground

### DIFF
--- a/packages/oc-docs/e2e/components/playground.component.ts
+++ b/packages/oc-docs/e2e/components/playground.component.ts
@@ -32,6 +32,7 @@ export class PlaygroundComponent extends BaseComponent {
   readonly inlinePanel = this.page.getByTestId('playground-dock-inline-panel');
   readonly bottomPanel = this.page.getByTestId('playground-dock-bottom-panel');
   readonly modalPanel = this.page.getByTestId('playground-dock-modal-panel');
+  readonly mobilePanel = this.page.getByTestId('playground-dock-mobile-panel');
   readonly methodSelect = this.view.getByTestId('query-bar-method-select');
   readonly methodMenu = this.page.getByTestId('query-bar-method-select-dropdown');
   readonly methodOptionsList = this.methodMenu.getByRole('menuitem');

--- a/packages/oc-docs/e2e/tests/playground/playground-mobile.spec.ts
+++ b/packages/oc-docs/e2e/tests/playground/playground-mobile.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../../playwright';
+
+// A phone user agent flips useIsMobilePhone to true (it reads navigator.userAgent,
+// not the viewport). The viewport is set to a phone size for realism.
+const IPHONE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+test.describe('playground on a phone', () => {
+  test.use({ userAgent: IPHONE_UA, viewport: { width: 390, height: 844 } });
+
+  test('opens fullscreen with no dock switcher or collapse', async ({ page, playground }) => {
+    // The dock param is ignored on a phone; MobileDock renders instead.
+    await page.goto('/#/?pg=1&dock=bottom');
+    await expect(playground.mobilePanel).toBeVisible();
+    await expect(playground.runner).toBeVisible();
+    await expect(playground.switcher).toHaveCount(0);
+    await expect(playground.collapseButton).toHaveCount(0);
+    await expect(playground.sidebarToggle).toBeVisible();
+    await expect(playground.closeButton).toBeVisible();
+    // The desktop dock shells never mount on a phone.
+    await expect(playground.bottomPanel).toHaveCount(0);
+  });
+
+  test('sidebar is an overlay: starts closed, opens on toggle, closes on navigate', async ({ page, playground }) => {
+    await page.goto('/#/?pg=1&dock=bottom');
+    await expect(playground.mobilePanel).toBeVisible();
+    await expect(playground.sidebarPanel).toHaveCount(0);
+
+    await playground.sidebarToggle.click();
+    await expect(playground.sidebarPanel).toBeVisible();
+
+    // Opening the environments view is a navigate; the overlay sidebar closes.
+    await playground.gear.click();
+    await expect(playground.sidebarPanel).toHaveCount(0);
+  });
+
+  test('closes from the header and clears the url state', async ({ page, playground }) => {
+    await page.goto('/#/?pg=1&dock=bottom');
+    await expect(playground.mobilePanel).toBeVisible();
+
+    await playground.close();
+    await expect(playground.header).toHaveCount(0);
+    await expect(page).toHaveURL(/#\/$/);
+  });
+});

--- a/packages/oc-docs/e2e/tests/playground/playground-mobile.spec.ts
+++ b/packages/oc-docs/e2e/tests/playground/playground-mobile.spec.ts
@@ -5,12 +5,15 @@ import { test, expect } from '../../playwright';
 const IPHONE_UA =
   'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 
+// The dock param is ignored on a phone (MobileDock renders regardless); a
+// non-default dock is used here to prove it is overridden.
+const OPEN_ON_PHONE = '/#/?pg=1&dock=bottom';
+
 test.describe('playground on a phone', () => {
   test.use({ userAgent: IPHONE_UA, viewport: { width: 390, height: 844 } });
 
   test('opens fullscreen with no dock switcher or collapse', async ({ page, playground }) => {
-    // The dock param is ignored on a phone; MobileDock renders instead.
-    await page.goto('/#/?pg=1&dock=bottom');
+    await page.goto(OPEN_ON_PHONE);
     await expect(playground.mobilePanel).toBeVisible();
     await expect(playground.runner).toBeVisible();
     await expect(playground.switcher).toHaveCount(0);
@@ -22,7 +25,7 @@ test.describe('playground on a phone', () => {
   });
 
   test('sidebar is an overlay: starts closed, opens on toggle, closes on navigate', async ({ page, playground }) => {
-    await page.goto('/#/?pg=1&dock=bottom');
+    await page.goto(OPEN_ON_PHONE);
     await expect(playground.mobilePanel).toBeVisible();
     await expect(playground.sidebarPanel).toHaveCount(0);
 
@@ -35,7 +38,7 @@ test.describe('playground on a phone', () => {
   });
 
   test('closes from the header and clears the url state', async ({ page, playground }) => {
-    await page.goto('/#/?pg=1&dock=bottom');
+    await page.goto(OPEN_ON_PHONE);
     await expect(playground.mobilePanel).toBeVisible();
 
     await playground.close();

--- a/packages/oc-docs/src/components/Playground/Playground.tsx
+++ b/packages/oc-docs/src/components/Playground/Playground.tsx
@@ -1,10 +1,11 @@
 import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
-import { usePlaygroundUrlState } from '../../hooks';
+import { usePlaygroundUrlState, useIsMobilePhone } from '../../hooks';
 import { useAppDispatch } from '../../store/hooks';
 import { resetPlaygroundEnvironments } from '@slices/playground';
 import InlineDock from './docks/InlineDock/InlineDock';
 import BottomSheetDock from './docks/BottomSheetDock/BottomSheetDock';
 import ModalDock from './docks/ModalDock/ModalDock';
+import MobileDock from './docks/MobileDock/MobileDock';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 
 // Lazy so opening the dock shell never eagerly loads the runner/QuickJS runtime.
@@ -31,6 +32,11 @@ const playgroundLoadError = (
 const Playground: React.FC = () => {
   const dispatch = useAppDispatch();
   const { open, dock, requestSlug, setDock, closePlayground } = usePlaygroundUrlState();
+  const isPhone = useIsMobilePhone();
+  // On a phone the playground is always the fullscreen MobileDock, and its
+  // sidebar behaves like the inline dock's overlay. Feed that dock downstream so
+  // the sidebar-open default and PlaygroundBody's overlay behaviour follow.
+  const effectiveDock = isPhone ? 'inline' : dock;
 
   // discard environment edits when the playground reopens
   useEffect(() => {
@@ -39,10 +45,10 @@ const Playground: React.FC = () => {
   // In the inline dock the sidebar is an overlay over the request/response, so it
   // starts closed (content full width) and opens on demand; bottom/modal show it
   // side by side, so it starts open. Reset to the dock's default when the dock changes.
-  const [sidebarOpen, setSidebarOpen] = useState(dock !== 'inline');
+  const [sidebarOpen, setSidebarOpen] = useState(effectiveDock !== 'inline');
   useEffect(() => {
-    setSidebarOpen(dock !== 'inline');
-  }, [dock]);
+    setSidebarOpen(effectiveDock !== 'inline');
+  }, [effectiveDock]);
 
   // Tracks which request slug has been applied to the view. Lives here (not in
   // PlaygroundBody) because Playground stays mounted across a dock switch but
@@ -54,7 +60,7 @@ const Playground: React.FC = () => {
   if (!open) return null;
 
   const shared = {
-    dock,
+    dock: effectiveDock,
     onDockChange: setDock,
     onToggleSidebar: () => setSidebarOpen((value) => !value),
     onClose: closePlayground,
@@ -66,7 +72,7 @@ const Playground: React.FC = () => {
         <PlaygroundBody
           requestSlug={requestSlug}
           sidebarOpen={sidebarOpen}
-          dock={dock}
+          dock={effectiveDock}
           onCloseSidebar={() => setSidebarOpen(false)}
           appliedSlugRef={appliedSlugRef}
         />
@@ -74,6 +80,7 @@ const Playground: React.FC = () => {
     </ErrorBoundary>
   );
 
+  if (isPhone) return <MobileDock {...shared}>{body}</MobileDock>;
   if (dock === 'inline') return <InlineDock {...shared}>{body}</InlineDock>;
   if (dock === 'modal') return <ModalDock {...shared}>{body}</ModalDock>;
   return <BottomSheetDock {...shared}>{body}</BottomSheetDock>;

--- a/packages/oc-docs/src/components/Playground/PlaygroundHeader/PlaygroundHeader.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundHeader/PlaygroundHeader.spec.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect } from 'vitest';
+import PlaygroundHeader from './PlaygroundHeader';
+
+const noop = () => undefined;
+
+describe('PlaygroundHeader', () => {
+  it('renders the dock switcher by default', () => {
+    const html = renderToStaticMarkup(
+      <PlaygroundHeader dock="bottom" onDockChange={noop} onToggleSidebar={noop} onClose={noop} />
+    );
+    expect(html).toContain('playground-dock-switcher');
+    expect(html).toContain('playground-close');
+  });
+
+  it('hides the dock switcher when showDockSwitcher is false', () => {
+    const html = renderToStaticMarkup(
+      <PlaygroundHeader dock="bottom" onDockChange={noop} onToggleSidebar={noop} onClose={noop} showDockSwitcher={false} />
+    );
+    expect(html).not.toContain('playground-dock-switcher');
+    expect(html).toContain('playground-sidebar-toggle');
+    expect(html).toContain('playground-close');
+  });
+});

--- a/packages/oc-docs/src/components/Playground/PlaygroundHeader/PlaygroundHeader.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundHeader/PlaygroundHeader.tsx
@@ -8,6 +8,7 @@ import { StyledWrapper } from './StyledWrapper';
 interface PlaygroundHeaderProps {
   dock: DockMode;
   onDockChange: (dock: DockMode) => void;
+  showDockSwitcher?: boolean;
   onToggleSidebar: () => void;
   onClose: () => void;
   collapsed?: boolean;
@@ -18,6 +19,7 @@ interface PlaygroundHeaderProps {
 const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({
   dock,
   onDockChange,
+  showDockSwitcher = true,
   onToggleSidebar,
   onClose,
   collapsed,
@@ -41,7 +43,7 @@ const PlaygroundHeader: React.FC<PlaygroundHeaderProps> = ({
       </span>
     </div>
     <div className="header-right">
-      <DockSwitcher dock={dock} onDockChange={onDockChange} />
+      {showDockSwitcher && <DockSwitcher dock={dock} onDockChange={onDockChange} />}
       {onToggleCollapse && (
         <IconButton
           className={`header-collapse${collapsed ? ' collapsed' : ''}`}

--- a/packages/oc-docs/src/components/Playground/docks/MobileDock/MobileDock.tsx
+++ b/packages/oc-docs/src/components/Playground/docks/MobileDock/MobileDock.tsx
@@ -20,7 +20,7 @@ const MobileDock: React.FC<MobileDockProps> = ({ dock, onDockChange, onToggleSid
 
   return (
     <Portal>
-      <StyledWrapper data-testid="playground-dock-mobile-panel">
+      <StyledWrapper data-testid="playground-dock-mobile-panel" role="dialog" aria-modal="true" aria-label="Bruno Playground">
         <PlaygroundHeader
           dock={dock}
           onDockChange={onDockChange}

--- a/packages/oc-docs/src/components/Playground/docks/MobileDock/MobileDock.tsx
+++ b/packages/oc-docs/src/components/Playground/docks/MobileDock/MobileDock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Portal from '../../../../ui/Portal/Portal';
 import PlaygroundHeader from '../../PlaygroundHeader/PlaygroundHeader';
-import { useEscapeKey, useLockBodyScroll } from '../../../../hooks';
+import { useLockBodyScroll } from '../../../../hooks';
 import type { DockMode } from '../../../../utils/playgroundDock';
 import { StyledWrapper } from './StyledWrapper';
 
@@ -14,11 +14,9 @@ interface MobileDockProps {
 }
 
 const MobileDock: React.FC<MobileDockProps> = ({ dock, onDockChange, onToggleSidebar, onClose, children }) => {
-  // Full-screen phone presentation: lock the docs scroll behind it and close on
-  // Escape, like the modal dock. No dock switcher or collapse - there is nowhere
-  // to dock on a phone.
+  // Full-screen phone presentation: lock the docs scroll behind it. No dock
+  // switcher or collapse - there is nowhere to dock on a phone.
   useLockBodyScroll();
-  useEscapeKey(onClose);
 
   return (
     <Portal>

--- a/packages/oc-docs/src/components/Playground/docks/MobileDock/MobileDock.tsx
+++ b/packages/oc-docs/src/components/Playground/docks/MobileDock/MobileDock.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Portal from '../../../../ui/Portal/Portal';
+import PlaygroundHeader from '../../PlaygroundHeader/PlaygroundHeader';
+import { useEscapeKey, useLockBodyScroll } from '../../../../hooks';
+import type { DockMode } from '../../../../utils/playgroundDock';
+import { StyledWrapper } from './StyledWrapper';
+
+interface MobileDockProps {
+  dock: DockMode;
+  onDockChange: (dock: DockMode) => void;
+  onToggleSidebar: () => void;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const MobileDock: React.FC<MobileDockProps> = ({ dock, onDockChange, onToggleSidebar, onClose, children }) => {
+  // Full-screen phone presentation: lock the docs scroll behind it and close on
+  // Escape, like the modal dock. No dock switcher or collapse - there is nowhere
+  // to dock on a phone.
+  useLockBodyScroll();
+  useEscapeKey(onClose);
+
+  return (
+    <Portal>
+      <StyledWrapper data-testid="playground-dock-mobile-panel">
+        <PlaygroundHeader
+          dock={dock}
+          onDockChange={onDockChange}
+          onToggleSidebar={onToggleSidebar}
+          onClose={onClose}
+          showDockSwitcher={false}
+        />
+        <div className="mobile-content" data-testid="playground-content">
+          {children}
+        </div>
+      </StyledWrapper>
+    </Portal>
+  );
+};
+
+export default MobileDock;

--- a/packages/oc-docs/src/components/Playground/docks/MobileDock/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/docks/MobileDock/StyledWrapper.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay);
+  display: flex;
+  flex-direction: column;
+  background-color: var(--oc-background-base);
+
+  .mobile-content {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+  }
+`;

--- a/packages/oc-docs/src/hooks/index.ts
+++ b/packages/oc-docs/src/hooks/index.ts
@@ -9,7 +9,9 @@ export {
   useCanRunBrunoApp,
   computeCanRunBrunoApp,
   computeIsMobileOS,
+  computeIsMobilePhone,
   useIsMobileDevice,
+  useIsMobilePhone,
   type DeviceEnv,
 } from './useCanRunBrunoApp';
 export { useSearchHotkey } from './useSearchHotkey';

--- a/packages/oc-docs/src/hooks/useCanRunBrunoApp.spec.ts
+++ b/packages/oc-docs/src/hooks/useCanRunBrunoApp.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeCanRunBrunoApp, computeIsMobileOS, type DeviceEnv } from './useCanRunBrunoApp';
+import { computeCanRunBrunoApp, computeIsMobileOS, computeIsMobilePhone, type DeviceEnv } from './useCanRunBrunoApp';
 
 const base: DeviceEnv = {
   anyHoverFine: true,
@@ -101,5 +101,39 @@ describe('computeIsMobileOS', () => {
   it('does not depend on viewport width (a narrow desktop window is still not mobile)', () => {
     // Same desktop env regardless of window size -> always false.
     expect(computeIsMobileOS(base)).toBe(false);
+  });
+});
+
+describe('computeIsMobilePhone', () => {
+  it('is true for an iPhone', () => {
+    expect(
+      computeIsMobilePhone({ ...base, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148', platform: 'iPhone', maxTouchPoints: 5 })
+    ).toBe(true);
+  });
+
+  it('is true for an Android phone (carries the Mobile token)', () => {
+    expect(
+      computeIsMobilePhone({ ...base, userAgent: 'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36', platform: 'Linux armv8l', maxTouchPoints: 5 })
+    ).toBe(true);
+  });
+
+  it('is false for an Android tablet (no Mobile token)', () => {
+    expect(
+      computeIsMobilePhone({ ...base, userAgent: 'Mozilla/5.0 (Linux; Android 13; SM-X700) AppleWebKit/537.36 Chrome/120 Safari/537.36', platform: 'Linux armv8l', maxTouchPoints: 5 })
+    ).toBe(false);
+  });
+
+  it('is false for an iPad reporting iPad in the UA', () => {
+    expect(
+      computeIsMobilePhone({ ...base, userAgent: 'Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) Safari/604', platform: 'iPad', maxTouchPoints: 5 })
+    ).toBe(false);
+  });
+
+  it('is false for an iPad masquerading as MacIntel with touch points', () => {
+    expect(computeIsMobilePhone({ ...base, maxTouchPoints: 5 })).toBe(false);
+  });
+
+  it('is false for a real desktop', () => {
+    expect(computeIsMobilePhone(base)).toBe(false);
   });
 });

--- a/packages/oc-docs/src/hooks/useCanRunBrunoApp.ts
+++ b/packages/oc-docs/src/hooks/useCanRunBrunoApp.ts
@@ -20,6 +20,18 @@ export const computeIsMobileOS = ({ userAgent, platform, maxTouchPoints }: Devic
   (platform === 'MacIntel' && maxTouchPoints > 1);
 
 /**
+ * True only on a phone OS, deliberately narrower than computeIsMobileOS: an
+ * Android phone carries the `Mobile` token where a tablet does not, and iPad is
+ * excluded entirely (both the `iPad` UA and the iPadOS-as-`MacIntel` case). Used
+ * to switch on the phone-only fullscreen playground; a tablet keeps the desktop
+ * docks. Pure so it can be unit tested against a device matrix without a DOM.
+ */
+export const computeIsMobilePhone = ({ userAgent }: DeviceEnv): boolean =>
+  /iPhone|iPod/.test(userAgent) ||
+  (/Android/.test(userAgent) && /Mobile/.test(userAgent)) ||
+  /Windows Phone/.test(userAgent);
+
+/**
  * Whether this device can plausibly run the Bruno desktop app, the gate for
  * showing the Open-in-Bruno CTA. Viewport width is the wrong signal (iPad Pro is
  * 1024-1366px wide), so we look at input capability instead: require a fine,
@@ -75,4 +87,16 @@ export const useIsMobileDevice = (): boolean => {
     typeof window === 'undefined' ? false : computeIsMobileOS(readDeviceEnv())
   );
   return isMobile;
+};
+
+/**
+ * True only on a phone, whatever the window size. The device can't change
+ * mid-session, so it's checked once (safe to `false` with no window). Use this,
+ * not a width breakpoint, so a narrow laptop window is never treated as a phone.
+ */
+export const useIsMobilePhone = (): boolean => {
+  const [isPhone] = useState(() =>
+    typeof window === 'undefined' ? false : computeIsMobilePhone(readDeviceEnv())
+  );
+  return isPhone;
 };


### PR DESCRIPTION
Adapts the request playground for phones. Desktop and tablet are unchanged (all three docks).
JIRA : BRU-2547

- On a phone, opening the playground (Try it or a deep link) fills the whole screen instead of docking.
- The header shows only the sidebar toggle, brand, and close, no view switcher and no collapse button.
- The sidebar opens as an overlay: starts closed, opens from the toggle, and closes once you pick an item.
- Detection is device based (phone user agent), not viewport width, so a narrow laptop window keeps the docks.
- Covered by unit tests (phone detection matrix, header) and Playwright e2e (fullscreen open, hidden controls, overlay sidebar).