### PR TITLE
fix(oc-docs): cap menu dropdown height so long lists scroll

### DIFF
--- a/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
@@ -16,7 +16,10 @@ export const StyledWrapper = styled.div`
   box-shadow: var(--oc-dropdown-shadow);
   border-radius: var(--oc-border-radius-base);
   border: 1px solid var(--oc-dropdown-border);
-  max-height: 90vh;
+  /* Cap the surface height so a long list (e.g. the assertion operators) scrolls
+     instead of spilling past the embedded component; min() keeps it within small
+     viewports too. */
+  max-height: min(20rem, 90vh);
   overflow-y: auto;
   max-width: unset !important;
   padding: 0.25rem;


### PR DESCRIPTION
## Problem

Opening the operator dropdown in the assertions table (playground) renders all 28 options at full height. The shared `MenuDropdown` surface was capped at `max-height: 90vh`, but `vh` is the **browser viewport** height, not the embedded OpenCollection component's height — so the list spilled well past the app area.

### Before

<img width="2987" height="1609" alt="image" src="https://github.com/user-attachments/assets/357a4431-7efc-40e8-b018-ec70278367d4" />

### After

<img width="3001" height="1580" alt="image" src="https://github.com/user-attachments/assets/c9193f5f-ef63-4c02-bbcf-8db64ef6233b" />
<img width="3008" height="1663" alt="image" src="https://github.com/user-attachments/assets/6dee939c-aa15-4faa-a6b8-e4a10d09f0fd" />



## Fix

Cap the dropdown surface at `min(20rem, 90vh)` so a long list scrolls inside the popover instead of overflowing. `20rem` shows ~12 items; `min(…, 90vh)` keeps it safe on small viewports. Short-list dropdowns (env switcher, body-mode, query bar, select) never reach the cap, so they're unaffected.

Change is a single CSS line in `src/ui/MenuDropdown/StyledWrapper.ts`.

## Testing

- `npm run lint` — no new problems (identical count vs. main)
- `npm run test:run` — all MenuDropdown/AssertsTab unit tests pass