### PR TITLE
fix(size/S):Removed two auth modes from auth options and fixed scroll issue in the playground

### DIFF
--- a/packages/oc-docs/e2e/components/collection-settings/collection-settings.component.ts
+++ b/packages/oc-docs/e2e/components/collection-settings/collection-settings.component.ts
@@ -22,6 +22,11 @@ export class CollectionSettingsComponent extends BaseComponent {
     return this.view.getByTestId(`auth-${name}`);
   }
 
+  /** An option inside the (opened) auth-mode dropdown. */
+  authModeOption(value: string): Locator {
+    return this.page.getByTestId(`auth-mode-select-${value}`);
+  }
+
   async open(): Promise<void> {
     await this.collectionNode.click();
   }

--- a/packages/oc-docs/e2e/tests/collection-settings/collection-settings.spec.ts
+++ b/packages/oc-docs/e2e/tests/collection-settings/collection-settings.spec.ts
@@ -42,7 +42,7 @@ test.describe('collection settings', () => {
     await expect(collectionSettings.authField('password')).toHaveAttribute('type', 'password');
   });
 
-  test('bearer, api key, and digest render their fields', async ({ collectionSettings }) => {
+  test('bearer and api key render their fields', async ({ collectionSettings }) => {
     await collectionSettings.openTab('auth');
 
     await collectionSettings.selectAuthMode('bearer');
@@ -52,28 +52,15 @@ test.describe('collection settings', () => {
     await expect(collectionSettings.authField('key')).toBeVisible();
     await expect(collectionSettings.authField('value')).toHaveAttribute('type', 'text');
     await expect(collectionSettings.authField('placement')).toBeVisible();
-
-    await collectionSettings.selectAuthMode('digest');
-    await expect(collectionSettings.authField('username')).toBeVisible();
-    await expect(collectionSettings.authField('password')).toHaveAttribute('type', 'password');
   });
 
-  test('aws signature v4 shows all six fields and reveals only the secret access key', async ({
-    collectionSettings
-  }) => {
+  test('does not offer Digest or AWS Signature v4 as selectable auth modes', async ({ collectionSettings }) => {
     await collectionSettings.openTab('auth');
-    await collectionSettings.selectAuthMode('awsv4');
+    await collectionSettings.authMode.click();
 
-    for (const field of ['accessKeyId', 'secretAccessKey', 'sessionToken', 'service', 'region', 'profileName']) {
-      await expect(collectionSettings.authField(field)).toBeVisible();
-    }
-
-    const secret = collectionSettings.authField('secretAccessKey');
-    await expect(secret).toHaveAttribute('type', 'password');
-    await collectionSettings.authField('secretAccessKey-toggle').click();
-    await expect(secret).toHaveAttribute('type', 'text');
-
-    await expect(collectionSettings.authField('accessKeyId')).toHaveAttribute('type', 'text');
+    await expect(collectionSettings.authModeOption('basic')).toBeVisible();
+    await expect(collectionSettings.authModeOption('digest')).toHaveCount(0);
+    await expect(collectionSettings.authModeOption('awsv4')).toHaveCount(0);
   });
 
   test('scripts shows pre-request and post-response editors', async ({ collectionSettings }) => {

--- a/packages/oc-docs/src/components/Playground/Content/Views/CollectionSettingsView/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/CollectionSettingsView/StyledWrapper.ts
@@ -30,7 +30,8 @@ export const StyledWrapper = styled.div`
 
   .collection-settings-tabs {
     flex: 1;
-    overflow: hidden;
+    min-height: 0;
+    overflow-y: auto;
     margin-top: 1.25rem;
 
     .tabs {

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.spec.tsx
@@ -24,10 +24,10 @@ const renderAuth = (auth: unknown, extra: Record<string, unknown> = {}) =>
   render(<AuthTab auth={auth} onAuthChange={noop} showFullAuth item={{ request: {} }} onItemChange={noop} {...extra} />);
 
 describe('AuthTab', () => {
-  it('offers exactly the six supported auth types and none of the unsupported ones', () => {
+  it('offers exactly the four supported auth types and none of the unsupported ones', () => {
     const modeLabels = ['No Auth', ...Object.keys(AUTH_DEFAULTS).map((mode) => AUTH_MODE_LABELS[mode] ?? mode)];
-    expect(modeLabels).toEqual(['No Auth', 'Basic Auth', 'Bearer Token', 'API Key', 'Digest Auth', 'AWS Signature v4']);
-    ['oauth', 'wsse', 'ntlm', 'edgegrid', 'akamai'].forEach((excluded) =>
+    expect(modeLabels).toEqual(['No Auth', 'Basic Auth', 'Bearer Token', 'API Key']);
+    ['digest', 'aws', 'signature', 'oauth', 'wsse', 'ntlm', 'edgegrid', 'akamai'].forEach((excluded) =>
       expect(modeLabels.join(' ').toLowerCase()).not.toContain(excluded)
     );
   });

--- a/packages/oc-docs/src/components/Playground/Content/Views/FolderSettingsView/FolderSettingsView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/FolderSettingsView/FolderSettingsView.tsx
@@ -224,7 +224,7 @@ const FolderSettings: React.FC<FolderSettingsProps> = ({ folder, onFolderChange 
         </h2>
       </div>
 
-      <div className="flex-1 overflow-hidden mt-4">
+      <div className="flex-1 min-h-0 overflow-y-auto mt-4">
         <Tabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
       </div>
     </div>

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -263,7 +263,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
   ];
 
   return (
-    <div className="h-full" style={{ backgroundColor: 'var(--bg-primary)' }}>
+    <div className="h-full overflow-y-auto" style={{ backgroundColor: 'var(--bg-primary)' }}>
       <Tabs
         tabs={tabs}
         activeTab={activeTab}

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
@@ -4,6 +4,7 @@ import ResponseBodyTab from '../../Common/ResponseBodyTab';
 import ResponseHeadersTab from '../../Common/ResponseHeadersTab';
 import TestResultsTab from '../../Common/TestResultsTab';
 import ErrorBanner from '../../../../../../ui/ErrorBanner/ErrorBanner';
+import { StyledWrapper } from './StyledWrapper';
 
 interface ResponsePaneProps {
   response: any;
@@ -131,7 +132,7 @@ const ResponsePane: React.FC<ResponsePaneProps> = ({ response, isLoading }) => {
   );
 
   return (
-    <div className="h-full" style={{ backgroundColor: 'var(--bg-primary)' }}>
+    <StyledWrapper>
       <Tabs
         className='h-full'
         tabs={tabs}
@@ -139,7 +140,7 @@ const ResponsePane: React.FC<ResponsePaneProps> = ({ response, isLoading }) => {
         onTabChange={setActiveTab}
         rightElement={response.error ? undefined : statusInfo}
       />
-    </div>
+    </StyledWrapper>
   );
 };
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/StyledWrapper.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  height: 100%;
+  min-height: 0;
+  background-color: var(--bg-primary);
+
+  .tab-panel {
+    min-height: 0;
+    overflow-y: auto;
+  }
+`;

--- a/packages/oc-docs/src/constants/auth.ts
+++ b/packages/oc-docs/src/constants/auth.ts
@@ -37,21 +37,10 @@ export const ADDITIONAL_PARAM_GROUPS: Array<{
   { key: 'refreshTokenRequest', label: 'Refresh Token Request' }
 ];
 
-/** Blank field sets seeded when switching an item to a given auth mode. */
 export const AUTH_DEFAULTS: Record<string, Record<string, string>> = {
   basic: { type: 'basic', username: '', password: '' },
   bearer: { type: 'bearer', token: '' },
-  apikey: { type: 'apikey', key: '', value: '', placement: 'header' },
-  digest: { type: 'digest', username: '', password: '' },
-  awsv4: {
-    type: 'awsv4',
-    accessKeyId: '',
-    secretAccessKey: '',
-    sessionToken: '',
-    service: '',
-    region: '',
-    profileName: ''
-  }
+  apikey: { type: 'apikey', key: '', value: '', placement: 'header' }
 };
 
 /** Where an API-key credential is sent. */


### PR DESCRIPTION
Fixes:
1. Removed two auth modes from auth options - AWS Signature V4, Digest Auth
2. Fixed scroll issue in the playground

BRU - 3791

<img width="2836" height="1492" alt="image" src="https://github.com/user-attachments/assets/ba061f45-1bad-480f-b95b-79ac62e20f57" />
