### PR TITLE
feat(oc-docs): resizable, collapsible docs and playground sidebars

### DIFF
--- a/packages/oc-docs/e2e/components/base.component.ts
+++ b/packages/oc-docs/e2e/components/base.component.ts
@@ -2,8 +2,26 @@ import type { Page, Locator } from '@playwright/test';
 
 export abstract class BaseComponent {
   readonly root: Locator;
+  private dragY = 0;
 
   constructor(protected readonly page: Page, root?: Locator) {
     this.root = root ?? page.locator(':root');
+  }
+
+  /** Press the pointer on a resize handle; the drag y is kept for later moves. */
+  protected async grabHandle(handle: Locator): Promise<void> {
+    const box = await handle.boundingBox();
+    this.dragY = (box?.y ?? 0) + (box?.height ?? 0) / 2;
+    await handle.hover();
+    await this.page.mouse.down();
+  }
+
+  /** Move the held pointer to an absolute x (keeps the grabbed y). */
+  async movePointerToX(x: number): Promise<void> {
+    await this.page.mouse.move(x, this.dragY, { steps: 10 });
+  }
+
+  async releasePointer(): Promise<void> {
+    await this.page.mouse.up();
   }
 }

--- a/packages/oc-docs/e2e/components/playground.component.ts
+++ b/packages/oc-docs/e2e/components/playground.component.ts
@@ -16,7 +16,6 @@ export class PlaygroundComponent extends BaseComponent {
   readonly loadError = this.page.getByTestId('playground-load-error');
   readonly sidebarPanel = this.page.getByTestId('playground-sidebar-panel');
   readonly sidebarResizer = this.page.getByTestId('playground-sidebar-resizer');
-  private dragY = 0;
   readonly sidebarBackdrop = this.page.getByTestId('playground-sidebar-backdrop');
   readonly collectionNode = this.page.getByTestId('sidebar-collection-root');
   readonly collectionCollapseToggle = this.collectionNode.getByRole('button', {
@@ -129,20 +128,7 @@ export class PlaygroundComponent extends BaseComponent {
     return box?.width ?? 0;
   }
 
-  /** Press the pointer on the resize handle; the drag y is kept for later moves. */
   async grabSidebarResizer(): Promise<void> {
-    const box = await this.sidebarResizer.boundingBox();
-    this.dragY = (box?.y ?? 0) + (box?.height ?? 0) / 2;
-    await this.sidebarResizer.hover();
-    await this.page.mouse.down();
-  }
-
-  /** Move the held pointer to an absolute x (keeps the grabbed y). */
-  async movePointerToX(x: number): Promise<void> {
-    await this.page.mouse.move(x, this.dragY, { steps: 10 });
-  }
-
-  async releasePointer(): Promise<void> {
-    await this.page.mouse.up();
+    await this.grabHandle(this.sidebarResizer);
   }
 }

--- a/packages/oc-docs/e2e/components/playground.component.ts
+++ b/packages/oc-docs/e2e/components/playground.component.ts
@@ -15,6 +15,8 @@ export class PlaygroundComponent extends BaseComponent {
   readonly runner = this.page.getByTestId('playground-runner');
   readonly loadError = this.page.getByTestId('playground-load-error');
   readonly sidebarPanel = this.page.getByTestId('playground-sidebar-panel');
+  readonly sidebarResizer = this.page.getByTestId('playground-sidebar-resizer');
+  private dragY = 0;
   readonly sidebarBackdrop = this.page.getByTestId('playground-sidebar-backdrop');
   readonly collectionNode = this.page.getByTestId('sidebar-collection-root');
   readonly collectionCollapseToggle = this.collectionNode.getByRole('button', {
@@ -120,5 +122,27 @@ export class PlaygroundComponent extends BaseComponent {
 
   async toggleCollapse(): Promise<void> {
     await this.collapseButton.click();
+  }
+
+  async sidebarWidth(): Promise<number> {
+    const box = await this.sidebarPanel.boundingBox();
+    return box?.width ?? 0;
+  }
+
+  /** Press the pointer on the resize handle; the drag y is kept for later moves. */
+  async grabSidebarResizer(): Promise<void> {
+    const box = await this.sidebarResizer.boundingBox();
+    this.dragY = (box?.y ?? 0) + (box?.height ?? 0) / 2;
+    await this.sidebarResizer.hover();
+    await this.page.mouse.down();
+  }
+
+  /** Move the held pointer to an absolute x (keeps the grabbed y). */
+  async movePointerToX(x: number): Promise<void> {
+    await this.page.mouse.move(x, this.dragY, { steps: 10 });
+  }
+
+  async releasePointer(): Promise<void> {
+    await this.page.mouse.up();
   }
 }

--- a/packages/oc-docs/e2e/components/sidebar.component.ts
+++ b/packages/oc-docs/e2e/components/sidebar.component.ts
@@ -9,7 +9,6 @@ export class SidebarComponent extends BaseComponent {
   readonly collapseButton = this.page.getByTestId('sidebar-collapse');
   readonly expandButton = this.page.getByTestId('sidebar-expand');
   readonly resizer = this.page.getByTestId('sidebar-resizer');
-  private dragY = 0;
   readonly drawer = this.page.getByTestId('sidebar-drawer');
   readonly backdrop = this.page.getByTestId('sidebar-backdrop');
   readonly hamburger = this.page.getByTestId('topbar-menu');
@@ -49,21 +48,8 @@ export class SidebarComponent extends BaseComponent {
     return box?.width ?? 0;
   }
 
-  /** Press the pointer on the resize handle; the drag y is kept for later moves. */
   async grabResizer(): Promise<void> {
-    const box = await this.resizer.boundingBox();
-    this.dragY = (box?.y ?? 0) + (box?.height ?? 0) / 2;
-    await this.resizer.hover();
-    await this.page.mouse.down();
-  }
-
-  /** Move the held pointer to an absolute x (keeps the grabbed y). */
-  async movePointerToX(x: number): Promise<void> {
-    await this.page.mouse.move(x, this.dragY, { steps: 10 });
-  }
-
-  async releasePointer(): Promise<void> {
-    await this.page.mouse.up();
+    await this.grabHandle(this.resizer);
   }
 
   async collapse(): Promise<void> {

--- a/packages/oc-docs/e2e/components/sidebar.component.ts
+++ b/packages/oc-docs/e2e/components/sidebar.component.ts
@@ -8,6 +8,8 @@ export class SidebarComponent extends BaseComponent {
   readonly environments = this.page.getByTestId('sidebar-environments');
   readonly collapseButton = this.page.getByTestId('sidebar-collapse');
   readonly expandButton = this.page.getByTestId('sidebar-expand');
+  readonly resizer = this.page.getByTestId('sidebar-resizer');
+  private dragY = 0;
   readonly drawer = this.page.getByTestId('sidebar-drawer');
   readonly backdrop = this.page.getByTestId('sidebar-backdrop');
   readonly hamburger = this.page.getByTestId('topbar-menu');
@@ -40,6 +42,28 @@ export class SidebarComponent extends BaseComponent {
     for (const name of paths) {
       await this.item(name).first().click();
     }
+  }
+
+  async width(): Promise<number> {
+    const box = await this.inline.boundingBox();
+    return box?.width ?? 0;
+  }
+
+  /** Press the pointer on the resize handle; the drag y is kept for later moves. */
+  async grabResizer(): Promise<void> {
+    const box = await this.resizer.boundingBox();
+    this.dragY = (box?.y ?? 0) + (box?.height ?? 0) / 2;
+    await this.resizer.hover();
+    await this.page.mouse.down();
+  }
+
+  /** Move the held pointer to an absolute x (keeps the grabbed y). */
+  async movePointerToX(x: number): Promise<void> {
+    await this.page.mouse.move(x, this.dragY, { steps: 10 });
+  }
+
+  async releasePointer(): Promise<void> {
+    await this.page.mouse.up();
   }
 
   async collapse(): Promise<void> {

--- a/packages/oc-docs/e2e/tests/sidebar/sidebar-resize.spec.ts
+++ b/packages/oc-docs/e2e/tests/sidebar/sidebar-resize.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../../playwright';
+
+const FOLDERS = '/?fixture=folders';
+const DESKTOP = { width: 1280, height: 900 };
+
+// The resize handle sits at the sidebar's right edge (left: var(--sidebar-width),
+// default 260px), and the drag is delta-based from where it is grabbed, so moving
+// the pointer to an absolute x lands the width near that x. Collapse fires when the
+// pointer is dragged ~100px past the 200px min (i.e. below x=100); re-expand fires
+// once it climbs back to the min (x>=200) within the same held gesture.
+
+test.describe('docs sidebar - resize (desktop)', () => {
+  test.use({ viewport: DESKTOP });
+
+  test('widens when the handle is dragged right', async ({ page, sidebar }) => {
+    await page.goto(FOLDERS);
+    await expect(sidebar.inline).toBeVisible();
+    const before = await sidebar.width();
+
+    await sidebar.grabResizer();
+    await sidebar.movePointerToX(400);
+    await sidebar.releasePointer();
+
+    const after = await sidebar.width();
+    expect(after).toBeGreaterThan(before);
+    expect(after).toBeGreaterThan(360);
+  });
+
+  test('clamps to the max width (480px)', async ({ page, sidebar }) => {
+    await page.goto(FOLDERS);
+    await sidebar.grabResizer();
+    await sidebar.movePointerToX(900);
+    await sidebar.releasePointer();
+
+    const after = await sidebar.width();
+    expect(after).toBeGreaterThan(470);
+    expect(after).toBeLessThanOrEqual(482);
+  });
+
+  test('persists the resized width across a reload (sessionStorage)', async ({ page, sidebar }) => {
+    await page.goto(FOLDERS);
+    await sidebar.grabResizer();
+    await sidebar.movePointerToX(380);
+    await sidebar.releasePointer();
+    const resized = await sidebar.width();
+    expect(resized).toBeGreaterThan(360);
+
+    await page.reload();
+    await expect(sidebar.inline).toBeVisible();
+    expect(Math.abs((await sidebar.width()) - resized)).toBeLessThan(5);
+  });
+
+  test('collapses when dragged past the min, and can be re-opened', async ({ page, sidebar }) => {
+    await page.goto(FOLDERS);
+    await sidebar.grabResizer();
+    await sidebar.movePointerToX(60);
+    await sidebar.releasePointer();
+
+    await expect(sidebar.inline).toHaveCount(0);
+    await expect(sidebar.expandButton).toBeVisible();
+
+    await sidebar.expand();
+    await expect(sidebar.inline).toBeVisible();
+  });
+
+  test('re-expands within the same held drag after collapsing', async ({ page, sidebar }) => {
+    await page.goto(FOLDERS);
+    await sidebar.grabResizer();
+
+    await sidebar.movePointerToX(60);
+    await expect(sidebar.inline).toHaveCount(0);
+
+    await sidebar.movePointerToX(320);
+    await expect(sidebar.inline).toBeVisible();
+
+    await sidebar.releasePointer();
+    await expect(sidebar.inline).toBeVisible();
+  });
+});
+
+test.describe('playground sidebar - resize (bottom dock)', () => {
+  test.use({ viewport: DESKTOP });
+
+  test('widens when the handle is dragged right', async ({ playground }) => {
+    await playground.open('bottom');
+    await expect(playground.sidebarPanel).toBeVisible();
+    const before = await playground.sidebarWidth();
+
+    await playground.grabSidebarResizer();
+    await playground.movePointerToX(400);
+    await playground.releasePointer();
+
+    expect(await playground.sidebarWidth()).toBeGreaterThan(before);
+  });
+
+  test('collapses when dragged past the min, and re-opens from the toggle', async ({ playground }) => {
+    await playground.open('bottom');
+    await expect(playground.sidebarPanel).toBeVisible();
+
+    await playground.grabSidebarResizer();
+    await playground.movePointerToX(60);
+    await playground.releasePointer();
+
+    await expect(playground.sidebarPanel).toHaveCount(0);
+
+    await playground.sidebarToggle.click();
+    await expect(playground.sidebarPanel).toBeVisible();
+  });
+});

--- a/packages/oc-docs/src/components/AppShell/AppShell.tsx
+++ b/packages/oc-docs/src/components/AppShell/AppShell.tsx
@@ -56,7 +56,7 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
   const isDesktop = mode === 'desktop';
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-  const { width: sidebarWidth, startDrag: startSidebarResize } = useResizableSidebar(
+  const { width: sidebarWidth, dragging: sidebarDragging, startDrag: startSidebarResize } = useResizableSidebar(
     'oc-docs:docsSidebarWidth',
     () => setSidebarCollapsed(true),
     () => setSidebarCollapsed(false)
@@ -150,6 +150,7 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
                 <div
                   className="appshell-sidebar-resizer"
                   data-testid="sidebar-resizer"
+                  data-dragging={sidebarDragging ? 'true' : undefined}
                   role="separator"
                   aria-orientation="vertical"
                   aria-label="Resize sidebar"

--- a/packages/oc-docs/src/components/AppShell/AppShell.tsx
+++ b/packages/oc-docs/src/components/AppShell/AppShell.tsx
@@ -11,7 +11,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '../../assets/icons';
 import PageRouter from '../PageRouter/PageRouter';
 import Playground from '../Playground/Playground';
 import SearchBar from '../Search/SearchBar/SearchBar';
-import { useSearchHotkey, usePlaygroundUrlState, useElementWidth } from '../../hooks';
+import { useSearchHotkey, usePlaygroundUrlState, useElementWidth, useResizableSidebar } from '../../hooks';
 import { useAppSelector } from '../../store/hooks';
 import { selectDocsCollection } from '../../store/slices/docs';
 import { selectGitCollectionUrl } from '../../store/slices/app';
@@ -56,6 +56,11 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
   const isDesktop = mode === 'desktop';
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
+  const { width: sidebarWidth, startDrag: startSidebarResize } = useResizableSidebar(
+    'oc-docs:docsSidebarWidth',
+    () => setSidebarCollapsed(true),
+    () => setSidebarCollapsed(false)
+  );
   const { pathname } = useLocation();
 
   const { open: playgroundOpen, dock: playgroundDock, openPlayground, setRequestExample } = usePlaygroundUrlState();
@@ -104,7 +109,11 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
       data-testid={testId}
       data-dock={playgroundOpen ? playgroundDock : 'none'}
     >
-      <div className="appshell-body" ref={bodyRef}>
+      <div
+        className="appshell-body"
+        ref={bodyRef}
+        style={{ '--sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}
+      >
         <Topbar
           layoutMode={mode}
           collectionName={collection?.info?.name || 'API Collection'}
@@ -138,6 +147,14 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
                 <aside className="appshell-sidebar" data-testid="app-sidebar">
                   <Sidebar />
                 </aside>
+                <div
+                  className="appshell-sidebar-resizer"
+                  data-testid="sidebar-resizer"
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label="Resize sidebar"
+                  onPointerDown={startSidebarResize}
+                />
                 <IconButton
                   className="appshell-collapse"
                   label="Collapse sidebar"

--- a/packages/oc-docs/src/components/AppShell/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/AppShell/StyledWrapper.ts
@@ -56,6 +56,23 @@ export const StyledWrapper = styled.div`
     touch-action: none;
   }
 
+  .appshell-sidebar-resizer::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    transform: translateX(-50%);
+    background-color: transparent;
+  }
+
+  .appshell-sidebar-resizer:hover::before,
+  .appshell-sidebar-resizer[data-dragging='true']::before {
+    width: 2px;
+    background-color: var(--oc-border-border2);
+  }
+
   .appshell-content {
     flex: 1;
     min-width: 0;

--- a/packages/oc-docs/src/components/AppShell/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/AppShell/StyledWrapper.ts
@@ -44,6 +44,18 @@ export const StyledWrapper = styled.div`
     background-color: var(--oc-background-base);
   }
 
+  .appshell-sidebar-resizer {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--sidebar-width);
+    width: 9px;
+    transform: translateX(-4px);
+    z-index: calc(var(--z-sidebar, 5) + 1);
+    cursor: col-resize;
+    touch-action: none;
+  }
+
   .appshell-content {
     flex: 1;
     min-width: 0;

--- a/packages/oc-docs/src/components/AppShell/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/AppShell/StyledWrapper.ts
@@ -49,8 +49,8 @@ export const StyledWrapper = styled.div`
     top: 0;
     bottom: 0;
     left: var(--sidebar-width);
-    width: 9px;
-    transform: translateX(-4px);
+    width: 0.5625rem;
+    transform: translateX(-0.25rem);
     z-index: calc(var(--z-sidebar, 5) + 1);
     cursor: col-resize;
     touch-action: none;
@@ -62,14 +62,14 @@ export const StyledWrapper = styled.div`
     top: 0;
     bottom: 0;
     left: 50%;
-    width: 1px;
+    width: 0.0625rem;
     transform: translateX(-50%);
     background-color: transparent;
   }
 
   .appshell-sidebar-resizer:hover::before,
   .appshell-sidebar-resizer[data-dragging='true']::before {
-    width: 2px;
+    width: 0.125rem;
     background-color: var(--oc-border-border2);
   }
 

--- a/packages/oc-docs/src/components/Playground/Playground.tsx
+++ b/packages/oc-docs/src/components/Playground/Playground.tsx
@@ -81,6 +81,7 @@ const Playground: React.FC<PlaygroundProps> = ({ openNonce }) => {
           sidebarOpen={sidebarOpen}
           dock={effectiveDock}
           onCloseSidebar={() => setSidebarOpen(false)}
+          onOpenSidebar={() => setSidebarOpen(true)}
           appliedSlugRef={appliedSlugRef}
         />
       </Suspense>

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.spec.tsx
@@ -44,6 +44,7 @@ describe('PlaygroundBody example view', () => {
             sidebarOpen={false}
             dock="modal"
             onCloseSidebar={() => {}}
+            onOpenSidebar={() => {}}
             appliedSlugRef={ref as any}
           />
         </MemoryRouter>

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.tsx
@@ -101,7 +101,7 @@ const PlaygroundBody: React.FC<PlaygroundBodyProps> = ({
 
   const viewRef = useRef<HTMLDivElement>(null);
   const viewWidth = useElementWidth(viewRef);
-  const { width: sidebarWidth, startDrag: startSidebarResize } =
+  const { width: sidebarWidth, dragging: sidebarDragging, startDrag: startSidebarResize } =
     useResizableSidebar('oc-docs:playgroundSidebarWidth', onCloseSidebar, onOpenSidebar);
   const orientation = viewWidth > 0 && viewWidth < ORIENTATION_BREAKPOINT ? 'vertical' : 'horizontal';
 
@@ -254,6 +254,7 @@ const PlaygroundBody: React.FC<PlaygroundBodyProps> = ({
           <div
             className="sidebar-resizer"
             data-testid="playground-sidebar-resizer"
+            data-dragging={sidebarDragging ? 'true' : undefined}
             role="separator"
             aria-orientation="vertical"
             aria-label="Resize sidebar"

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/PlaygroundBody.tsx
@@ -16,7 +16,7 @@ import {
 import { selectActiveEnvName } from '../../../store/slices/env';
 import type { ExampleHighlight } from '../../Docs/Sidebar/SidebarTree/SidebarTree';
 import { useNavModel } from '../../../routing/hooks';
-import { usePlaygroundUrlState, useElementWidth } from '../../../hooks';
+import { usePlaygroundUrlState, useElementWidth, useResizableSidebar } from '../../../hooks';
 import { getItemUuid, findItemByUuid } from '../../../utils/itemUtils';
 import { isFolder } from '../../../utils/schemaHelpers';
 import { exampleIndexForSlug, exampleSlugForIndex } from '../../../routing/slug';
@@ -48,6 +48,7 @@ interface PlaygroundBodyProps {
   sidebarOpen: boolean;
   dock: DockMode;
   onCloseSidebar: () => void;
+  onOpenSidebar: () => void;
   // Tracks the applied request (+example) key across dock-switch remounts; owned
   // by Playground so it survives a dock switch but resets on close (see there).
   appliedSlugRef: React.MutableRefObject<string | null>;
@@ -59,6 +60,7 @@ const PlaygroundBody: React.FC<PlaygroundBodyProps> = ({
   sidebarOpen,
   dock,
   onCloseSidebar,
+  onOpenSidebar,
   appliedSlugRef,
 }) => {
   const dispatch = useAppDispatch();
@@ -99,6 +101,8 @@ const PlaygroundBody: React.FC<PlaygroundBodyProps> = ({
 
   const viewRef = useRef<HTMLDivElement>(null);
   const viewWidth = useElementWidth(viewRef);
+  const { width: sidebarWidth, startDrag: startSidebarResize } =
+    useResizableSidebar('oc-docs:playgroundSidebarWidth', onCloseSidebar, onOpenSidebar);
   const orientation = viewWidth > 0 && viewWidth < ORIENTATION_BREAKPOINT ? 'vertical' : 'horizontal';
 
   // Reopen whatever the URL says was last open. `pgReq` holds a request, a
@@ -224,24 +228,38 @@ const PlaygroundBody: React.FC<PlaygroundBodyProps> = ({
   })();
 
   return (
-    <StyledWrapper data-testid="playground-runner" data-overlay-sidebar={dock === 'inline' ? 'true' : undefined}>
+    <StyledWrapper
+      data-testid="playground-runner"
+      data-overlay-sidebar={dock === 'inline' ? 'true' : undefined}
+      style={{ '--sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}
+    >
       {sidebarOpen && (
-        <aside className="sidebar" data-testid="playground-sidebar-panel">
-          <PlaygroundSidebar
-            collection={collection}
-            activeSlug={activeSlug}
-            uuidToSlug={uuidToSlug}
-            onNavigate={handleNavigate}
-            onToggleFolder={handleToggleFolder}
-            onExpandFolder={handleExpandFolder}
-            onOpenEnvironments={openEnvironments}
-            environmentsActive={viewMode === 'environments'}
-            onOpenCollection={openCollection}
-            collectionActive={viewMode === 'collection-settings'}
-            activeExample={activeExample}
-            onExampleClick={handleExampleClick}
+        <>
+          <aside className="sidebar" data-testid="playground-sidebar-panel">
+            <PlaygroundSidebar
+              collection={collection}
+              activeSlug={activeSlug}
+              uuidToSlug={uuidToSlug}
+              onNavigate={handleNavigate}
+              onToggleFolder={handleToggleFolder}
+              onExpandFolder={handleExpandFolder}
+              onOpenEnvironments={openEnvironments}
+              environmentsActive={viewMode === 'environments'}
+              onOpenCollection={openCollection}
+              collectionActive={viewMode === 'collection-settings'}
+              activeExample={activeExample}
+              onExampleClick={handleExampleClick}
+            />
+          </aside>
+          <div
+            className="sidebar-resizer"
+            data-testid="playground-sidebar-resizer"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize sidebar"
+            onPointerDown={startSidebarResize}
           />
-        </aside>
+        </>
       )}
       <div className="view" data-testid="playground-view" ref={viewRef}>
         {view}

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
@@ -22,7 +22,7 @@ export const StyledWrapper = styled.div`
     left: var(--sidebar-width);
     width: 9px;
     transform: translateX(-4px);
-    z-index: 6;
+    z-index: calc(var(--z-sidebar, 5) + 1);
     cursor: col-resize;
     touch-action: none;
   }

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
@@ -20,8 +20,8 @@ export const StyledWrapper = styled.div`
     top: 0;
     bottom: 0;
     left: var(--sidebar-width);
-    width: 9px;
-    transform: translateX(-4px);
+    width: 0.5625rem;
+    transform: translateX(-0.25rem);
     z-index: calc(var(--z-sidebar, 5) + 1);
     cursor: col-resize;
     touch-action: none;
@@ -33,14 +33,14 @@ export const StyledWrapper = styled.div`
     top: 0;
     bottom: 0;
     left: 50%;
-    width: 1px;
+    width: 0.0625rem;
     transform: translateX(-50%);
     background-color: transparent;
   }
 
   .sidebar-resizer:hover::before,
   .sidebar-resizer[data-dragging='true']::before {
-    width: 2px;
+    width: 0.125rem;
     background-color: var(--oc-border-border2);
   }
 

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
@@ -27,6 +27,23 @@ export const StyledWrapper = styled.div`
     touch-action: none;
   }
 
+  .sidebar-resizer::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    transform: translateX(-50%);
+    background-color: transparent;
+  }
+
+  .sidebar-resizer:hover::before,
+  .sidebar-resizer[data-dragging='true']::before {
+    width: 2px;
+    background-color: var(--oc-border-border2);
+  }
+
   .view {
     flex: 1;
     min-width: 0;

--- a/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundBody/StyledWrapper.ts
@@ -4,6 +4,7 @@ export const StyledWrapper = styled.div`
   display: flex;
   height: 100%;
   min-height: 0;
+  position: relative;
 
   .sidebar {
     width: var(--sidebar-width);
@@ -12,6 +13,18 @@ export const StyledWrapper = styled.div`
     min-height: 0;
     border-right: 1px solid var(--oc-border-border0);
     overflow: hidden;
+  }
+
+  .sidebar-resizer {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--sidebar-width);
+    width: 9px;
+    transform: translateX(-4px);
+    z-index: 6;
+    cursor: col-resize;
+    touch-action: none;
   }
 
   .view {

--- a/packages/oc-docs/src/hooks/index.ts
+++ b/packages/oc-docs/src/hooks/index.ts
@@ -31,3 +31,9 @@ export { usePlaygroundUrlState, type PlaygroundUrlApi } from './usePlaygroundUrl
 export { useDocsNavigate } from './useDocsNavigate';
 export { useElementWidth } from './useElementWidth';
 export { useAutoHideScrollbar } from './useAutoHideScrollbar';
+export {
+  useResizableSidebar,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_DEFAULT_WIDTH
+} from './useResizableSidebar';

--- a/packages/oc-docs/src/hooks/useDockResize.spec.ts
+++ b/packages/oc-docs/src/hooks/useDockResize.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { computeResizeDelta } from './useDockResize';
+
+describe('computeResizeDelta', () => {
+  it('grows a leading panel (left sidebar) as the pointer moves away from the origin', () => {
+    expect(computeResizeDelta('leading', 260, 320)).toBe(60);
+  });
+
+  it('shrinks a leading panel as the pointer moves back toward the origin', () => {
+    expect(computeResizeDelta('leading', 260, 210)).toBe(-50);
+  });
+
+  it('grows a trailing panel (right/bottom dock) as the pointer moves toward the origin', () => {
+    expect(computeResizeDelta('trailing', 400, 340)).toBe(60);
+  });
+
+  it('is zero when the pointer has not moved', () => {
+    expect(computeResizeDelta('leading', 260, 260)).toBe(0);
+    expect(computeResizeDelta('trailing', 260, 260)).toBe(0);
+  });
+});

--- a/packages/oc-docs/src/hooks/useDockResize.ts
+++ b/packages/oc-docs/src/hooks/useDockResize.ts
@@ -80,6 +80,8 @@ export const useDockResize = ({
   const [dragging, setDragging] = useState<boolean>(false);
   // Teardown for the in-flight drag, so it can be cancelled on unmount.
   const endDragRef = useRef<null | (() => void)>(null);
+  // Pending width frame, so pointermoves coalesce to one setSize per paint.
+  const rafRef = useRef(0);
 
   const startDrag = useCallback(
     (event: React.PointerEvent) => {
@@ -108,13 +110,21 @@ export const useDockResize = ({
       let collapsed = false;
       setDragging(true);
 
+      // Coalesce width writes to one per frame: a pointermove can fire several
+      // times per paint and each setSize re-renders, so schedule at most one.
+      // Collapse/expand stay synchronous below (rare, and their timing matters).
+      const commitSize = (value: number) => {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(() => setSize(value));
+      };
+
       const onMove = (moveEvent: PointerEvent) => {
         const current = axis === 'x' ? moveEvent.clientX : moveEvent.clientY;
         const intended = startSize + computeResizeDelta(edge, startPos, current);
         const { onCollapse: collapse, onExpand: expand, collapseThreshold: threshold } = collapseRef.current;
         if (collapse != null && threshold != null && !collapsed && intended < min - threshold) {
           collapsed = true;
-          setSize(min);
+          commitSize(min);
           collapse();
           return;
         }
@@ -124,11 +134,11 @@ export const useDockResize = ({
           if (intended >= min) {
             collapsed = false;
             expand?.();
-            setSize(clamp(intended, min, resolveMax()));
+            commitSize(clamp(intended, min, resolveMax()));
           }
           return;
         }
-        setSize(clamp(intended, min, resolveMax()));
+        commitSize(clamp(intended, min, resolveMax()));
       };
       // Listen on `window` (not the handle) so the drag survives the handle
       // unmounting when the panel collapses mid-gesture; move/up keep firing
@@ -163,7 +173,13 @@ export const useDockResize = ({
 
   // Cancel an in-flight drag if the dock unmounts, so listeners never outlive
   // the element and no state update fires after unmount.
-  useEffect(() => () => endDragRef.current?.(), []);
+  useEffect(
+    () => () => {
+      endDragRef.current?.();
+      cancelAnimationFrame(rafRef.current);
+    },
+    []
+  );
 
   return { size, dragging, startDrag, setSize };
 };

--- a/packages/oc-docs/src/hooks/useDockResize.ts
+++ b/packages/oc-docs/src/hooks/useDockResize.ts
@@ -9,6 +9,28 @@ interface DockResizeOptions {
    * tracks the live viewport; a plain number is treated as a fixed bound.
    */
   max: number | (() => number);
+  /**
+   * Which edge of the panel the handle sits on, i.e. which pointer direction
+   * grows it. A `trailing` panel (right/bottom dock, handle on its leading
+   * edge) grows as the pointer moves back toward the origin; a `leading` panel
+   * (left sidebar, handle on its trailing edge) grows as the pointer moves
+   * away. Defaults to `trailing` to preserve the docks' behaviour.
+   */
+  edge?: 'trailing' | 'leading';
+  /**
+   * Fires when the pointer is dragged past `min` by `collapseThreshold` more
+   * pixels (VS Code style): the size sticks at `min` until then, so a user has
+   * to deliberately overshoot to collapse. The caller hides the panel. The
+   * drag stays live so the same gesture can drag back and re-expand.
+   */
+  onCollapse?: () => void;
+  /**
+   * Fires when a collapsed panel is dragged back to at least `min`, within the
+   * same still-held drag. The caller re-shows the panel; sizing then resumes.
+   */
+  onExpand?: () => void;
+  /** Extra pixels the pointer must travel past `min` before `onCollapse`. */
+  collapseThreshold?: number;
 }
 
 interface DockResizeApi {
@@ -20,11 +42,36 @@ interface DockResizeApi {
 
 const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
 
-export const useDockResize = ({ axis, initial, min, max }: DockResizeOptions): DockResizeApi => {
+/**
+ * Signed size change for a pointer that moved from `startPos` to `current`
+ * along the resize axis. A `trailing` panel (right/bottom dock) grows as the
+ * pointer moves back toward the origin; a `leading` panel (left sidebar) grows
+ * as it moves away.
+ */
+export const computeResizeDelta = (
+  edge: 'trailing' | 'leading',
+  startPos: number,
+  current: number
+): number => (edge === 'leading' ? current - startPos : startPos - current);
+
+export const useDockResize = ({
+  axis,
+  initial,
+  min,
+  max,
+  edge = 'trailing',
+  onCollapse,
+  onExpand,
+  collapseThreshold
+}: DockResizeOptions): DockResizeApi => {
   // Keep the latest `max` in a ref so callers can pass an inline getter without
   // re-subscribing the resize listener or rebuilding startDrag every render.
   const maxRef = useRef(max);
   maxRef.current = max;
+  // Same for the collapse config: callers pass fresh callbacks each render, and
+  // reading them from a ref keeps startDrag's identity stable.
+  const collapseRef = useRef({ onCollapse, onExpand, collapseThreshold });
+  collapseRef.current = { onCollapse, onExpand, collapseThreshold };
   const resolveMax = useCallback(() => {
     const m = maxRef.current;
     return typeof m === 'function' ? m() : m;
@@ -41,31 +88,69 @@ export const useDockResize = ({ axis, initial, min, max }: DockResizeOptions): D
       const pointerId = event.pointerId;
       const startPos = axis === 'x' ? event.clientX : event.clientY;
       const startSize = size;
-      // Pointer capture routes move/up to the handle even when the pointer
-      // leaves the viewport (OS chrome / second monitor), so the drag can't run
-      // away when the release happens off-window.
+      // Capture keeps events flowing while the pointer leaves the viewport (OS
+      // chrome / second monitor). They still bubble to the window listeners
+      // below; when the handle unmounts on collapse the capture auto-releases
+      // and the window listeners keep the drag alive.
       handle.setPointerCapture?.(pointerId);
+      // Hold the resize cursor for the whole gesture and block text selection.
+      // The handle's own cursor would otherwise flip back to default the moment
+      // it unmounts on collapse, even while the pointer is still down.
+      const resizeCursor = axis === 'x' ? 'col-resize' : 'row-resize';
+      const prevCursor = document.body.style.cursor;
+      const prevUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = resizeCursor;
+      document.body.style.userSelect = 'none';
+      // Once past the min by the threshold the panel collapses, then can be
+      // dragged back open in the same gesture: `collapsed` tracks that state so
+      // collapse/expand each fire once per crossing. The point the two toggle
+      // around is `min`, so re-expanding snaps straight to the min width.
+      let collapsed = false;
       setDragging(true);
 
       const onMove = (moveEvent: PointerEvent) => {
         const current = axis === 'x' ? moveEvent.clientX : moveEvent.clientY;
-        const delta = startPos - current;
-        setSize(clamp(startSize + delta, min, resolveMax()));
+        const intended = startSize + computeResizeDelta(edge, startPos, current);
+        const { onCollapse: collapse, onExpand: expand, collapseThreshold: threshold } = collapseRef.current;
+        if (collapse != null && threshold != null && !collapsed && intended < min - threshold) {
+          collapsed = true;
+          setSize(min);
+          collapse();
+          return;
+        }
+        if (collapsed) {
+          // Stay collapsed until the pointer climbs back to the min, then
+          // re-show the panel and resume sizing from there (same gesture).
+          if (intended >= min) {
+            collapsed = false;
+            expand?.();
+            setSize(clamp(intended, min, resolveMax()));
+          }
+          return;
+        }
+        setSize(clamp(intended, min, resolveMax()));
       };
+      // Listen on `window` (not the handle) so the drag survives the handle
+      // unmounting when the panel collapses mid-gesture; move/up keep firing
+      // until the real pointer release.
       const end = () => {
         setDragging(false);
-        handle.releasePointerCapture?.(pointerId);
-        handle.removeEventListener('pointermove', onMove);
-        handle.removeEventListener('pointerup', end);
-        handle.removeEventListener('pointercancel', end);
+        document.body.style.cursor = prevCursor;
+        document.body.style.userSelect = prevUserSelect;
+        // The handle may already be detached (collapsed panel), which releases
+        // the capture on its own and makes an explicit release throw.
+        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId);
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', end);
+        window.removeEventListener('pointercancel', end);
         endDragRef.current = null;
       };
-      handle.addEventListener('pointermove', onMove);
-      handle.addEventListener('pointerup', end);
-      handle.addEventListener('pointercancel', end);
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', end);
+      window.addEventListener('pointercancel', end);
       endDragRef.current = end;
     },
-    [axis, size, min, resolveMax]
+    [axis, size, min, resolveMax, edge]
   );
 
   // Re-clamp to the live bound when the viewport changes, so a mid-session

--- a/packages/oc-docs/src/hooks/useResizableSidebar.ts
+++ b/packages/oc-docs/src/hooks/useResizableSidebar.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { useDockResize } from './useDockResize';
+import { readStored, writeStored } from './useStorage';
+
+export const SIDEBAR_MIN_WIDTH = 200;
+export const SIDEBAR_MAX_WIDTH = 480;
+export const SIDEBAR_DEFAULT_WIDTH = 260;
+// Extra drag past the min before the sidebar collapses (VS Code feel): the
+// width sticks at the min until the pointer overshoots by this much.
+export const SIDEBAR_COLLAPSE_THRESHOLD = 100;
+
+interface ResizableSidebarApi {
+  width: number;
+  dragging: boolean;
+  startDrag: (event: React.PointerEvent) => void;
+}
+
+const sessionArea = (): Storage | null => (typeof window === 'undefined' ? null : window.sessionStorage);
+
+/**
+ * Width state for a left-docked sidebar the user can drag-resize. Backs the
+ * drag with useDockResize (leading edge, so dragging right grows it) and
+ * persists the settled width to sessionStorage under `storageKey`: a reload
+ * restores it, closing the tab clears it (product wanted per-session, not
+ * permanent). Seeded from any stored value, clamped by useDockResize. Passing
+ * `onCollapse`/`onExpand` enables VS Code-style overshoot-to-collapse at the
+ * min width, with re-expand in the same drag.
+ */
+export const useResizableSidebar = (
+  storageKey: string,
+  onCollapse?: () => void,
+  onExpand?: () => void
+): ResizableSidebarApi => {
+  const { size, dragging, startDrag } = useDockResize({
+    axis: 'x',
+    edge: 'leading',
+    initial: readStored(sessionArea(), storageKey, SIDEBAR_DEFAULT_WIDTH),
+    min: SIDEBAR_MIN_WIDTH,
+    max: SIDEBAR_MAX_WIDTH,
+    onCollapse,
+    onExpand,
+    collapseThreshold: SIDEBAR_COLLAPSE_THRESHOLD
+  });
+
+  // Persist once the drag settles (and on any re-clamp), so the width survives a
+  // reload within the session without writing on every pointer move.
+  useEffect(() => {
+    if (!dragging) writeStored(sessionArea(), storageKey, size);
+  }, [dragging, size, storageKey]);
+
+  return { width: size, dragging, startDrag };
+};

--- a/packages/oc-docs/src/hooks/useResizableSidebar.ts
+++ b/packages/oc-docs/src/hooks/useResizableSidebar.ts
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useDockResize } from './useDockResize';
-import { readStored, writeStored } from './useStorage';
+import { areaFor, readStored, writeStored } from './useStorage';
 
 export const SIDEBAR_MIN_WIDTH = 200;
 export const SIDEBAR_MAX_WIDTH = 480;
@@ -14,8 +14,6 @@ interface ResizableSidebarApi {
   dragging: boolean;
   startDrag: (event: React.PointerEvent) => void;
 }
-
-const sessionArea = (): Storage | null => (typeof window === 'undefined' ? null : window.sessionStorage);
 
 /**
  * Width state for a left-docked sidebar the user can drag-resize. Backs the
@@ -31,10 +29,17 @@ export const useResizableSidebar = (
   onCollapse?: () => void,
   onExpand?: () => void
 ): ResizableSidebarApi => {
+  // Read the stored width once (not on every render, which during a drag would
+  // be a sessionStorage read + parse per pointer move); useDockResize seeds its
+  // state from it lazily.
+  const initialWidth = useMemo(
+    () => readStored(areaFor('session'), storageKey, SIDEBAR_DEFAULT_WIDTH),
+    [storageKey]
+  );
   const { size, dragging, startDrag } = useDockResize({
     axis: 'x',
     edge: 'leading',
-    initial: readStored(sessionArea(), storageKey, SIDEBAR_DEFAULT_WIDTH),
+    initial: initialWidth,
     min: SIDEBAR_MIN_WIDTH,
     max: SIDEBAR_MAX_WIDTH,
     onCollapse,
@@ -45,7 +50,7 @@ export const useResizableSidebar = (
   // Persist once the drag settles (and on any re-clamp), so the width survives a
   // reload within the session without writing on every pointer move.
   useEffect(() => {
-    if (!dragging) writeStored(sessionArea(), storageKey, size);
+    if (!dragging) writeStored(areaFor('session'), storageKey, size);
   }, [dragging, size, storageKey]);
 
   return { width: size, dragging, startDrag };

--- a/packages/oc-docs/src/hooks/useStorage.ts
+++ b/packages/oc-docs/src/hooks/useStorage.ts
@@ -22,7 +22,7 @@ export const writeStored = (storage: Storage | null, key: string, value: unknown
   }
 };
 
-const areaFor = (area: StorageArea): Storage | null => {
+export const areaFor = (area: StorageArea): Storage | null => {
   if (typeof window === 'undefined') return null;
   return area === 'local' ? window.localStorage : window.sessionStorage;
 };


### PR DESCRIPTION
JIRA : BRU-3753

## Summary
Make both sidebars drag-resizable and collapsible: the docs sidebar (AppShell) and the playground sidebar (PlaygroundBody).

## Behaviour
- Drag the right edge of either sidebar to resize its width (200-480px).
- Widths are independent per sidebar and persist per browser tab via sessionStorage: restored on reload, cleared when the tab or browser is closed.
- Dragging narrower sticks at the 200px minimum; keep dragging ~100px past it to collapse the sidebar. Within the same held gesture, dragging back to the minimum re-expands it.
- The resize handle shows a 2px highlight (`--oc-border-border2`) on hover, and stays highlighted for the whole drag (even when the pointer outruns the handle at max width).
- The resize cursor is held for the entire gesture and text selection is blocked while dragging.

## Implementation
- New `useResizableSidebar` hook: sessionStorage-backed width (read once via `areaFor`, persisted only when the drag settles) plus a collapse threshold.
- Extended the shared `useDockResize` hook: added a `leading` edge (left sidebars grow rightward), `onCollapse` / `onExpand` handoff, drag listeners on `window` so the gesture survives the handle unmounting on collapse, a body cursor/selection lock, and `requestAnimationFrame`-coalesced width writes (at most one `setSize` per frame). Docks keep their previous behaviour via the `trailing` default.
- Docs sidebar width is scoped via an inline `--sidebar-width` on `.appshell-body`; the playground scopes its own inline `--sidebar-width`, so the two stay independent. Collapse reuses the existing affordances to reopen (docs expand chevron, playground sidebar toggle).
