### PR TITLE
fix(oc-docs): env page value tooltip + multiline values (BRU-3790)

### DIFF
--- a/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.css
+++ b/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.css
@@ -212,6 +212,11 @@
   min-width: 0;
 }
 
+.key-value-table .value-input-tip {
+  display: block;
+  min-width: 0;
+}
+
 .key-value-table .value-cell-trailing {
   flex: none;
   display: flex;

--- a/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.tsx
+++ b/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.tsx
@@ -48,6 +48,11 @@ interface KeyValueTableProps {
   testId?: string;
 }
 
+const valueTruncated = (anchor: HTMLElement): boolean => {
+  const field = anchor.querySelector<HTMLElement>('input, textarea');
+  return !!field && (field.scrollWidth > field.clientWidth || field.scrollHeight > field.clientHeight);
+};
+
 const KeyValueTable: React.FC<KeyValueTableProps> = ({
   data,
   onChange,
@@ -140,6 +145,29 @@ const KeyValueTable: React.FC<KeyValueTableProps> = ({
                 </button>
               );
 
+              const valueField = row.secret ? (
+                <SecretValue
+                  value={row.value}
+                  placeholder={valuePlaceholder}
+                  onChange={(v) => updateField(index, 'value', v)}
+                />
+              ) : (
+                <Tooltip content={row.value} shouldOpen={valueTruncated}>
+                  <span className="value-input-tip">
+                    <HighlightedInput
+                      value={row.value}
+                      placeholder={isLastEmptyRow ? valuePlaceholder : ''}
+                      onValueChange={(v) => updateField(index, 'value', v)}
+                      isFound={isFound}
+                      names={names}
+                      anywordHints={valueAutocomplete}
+                      multiline={multilineValues}
+                      testId={`${testId}-value-input`}
+                    />
+                  </span>
+                </Tooltip>
+              );
+
               return (
                 <tr key={row.id} className={isLastEmptyRow ? 'empty-row' : ''}>
                   <td className="col-key">
@@ -180,27 +208,7 @@ const KeyValueTable: React.FC<KeyValueTableProps> = ({
                   <td className="col-value">
                     {inlineActions ? (
                       <div className="value-cell">
-                        <div className="value-cell-field">
-                          {row.secret ? (
-                            <SecretValue
-                              value={row.value}
-                              placeholder={valuePlaceholder}
-                              onChange={(v) => updateField(index, 'value', v)}
-                            />
-                          ) : (
-                            <HighlightedInput
-                              value={row.value}
-                              placeholder={isLastEmptyRow ? valuePlaceholder : ''}
-                              onValueChange={(v) => updateField(index, 'value', v)}
-                              isFound={isFound}
-                              names={names}
-                              anywordHints={valueAutocomplete}
-                              multiline={multilineValues}
-                              title={row.value}
-                              testId={`${testId}-value-input`}
-                            />
-                          )}
-                        </div>
+                        <div className="value-cell-field">{valueField}</div>
                         {!isLastEmptyRow && cellError(row, index, 'value')}
                         {!isLastEmptyRow && (
                           <div className="value-cell-trailing">
@@ -211,24 +219,8 @@ const KeyValueTable: React.FC<KeyValueTableProps> = ({
                           </div>
                         )}
                       </div>
-                    ) : row.secret ? (
-                      <SecretValue
-                        value={row.value}
-                        placeholder={valuePlaceholder}
-                        onChange={(v) => updateField(index, 'value', v)}
-                      />
                     ) : (
-                      <HighlightedInput
-                        value={row.value}
-                        placeholder={isLastEmptyRow ? valuePlaceholder : ''}
-                        onValueChange={(v) => updateField(index, 'value', v)}
-                        isFound={isFound}
-                        names={names}
-                        anywordHints={valueAutocomplete}
-                        multiline={multilineValues}
-                        title={row.value}
-                        testId={`${testId}-value-input`}
-                      />
+                      valueField
                     )}
                   </td>
                   {!inlineActions &&

--- a/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvironmentsView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvironmentsView.tsx
@@ -147,6 +147,7 @@ const EnvironmentsView: React.FC<EnvironmentsViewProps> = ({ collection, compact
         keyPlaceholder="Name"
         valuePlaceholder="Value"
         showEnabled={true}
+        multilineValues
         disableNewRow={disableNewRow}
         makeNewRow={makeNewRow}
         addWhenComplete

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -5,6 +5,8 @@ import MenuDropdown from '../../../../../../ui/MenuDropdown';
 import { getHttpMethod, getRequestUrl, getHttpParams } from '../../../../../../utils/schemaHelpers';
 import { syncPathParams, syncQueryParams } from '../../../../../../utils/pathParams';
 import { availableMethods, getMethodColorVar } from '../../../../../../theme/methodColors';
+import { MethodBadge } from '../../../../../MethodBadge/MethodBadge';
+import { CopyButton } from '../../../../../../ui/CopyButton/CopyButton';
 
 interface QueryBarProps {
   item: HttpRequest;
@@ -52,12 +54,7 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
   };
 
   return (
-    <StyledWrapper
-      className="flex items-stretch"
-      style={{
-        height: '36px'
-      }}
-    >
+    <StyledWrapper className="flex items-center">
       <div className="method-select-wrapper">
         <MenuDropdown
           selectedItemId={method}
@@ -70,13 +67,8 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
             onClick: () => handleMethodChange(m)
           }))}
         >
-          <button
-            type="button"
-            className="method-select h-full"
-            aria-label="HTTP method"
-            style={{ color: getMethodColorVar(method) }}
-          >
-            {method}
+          <button type="button" className="method-select" aria-label="HTTP method">
+            <MethodBadge method={method} />
           </button>
         </MenuDropdown>
       </div>
@@ -99,16 +91,20 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
         }}
       />
 
-      <button
-        onClick={onSendRequest}
-        disabled={isLoading || !url.trim()}
-        className="send px-4 uppercase text-xs font-semibold text-white disabled:cursor-not-allowed flex items-center gap-2 transition-all"
-      >
-        {isLoading && (
-          <div className="w-2.5 h-2.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-        )}
-        {isLoading ? 'Sending' : 'Send'}
-      </button>
+      <div className="actions">
+        <CopyButton text={url} label="Copy URL" copiedLabel="Copied" testId="query-bar-copy-url" />
+        <button
+          type="button"
+          onClick={onSendRequest}
+          disabled={isLoading || !url.trim()}
+          className="send font-semibold text-white disabled:cursor-not-allowed flex items-center gap-2 transition-all"
+        >
+          {isLoading && (
+            <div className="w-2.5 h-2.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+          )}
+          {isLoading ? 'Sending' : 'Send'}
+        </button>
+      </div>
     </StyledWrapper>
   );
 };

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
 
 export const StyledWrapper = styled.div`
+  gap: 0.5rem;
+  padding: 0.25rem 0.375rem;
   border: 1px solid var(--border-color);
   border-radius: var(--oc-radius);
-  overflow: hidden;
-  transition: border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1), 
+  transition: border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
               box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   background-color: var(--bg-primary);
 
@@ -21,17 +22,17 @@ export const StyledWrapper = styled.div`
     border-radius: 0;
     border: none;
     transition: background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    
+
     &::placeholder {
       color: var(--text-secondary);
       opacity: 0.6;
       transition: opacity 0.2s ease;
     }
-    
+
     &:focus::placeholder {
       opacity: 0.45;
     }
-    
+
     &:focus {
       background-color: color-mix(in srgb, var(--oc-text) 1%, transparent);
     }
@@ -41,6 +42,7 @@ export const StyledWrapper = styled.div`
     position: relative;
     display: flex;
     align-items: center;
+    padding-left: 0.375rem;
   }
 
   .method-select {
@@ -48,40 +50,40 @@ export const StyledWrapper = styled.div`
     display: inline-flex;
     align-items: center;
     margin: 0;
-    font-family: inherit;
-    line-height: 1;
     background-color: transparent;
     border: none;
     outline: none;
     cursor: pointer;
-    padding: 0 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
+    padding: 0;
+  }
+
+  .method-badge {
+    padding: 0.125rem 0.5rem;
+    border-radius: var(--oc-radius);
+    background-color: color-mix(in srgb, currentColor 12%, transparent);
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
   }
 
   button.send {
+    height: 1.75rem;
+    padding: 0 0.875rem;
+    border-radius: var(--oc-radius);
     background-color: var(--primary-color);
     font-size: 11px;
     font-weight: 600;
     letter-spacing: 0.01em;
     transition: background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
-    
-    &::before {
-      content: '';
-      position: absolute;
-      left: 0;
-      top: 0;
-      bottom: 0;
-      width: 1px;
-      background: color-mix(in srgb, var(--oc-text) 8%, transparent);
-    }
 
     &:hover:not(:disabled) {
       background-color: color-mix(in srgb, var(--oc-brand) 85%, black);
     }
-    
+
     &:disabled {
       opacity: 0.5;
       cursor: not-allowed;


### PR DESCRIPTION
QA fixes for the environments page (BRU-3790).
- uses the shared themed `Tooltip` 
- Env variable values render multiline were clipped

Re-adds the request query bar's method pill + copy-URL button. These were part of #117 but got dropped when it rebased
