### PR TITLE
fix (oc-docs): Multiple UI refinements in the playground

### DIFF
--- a/packages/oc-docs/src/assets/icons/SendIcon.tsx
+++ b/packages/oc-docs/src/assets/icons/SendIcon.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { baseIconProps } from './baseIconProps';
 
+interface SendIconProps {
+  width?: number;
+  height?: number;
+}
+
 /** Paper-plane "send" icon used by the Try action. */
-export const SendIcon: React.FC = () => (
-  <svg {...baseIconProps} width={11} height={11}>
+export const SendIcon: React.FC<SendIconProps> = ({ width = 11, height = 11 }) => (
+  <svg {...baseIconProps} width={width} height={height}>
     <line x1="22" y1="2" x2="11" y2="13" />
     <polygon points="22 2 15 22 11 13 2 9 22 2" />
   </svg>

--- a/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/SidebarNavLink.tsx
+++ b/packages/oc-docs/src/components/Docs/Sidebar/SidebarNavLink/SidebarNavLink.tsx
@@ -57,8 +57,8 @@ const SidebarNavLink: React.FC<SidebarNavLinkProps> = ({
       // indent, while each level's glyph still lines up under its parent. Right
       // margin keeps the highlight short of the edge: 8px at root, 4px when nested.
       style={{
-        marginLeft: `${(level * 19 + 4) / 16}rem`,
-        paddingLeft: '0.25rem',
+        marginLeft: `${(level * 19) / 16}rem`,
+        paddingLeft: '0.5rem',
         marginRight: level === 0 ? '0.5rem' : '0.25rem'
       }}
       data-testid={testId}

--- a/packages/oc-docs/src/components/Docs/Sidebar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Docs/Sidebar/StyledWrapper.ts
@@ -9,7 +9,7 @@ export const StyledWrapper = styled.div`
   color: var(--oc-sidebar-color);
 
   .sidebar-items::-webkit-scrollbar {
-    width: 6px;
+    width: 0.375rem;
   }
   .sidebar-items::-webkit-scrollbar-track {
     background: transparent;
@@ -18,7 +18,7 @@ export const StyledWrapper = styled.div`
   .sidebar-items::-webkit-scrollbar-thumb {
     background-color: transparent;
     border: none;
-    border-radius: 20px;
+    border-radius: 1.25rem;
     transition: background-color 0.4s ease;
   }
   .sidebar-items.scrolling::-webkit-scrollbar-thumb {
@@ -30,13 +30,13 @@ export const StyledWrapper = styled.div`
     display: flex;
     flex-direction: column;
     gap: 1px;
-    padding: 10px 6px 0 6px;
+    padding: 0.625rem 0.75rem 0 0.75rem;
   }
 
   .sidebar-divider {
     flex-shrink: 0;
     height: 1px;
-    margin: 8px 0;
+    margin: 0.5rem 0;
     background-color: var(--oc-border-border0);
   }
 
@@ -48,6 +48,6 @@ export const StyledWrapper = styled.div`
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    padding: 0 0 0 0.375rem;
+    padding: 0 0 0 0.75rem;
   }
 `;

--- a/packages/oc-docs/src/components/PageWrapper/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/PageWrapper/StyledWrapper.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const StyledWrapper = styled.div`
   max-width: 100rem;
   margin-inline: auto;
-  padding: 2rem 3rem;
+  padding: 1rem 3rem;
 
   @container docs (max-width: 768px) {
     padding: 0.9375rem 1.25rem;

--- a/packages/oc-docs/src/components/Playground/Content/Views/CollectionSettingsView/CollectionSettingsView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/CollectionSettingsView/CollectionSettingsView.tsx
@@ -93,7 +93,6 @@ const CollectionSettings: React.FC<CollectionSettingsProps> = ({ collection }) =
         <HeadersTab
           headers={headers}
           onHeadersChange={handleHeadersChange}
-          title=""
           description="Add request headers that will be sent with every request in this collection."
         />
       )
@@ -109,7 +108,6 @@ const CollectionSettings: React.FC<CollectionSettingsProps> = ({ collection }) =
           postResponseVars={postResponseVars}
           onPostResponseVarsChange={handlePostResponseVarsChange}
           exprHelp="You can write any valid JS Template Literal here"
-          title=""
         />
       )
     },
@@ -122,7 +120,6 @@ const CollectionSettings: React.FC<CollectionSettingsProps> = ({ collection }) =
           onAuthChange={handleAuthChange}
           onItemChange={handleCollectionChange}
           item={collection}
-          title=""
           description="Configures authentication for the entire collection. This applies to all requests using the Inherit option in the Auth tab."
           showInherit={false}
           showFullAuth={true}
@@ -137,7 +134,6 @@ const CollectionSettings: React.FC<CollectionSettingsProps> = ({ collection }) =
         <ScriptsTab
           scripts={scripts}
           onScriptChange={handleScriptChange}
-          title=""
           description="Write pre and post-request scripts that will run before and after any request in this collection is sent."
           showTests={false}
         />

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AssertsTab/AssertsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AssertsTab/AssertsTab.tsx
@@ -104,7 +104,7 @@ interface AssertsTabProps {
 export const AssertsTab: React.FC<AssertsTabProps> = ({
   assertions,
   onAssertionsChange,
-  title = 'Assertions',
+  title,
   description
 }) => {
   const assertionsData: KeyValueRow[] = (assertions || []).map((assertion, index) => ({
@@ -141,7 +141,7 @@ export const AssertsTab: React.FC<AssertsTabProps> = ({
   return (
     <StyledWrapper className="space-y-3">
       <div className="flex items-center justify-between mb-2">
-        <span className="asserts-title text-sm font-semibold">{title}</span>
+        {title && <span className="asserts-title text-sm font-semibold">{title}</span>}
         {description && <span className="asserts-description text-xs leading-tight">{description}</span>}
       </div>
       <KeyValueTable

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { parse } from 'node-html-parser';
 import { describe, it, expect } from 'vitest';
-import { query } from '../../../../../../test-utils/dom';
+import { getByTestId, query } from '../../../../../../test-utils/dom';
 import { AUTH_DEFAULTS, AUTH_MODE_LABELS, PLACEMENT_OPTIONS } from '../../../../../../constants';
 import { AuthTab } from './AuthTab';
 
@@ -48,12 +48,12 @@ describe('AuthTab', () => {
     const { root, byTestId } = renderAuth(undefined);
     expect(root.querySelector('.auth-form')).toBeNull();
     expect(byTestId('auth-username')).toBeNull();
-    expect(query(root, '.auth-empty').text.trim()).toBe('No authentication configured.');
+    expect(getByTestId(root, 'no-content-text').text.trim()).toBe('No authentication configured.');
   });
 
   it('shows an inherit note for inherited auth', () => {
     const { root } = renderAuth('inherit', { showInherit: true });
-    expect(query(root, '.auth-empty').text.trim()).toBe('Inherits auth from parent collection.');
+    expect(getByTestId(root, 'no-content-text').text.trim()).toBe('Inherits auth from parent collection.');
   });
 
   it('renders basic auth with a plain username and a masked, revealable password', () => {

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.tsx
@@ -3,6 +3,7 @@ import { Field, type SelectOption } from '../../../../../../ui/Field';
 import { AUTH_DEFAULTS, AUTH_MODE_LABELS, PLACEMENT_OPTIONS } from '../../../../../../constants';
 import { REQUEST_PROTOCOL_KEYS } from '../../../../../../utils/schemaHelpers';
 import { StyledWrapper } from './StyledWrapper';
+import NoContentText from '../../../../../../ui/NoContentText/NoContentText';
 
 interface AuthTabProps {
   auth: any;
@@ -135,15 +136,15 @@ export const AuthTab: React.FC<AuthTabProps> = ({
 
   const renderBody = () => {
     if (!auth) {
-      return <p className="auth-empty">No authentication configured.</p>;
+      return <NoContentText text='No authentication configured.' />
     }
     if (auth === 'inherit') {
-      return <p className="auth-empty">Inherits auth from parent collection.</p>;
+      return <NoContentText text='Inherits auth from parent collection.' />
     }
     if (showFullAuth) {
       return <div className="auth-form">{renderForm()}</div>;
     }
-    return <p className="auth-empty">{title} auth is configured elsewhere.</p>;
+    return <NoContentText text='{title} auth is configured elsewhere.' />
   };
 
   return (

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/AuthTab.tsx
@@ -21,7 +21,7 @@ export const AuthTab: React.FC<AuthTabProps> = ({
   onAuthChange,
   onItemChange,
   item,
-  title = 'Authentication',
+  title,
   description,
   showInherit = false,
   showFullAuth = false
@@ -151,7 +151,7 @@ export const AuthTab: React.FC<AuthTabProps> = ({
     <StyledWrapper className="auth-tab">
       {(Boolean(title) || Boolean(description)) && (
         <div className="auth-header flex items-center justify-between">
-          {Boolean(title) && <span className="title text-sm font-semibold">{title}</span>}
+          {title && <span className="title text-sm font-semibold">{title}</span>}
           {description && <span className="description text-xs leading-tight">{description}</span>}
         </div>
       )}

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AuthTab/StyledWrapper.ts
@@ -22,13 +22,6 @@ export const StyledWrapper = styled.div`
     gap: 1rem;
   }
 
-  .auth-empty {
-    margin: 0;
-    font-style: italic;
-    font-size: 0.8125rem;
-    color: var(--text-muted);
-  }
-
   .auth-form {
     display: flex;
     flex-direction: column;

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/BodyModeSelector/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/BodyModeSelector/StyledWrapper.ts
@@ -7,12 +7,13 @@ import styled from '@emotion/styled';
 export const TriggerButton = styled.button`
   display: inline-flex;
   align-items: center;
-  padding: 0.25rem 0;
+  padding: 0 0 0.25rem;
   background: transparent;
   border: none;
   font-family: inherit;
-  font-size: 0.875rem;
-  font-weight: 500;
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+  letter-spacing: 0;
   color: var(--oc-primary-text);
   cursor: pointer;
   user-select: none;

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/HeadersTab/HeadersTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/HeadersTab/HeadersTab.tsx
@@ -68,13 +68,15 @@ const HeadersDisplay: React.FC<Omit<HeadersTabProps, 'title' | 'description'>> =
   );
 };
 
-export const HeadersTab: React.FC<HeadersTabProps> = ({ headers, onHeadersChange, title = 'Headers', description }) => {
+export const HeadersTab: React.FC<HeadersTabProps> = ({ headers, onHeadersChange, title, description }) => {
   return (
     <StyledWrapper className="space-y-3">
-      <div className="flex items-center justify-between mb-4">
-        {title && <span className="title text-sm font-semibold">{title}</span>}
-        {description && <span className="description text-xs leading-tight">{description}</span>}
-      </div>
+      {(Boolean(title) || Boolean(description)) && (
+        <div className="flex items-center justify-between mb-4">
+          {title && <span className="title text-sm font-semibold">{title}</span>}
+          {description && <span className="description text-xs leading-tight">{description}</span>}
+        </div>
+      )}
       <HeadersDisplay headers={headers} onHeadersChange={onHeadersChange} />
     </StyledWrapper>
   );

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/HeadersTab/HeadersTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/HeadersTab/HeadersTab.tsx
@@ -72,7 +72,7 @@ export const HeadersTab: React.FC<HeadersTabProps> = ({ headers, onHeadersChange
   return (
     <StyledWrapper className="space-y-3">
       <div className="flex items-center justify-between mb-4">
-        {Boolean(title) && <span className="title text-sm font-semibold">{title}</span>}
+        {title && <span className="title text-sm font-semibold">{title}</span>}
         {description && <span className="description text-xs leading-tight">{description}</span>}
       </div>
       <HeadersDisplay headers={headers} onHeadersChange={onHeadersChange} />

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/OverviewTab/OverviewTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/OverviewTab/OverviewTab.tsx
@@ -3,10 +3,18 @@ import { useMemo } from 'react';
 import { StyledWrapper } from './StyledWrapper';
 import { EmptyState } from '../../../../../../ui/EmptyState/EmptyState';
 import { BookIcon } from '../../../../../../assets/icons';
+import NoContentText from '../../../../../../ui/NoContentText/NoContentText';
 
-const OverviewTab: React.FC<{ docs?: string; emptyStateSubheading: string }> = ({
+interface OverviewTabProps {
+  docs?: string;
+  emptyStateSubheading: string;
+  displayEmptyStateBox?: boolean;
+}
+
+const OverviewTab: React.FC<OverviewTabProps> = ({
   docs,
-  emptyStateSubheading
+  emptyStateSubheading,
+  displayEmptyStateBox = true
 }) => {
   const md = useMarkdownRenderer();
   const docsHtml = useMemo(() => {
@@ -14,13 +22,15 @@ const OverviewTab: React.FC<{ docs?: string; emptyStateSubheading: string }> = (
   }, [md, docs]);
 
   if (!docsHtml) {
-    return (
+    return displayEmptyStateBox ? (
       <EmptyState
         testId="overview-empty"
         icon={<BookIcon />}
         heading="No overview content yet"
         subheading={emptyStateSubheading}
       />
+    ) : (
+      <NoContentText text="No overview content yet" />
     );
   }
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ParamsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ParamsTab.tsx
@@ -51,7 +51,6 @@ const ParamsSection: React.FC<ParamsSectionProps> = React.memo(({
       data={data}
       onChange={onChange}
       keyPlaceholder={keyLabel}
-      valuePlaceholder="Value"
       showEnabled={showEnabled}
       showActions={showActions}
       disableNewRow={disableNewRow}

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ParamsTab/ParamsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ParamsTab/ParamsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
-import KeyValueTable, { type KeyValueRow } from '../../../../../components/KeyValueTable/KeyValueTable';
+import KeyValueTable, { type KeyValueRow } from '../../../../../KeyValueTable/KeyValueTable';
+import { StyledWrapper } from './StyledWrapper';
 
 interface ParamsTabProps {
   params: Array<{ name?: string; value?: string; disabled?: boolean; type?: string }>;
@@ -38,11 +39,11 @@ const ParamsSection: React.FC<ParamsSectionProps> = React.memo(({
 }) => (
   <div className="space-y-3">
     <div className="flex items-center justify-between mb-2">
-      <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+      <span className="params-section-title">
         {title}
       </span>
       {description && (
-        <span className="text-xs leading-tight" style={{ color: 'var(--text-secondary)' }}>
+        <span className="text-xs leading-tight description">
           {description}
         </span>
       )}
@@ -108,7 +109,7 @@ export const ParamsTab: React.FC<ParamsTabProps> = ({
   const hasPath = pathData.length > 0;
 
   return (
-    <div className="space-y-4">
+    <StyledWrapper className="space-y-4">
       {/* Query table: always shown so query params can be viewed/added
           regardless of whether the request currently has any. */}
       <ParamsSection
@@ -131,7 +132,7 @@ export const ParamsTab: React.FC<ParamsTabProps> = ({
           readOnlyKey={true}
         />
       )}
-    </div>
+    </StyledWrapper>
   );
 };
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ParamsTab/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ParamsTab/StyledWrapper.ts
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+
+  .description {
+    color: 'var(--text-secondary)'
+  }
+  
+  .params-section-title {
+    margin: 0 0 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--oc-colors-text-subtext2);
+  }
+`;

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ResponseHeadersTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ResponseHeadersTab.tsx
@@ -1,51 +1,53 @@
 import React from 'react';
+import NoContentText from '../../../../../ui/NoContentText/NoContentText';
 
 interface ResponseHeadersTabProps {
   headers?: Record<string, any>;
 }
 
 const ResponseHeadersTab: React.FC<ResponseHeadersTabProps> = ({ headers }) => {
+
+  if(!headers) {
+    return (
+      <NoContentText text='No response headers' />
+    )
+  }
+
   return (
     <div className="h-full overflow-auto">
       <div className="py-3">
-        {headers ? (
-          <div className="space-y-0">
-            {Object.entries(headers).map(([key, value], index) => (
-              <div 
-                key={key} 
-                className="flex items-center gap-4 py-1.5 border-b"
+        <div className="space-y-0">
+          {Object.entries(headers).map(([key, value], index) => (
+            <div 
+              key={key} 
+              className="flex items-center gap-4 py-1.5 border-b"
+              style={{ 
+                borderColor: 'var(--border-color)',
+                borderBottomWidth: index === Object.entries(headers).length - 1 ? '0' : '1px'
+              }}
+            >
+              <span 
+                className="font-mono text-xs font-medium" 
                 style={{ 
-                  borderColor: 'var(--border-color)',
-                  borderBottomWidth: index === Object.entries(headers).length - 1 ? '0' : '1px'
+                  color: 'var(--text-primary)', 
+                  minWidth: '180px',
+                  letterSpacing: '0.01em'
                 }}
               >
-                <span 
-                  className="font-mono text-xs font-medium" 
-                  style={{ 
-                    color: 'var(--text-primary)', 
-                    minWidth: '180px',
-                    letterSpacing: '0.01em'
-                  }}
-                >
-                  {key}
-                </span>
-                <span 
-                  className="font-mono text-xs flex-1 break-all" 
-                  style={{ 
-                    color: 'var(--text-secondary)',
-                    letterSpacing: '0.01em'
-                  }}
-                >
-                  {String(value)}
-                </span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-12" style={{ color: 'var(--text-secondary)' }}>
-            <span className="text-xs">No response headers</span>
-          </div>
-        )}
+                {key}
+              </span>
+              <span 
+                className="font-mono text-xs flex-1 break-all" 
+                style={{ 
+                  color: 'var(--text-secondary)',
+                  letterSpacing: '0.01em'
+                }}
+              >
+                {String(value)}
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ScriptsTab/ScriptsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ScriptsTab/ScriptsTab.tsx
@@ -65,10 +65,12 @@ export const ScriptsTab: React.FC<ScriptsTabProps> = ({
 
   return (
     <StyledWrapper className="space-y-4">
-      <div className="flex items-center justify-between mb-4">
-        {Boolean(title) && <span className="title text-sm font-semibold">{title}</span>}
-        {description && <span className="description text-xs leading-tight">{description}</span>}
-      </div>
+      {(Boolean(title) || Boolean(description)) && (
+        <div className="flex items-center justify-between mb-4">
+          {title && <span className="title text-sm font-semibold">{title}</span>}
+          {description && <span className="description text-xs leading-tight">{description}</span>}
+        </div>
+      )}
 
       <div className="space-y-4">
         <Tabs

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/ScriptsTab/ScriptsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/ScriptsTab/ScriptsTab.tsx
@@ -20,7 +20,7 @@ interface ScriptsTabProps {
 export const ScriptsTab: React.FC<ScriptsTabProps> = ({
   scripts,
   onScriptChange,
-  title = 'Scripts',
+  title,
   description,
   showTests = true
 }) => {

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/TestResultsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/TestResultsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { TestResultsResponse, AssertionResultsResponse } from '../../../../../runner';
+import NoContentText from '../../../../../ui/NoContentText/NoContentText';
 
 interface TestResultsTabProps {
   testResults?: TestResultsResponse;
@@ -15,16 +16,7 @@ const TestResultsTab: React.FC<TestResultsTabProps> = ({ testResults, assertionR
 
   if (!hasTests && !hasAssertions) {
     return (
-      <div className="h-full flex items-center justify-center" style={{ backgroundColor: 'var(--bg-primary)' }}>
-        <div className="text-center py-12">
-          <div className="w-16 h-16 mx-auto mb-4 opacity-50">
-            <svg fill="currentColor" viewBox="0 0 24 24" style={{ color: 'var(--text-secondary)' }}>
-              <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
-            </svg>
-          </div>
-          <p style={{ color: 'var(--text-secondary)' }}>No tests or assertions were run</p>
-        </div>
-      </div>
+      <NoContentText text='No tests or assertions were run' />
     );
   }
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/TestsTab/TestsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/TestsTab/TestsTab.tsx
@@ -16,7 +16,7 @@ export const TestsTab: React.FC<TestsTabProps> = ({ scripts, onScriptChange, tit
     <StyledWrapper className="space-y-3">
       {(Boolean(title) || Boolean(description)) && (
         <div className="flex items-center justify-between mb-4">
-          {Boolean(title) && <span className="title text-sm font-semibold">{title}</span>}
+          {title && <span className="title text-sm font-semibold">{title}</span>}
           {description && <span className="description text-xs leading-tight">{description}</span>}
         </div>
       )}

--- a/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvVarCards/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvVarCards/StyledWrapper.ts
@@ -53,13 +53,11 @@ export const StyledWrapper = styled.div`
 
   .env-card .value .value-secret {
     flex: 1;
-    padding: 0 0.5rem;
   }
 
   .env-card .value-input {
     flex: 0 1 auto;
     field-sizing: content;
-    min-width: 40px;
     max-width: 100%;
     border: none;
     outline: none;
@@ -78,7 +76,6 @@ export const StyledWrapper = styled.div`
 
   .env-card .value .var-type {
     flex-shrink: 0;
-    margin-left: auto;
   }
 
   .env-card .delete {

--- a/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/StyledWrapper.ts
@@ -9,13 +9,14 @@ export const StyledWrapper = styled.div`
   background-color: var(--oc-background-base);
 
   .env-header {
-    padding: 16px 24px 0;
+    padding: 1rem 1.5rem 0;
     flex-shrink: 0;
   }
 
   .env-title {
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: 600;
+    font-size: 0.8125rem;
     color: var(--oc-text);
   }
 
@@ -32,14 +33,14 @@ export const StyledWrapper = styled.div`
   .env-pills {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    padding: 16px 24px;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
   }
 
   .env-pill {
     display: inline-flex;
     align-items: center;
-    padding: 6px 12px;
+    padding: 0.25rem 0.5rem;
     border: 1px solid var(--oc-border-border2);
     border-radius: var(--oc-border-radius-md);
     background: transparent;
@@ -58,8 +59,7 @@ export const StyledWrapper = styled.div`
 
   .env-pill.active {
     color: var(--oc-text);
-    border-color: var(--oc-text-link);
-    background: color-mix(in srgb, var(--oc-text-link) 8%, transparent);
+    border-color: var(--primary-color);
   }
 
   .env-tabs-area {
@@ -68,10 +68,10 @@ export const StyledWrapper = styled.div`
     display: flex;
     flex-direction: column;
     min-height: 0;
-    padding: 0 24px 24px;
+    padding: 0 1.5rem 1.5rem;
   }
 
   .env-tabs-area .tab-content {
-    margin-top: 16px;
+    margin-top: 1rem;
   }
 `;

--- a/packages/oc-docs/src/components/Playground/Content/Views/FolderSettingsView/FolderSettingsView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/FolderSettingsView/FolderSettingsView.tsx
@@ -138,7 +138,6 @@ const FolderSettings: React.FC<FolderSettingsProps> = ({ folder, onFolderChange 
     <HeadersTab
       headers={folder.request?.headers || []}
       onHeadersChange={handleHeadersChange}
-      title=""
       description="Request headers that will be sent with every request inside this folder."
     />
   );
@@ -147,7 +146,6 @@ const FolderSettings: React.FC<FolderSettingsProps> = ({ folder, onFolderChange 
     <VariablesTab
       variables={folder.request?.variables || []}
       onVariablesChange={handleVariablesChange}
-      title=""
       description="Variables available to every request inside this folder."
     />
   );
@@ -158,7 +156,6 @@ const FolderSettings: React.FC<FolderSettingsProps> = ({ folder, onFolderChange 
       onAuthChange={handleAuthChange}
       onItemChange={handleFolderAuthChange}
       item={folder}
-      title=""
       description="Configures authentication for this folder. This applies to all requests using the Inherit option in the Auth tab."
       showInherit={true}
       showFullAuth={true}
@@ -171,7 +168,6 @@ const FolderSettings: React.FC<FolderSettingsProps> = ({ folder, onFolderChange 
     <ScriptsTab
       scripts={scripts}
       onScriptChange={handleScriptChange}
-      title=""
       description="Pre and post-request scripts that will run before and after any request inside this folder is sent."
       showTests={false}
     />
@@ -181,7 +177,6 @@ const FolderSettings: React.FC<FolderSettingsProps> = ({ folder, onFolderChange 
     <TestsTab
       scripts={scripts}
       onScriptChange={handleScriptChange}
-      title=""
       description="These tests will run any time a request in this folder is sent."
     />
   );

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/PlaygroundView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/PlaygroundView.tsx
@@ -108,7 +108,7 @@ const HttpRequestPlaygroundView: React.FC<PlaygroundViewProps> = ({ item, collec
       
       <div
         ref={containerRef}
-        className={`flex flex-1 overflow-hidden pt-2 ${orientation === 'vertical' ? 'flex-col' : 'flex-row'}`}
+        className={`flex flex-1 overflow-hidden pt-4 ${orientation === 'vertical' ? 'flex-col' : 'flex-row'}`}
         style={{ userSelect: isResizing ? 'none' : undefined }}
       >
         <div

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -5,7 +5,7 @@ import Tabs from '../../../../../../ui/Tabs/Tabs';
 import { KeyValueRow } from '../../../../../../components/KeyValueTable/KeyValueTable';
 import { rowToVariable } from '../../../../../../utils/variableDataType';
 import HeadersTab from '../../Common/HeadersTab/HeadersTab';
-import ParamsTab from '../../Common/ParamsTab';
+import ParamsTab from '../../Common/ParamsTab/ParamsTab';
 import BodyTab from '../../Common/BodyTab';
 import BodyModeSelector from '../../Common/BodyModeSelector/BodyModeSelector';
 import AuthTab from '../../Common/AuthTab/AuthTab';

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -216,6 +216,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
           <OverviewTab
             docs={getItemDocs(item)}
             emptyStateSubheading="This request has no docs. Add one in Bruno to introduce your API to readers: what it does, who it's for, and how to authenticate."
+            displayEmptyStateBox={false}
           />
         </div>
       )

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -147,6 +147,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onVariablesChange={handleRequestVariablesChange}
       postResponseVars={postResponseVars}
       onPostResponseVarsChange={handlePostResponseVarsChange}
+      description="These variables will be available to this request."
     />
   );
 
@@ -154,6 +155,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <HeadersTab
       headers={headers}
       onHeadersChange={handleHeadersChange}
+      description="Headers sent with this request."
     />
   );
 
@@ -172,6 +174,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onItemChange={onItemChange}
       item={item}
       showFullAuth={true}
+      description="Configures authentication for this request."
     />
   );
 
@@ -180,6 +183,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       scripts={scriptsObj}
       onScriptChange={handleScriptChange}
       showTests={false}
+      description="Pre and post-request scripts that run before and after this request is sent."
     />
   );
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -147,7 +147,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onVariablesChange={handleRequestVariablesChange}
       postResponseVars={postResponseVars}
       onPostResponseVarsChange={handlePostResponseVarsChange}
-      description="These variables will be available to this request."
     />
   );
 
@@ -155,7 +154,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <HeadersTab
       headers={headers}
       onHeadersChange={handleHeadersChange}
-      description="Headers sent with this request."
     />
   );
 
@@ -173,7 +171,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onAuthChange={() => {}} // Not used for full auth
       onItemChange={onItemChange}
       item={item}
-      description="Configures authentication for this request."
       showFullAuth={true}
     />
   );
@@ -182,7 +179,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <ScriptsTab
       scripts={scriptsObj}
       onScriptChange={handleScriptChange}
-      description="Pre and post-request scripts that run before and after this request is sent."
       showTests={false}
     />
   );
@@ -192,7 +188,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       assertions={assertions}
       onAssertionsChange={handleAssertionsChange}
       title=""
-      description="Assertions that validate the response of this request."
     />
   );
 
@@ -200,7 +195,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <TestsTab
       scripts={scriptsObj}
       onScriptChange={handleScriptChange}
-      description="These tests run every time this request is sent."
     />
   );
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -146,8 +146,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onVariablesChange={handleRequestVariablesChange}
       postResponseVars={postResponseVars}
       onPostResponseVarsChange={handlePostResponseVarsChange}
-      title="Request Variables"
-      description="These variables will be available to this request"
     />
   );
 
@@ -155,7 +153,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <HeadersTab
       headers={headers}
       onHeadersChange={handleHeadersChange}
-      title="Headers"
     />
   );
 
@@ -173,7 +170,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onAuthChange={() => {}} // Not used for full auth
       onItemChange={onItemChange}
       item={item}
-      title="Authentication"
       showFullAuth={true}
     />
   );
@@ -182,7 +178,6 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <ScriptsTab
       scripts={scriptsObj}
       onScriptChange={handleScriptChange}
-      title="Scripts"
       showTests={false}
     />
   );
@@ -217,7 +212,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       id: 'overview',
       label: 'Overview',
       content: (
-        <div className="py-3">
+        <div className="pb-3">
           <OverviewTab
             docs={getItemDocs(item)}
             emptyStateSubheading="This request has no docs. Add one in Bruno to introduce your API to readers: what it does, who it's for, and how to authenticate."
@@ -229,50 +224,50 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       id: 'params',
       label: 'Params',
       contentIndicator: params?.length || undefined, 
-      content: <div className="py-3">{renderParams()}</div> 
+      content: <div className="pb-3">{renderParams()}</div> 
     },
     { 
       id: 'variables', 
       label: 'Variables', 
       contentIndicator: variables?.length || undefined,
-      content: <div className="py-3">{renderVariables()}</div>
+      content: <div className="pb-3">{renderVariables()}</div>
     },
     { 
       id: 'headers', 
       label: 'Headers', 
       contentIndicator: headers?.length || undefined, 
-      content: <div className="py-3">{renderHeaders()}</div> 
+      content: <div className="pb-3">{renderHeaders()}</div> 
     },
     {
       id: 'body',
       label: 'Body',
       contentIndicator: hasBody ? '•' : undefined,
       rightElement: <BodyModeSelector body={body} onItemChange={onItemChange} item={item} />,
-      content: <div className="py-3">{renderBody()}</div>
+      content: <div className="pb-3">{renderBody()}</div>
     },
     { 
       id: 'auth', 
       label: 'Auth',
       contentIndicator: auth ? '•' : undefined,
-      content: <div className="py-3">{renderAuth()}</div> 
+      content: <div className="pb-3">{renderAuth()}</div> 
     },
     { 
       id: 'scripts', 
       label: 'Scripts',
       contentIndicator: hasScripts ? '•' : undefined,
-      content: <div className="py-3">{renderScripts()}</div> 
+      content: <div className="pb-3">{renderScripts()}</div> 
     },
     { 
       id: 'assertions', 
       label: 'Assertions', 
       contentIndicator: assertions?.length || undefined, 
-      content: <div className="py-3">{renderAssertions()}</div> 
+      content: <div className="pb-3">{renderAssertions()}</div> 
     },
     { 
       id: 'tests', 
       label: 'Tests',
       contentIndicator: hasTests ? '•' : undefined,
-      content: <div className="py-3">{renderTests()}</div> 
+      content: <div className="pb-3">{renderTests()}</div> 
     }
   ];
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/ResponsePane.tsx
@@ -4,7 +4,8 @@ import ResponseBodyTab from '../../Common/ResponseBodyTab';
 import ResponseHeadersTab from '../../Common/ResponseHeadersTab';
 import TestResultsTab from '../../Common/TestResultsTab';
 import ErrorBanner from '../../../../../../ui/ErrorBanner/ErrorBanner';
-import { StyledWrapper } from './StyledWrapper';
+import { SendIconWrapper, StyledWrapper } from './StyledWrapper';
+import { SendIcon } from '../../../../../../assets/icons';
 
 interface ResponsePaneProps {
   response: any;
@@ -37,15 +38,11 @@ const ResponsePane: React.FC<ResponsePaneProps> = ({ response, isLoading }) => {
 
   if (!response) {
     return (
-      <div className="h-full flex items-center justify-center" style={{ backgroundColor: 'var(--bg-primary)' }}>
-        <div className="text-center">
-          <div className="w-16 h-16 mx-auto mb-4 opacity-50">
-            <svg fill="currentColor" viewBox="0 0 24 24" style={{ color: 'var(--text-secondary)' }}>
-              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-            </svg>
-          </div>
-          <p style={{ color: 'var(--text-secondary)' }}>Click Send to make a request</p>
-        </div>
+      <div className="h-full flex flex-col items-center justify-center" style={{ backgroundColor: 'var(--bg-primary)' }}>
+        <SendIconWrapper className="mb-4 send-icon">
+          <SendIcon width={26} height={24} />
+        </SendIconWrapper>
+        <p style={{ color: 'var(--oc-tabs-secondary-inactive-color)' }}>Click Send to make a request</p>
       </div>
     );
   }

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/ResponsePane/StyledWrapper.ts
@@ -9,4 +9,20 @@ export const StyledWrapper = styled.div`
     min-height: 0;
     overflow-y: auto;
   }
+
+  & .send-icon {
+    padding: 0.5625rem;
+    border-radius: 50%;
+    background: var(--oc-background-mantle);
+  }
 `;
+
+export const SendIconWrapper = styled.div`
+  padding: 0.5625rem;
+  border-radius: 50%;
+  background: var(--oc-background-mantle);
+
+  svg {
+    color: var(--text-muted);
+  }
+`

--- a/packages/oc-docs/src/components/Playground/PlaygroundSidebar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundSidebar/StyledWrapper.ts
@@ -55,7 +55,7 @@ export const StyledWrapper = styled.div`
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    padding: 0.25rem 0.5rem 0.75rem;
+    padding: 0.25rem 0.75rem 0.75rem;
   }
 
   &.mobile .navlink-main {

--- a/packages/oc-docs/src/components/Playground/PlaygroundSidebar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/PlaygroundSidebar/StyledWrapper.ts
@@ -10,9 +10,9 @@ export const StyledWrapper = styled.div`
   .controls {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 0.5rem;
     flex-shrink: 0;
-    padding: 12px;
+    padding: 0.75rem;
   }
 
   .controls > :first-child {
@@ -22,9 +22,9 @@ export const StyledWrapper = styled.div`
 
   .controls .env-switcher-trigger {
     width: 100%;
-    height: 28px;
+    height: 1.75rem;
     justify-content: space-between;
-    padding: 5px 8px;
+    padding: 0.3125rem 0.5rem;
     border-radius: var(--oc-radius);
   }
 
@@ -34,8 +34,8 @@ export const StyledWrapper = styled.div`
 
   .env-settings {
     flex: none;
-    width: 28px;
-    height: 28px;
+    width: 1.75rem;
+    height: 1.75rem;
     border: 1px solid var(--oc-border-border2);
     border-radius: var(--oc-radius);
     color: var(--text-secondary);
@@ -55,7 +55,7 @@ export const StyledWrapper = styled.div`
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    padding: 4px 6px 12px;
+    padding: 0.25rem 0.5rem 0.75rem;
   }
 
   &.mobile .navlink-main {

--- a/packages/oc-docs/src/components/PrevNext/PrevNext.tsx
+++ b/packages/oc-docs/src/components/PrevNext/PrevNext.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import type { SeqNeighbor } from '../../routing/types';
+import type { PageType, SeqNeighbor } from '../../routing/types';
 import { getMethodColorVar } from '../../theme/methodColors';
 import { getShortMethod } from '../../utils/request';
 import { ChevronLeftIcon, ChevronRightIcon } from '../../assets/icons';
@@ -8,12 +8,14 @@ import { StyledWrapper } from './StyledWrapper';
 
 const toPath = (slug: string) => `/${slug}`;
 
-const MethodTag: React.FC<{ method?: string }> = ({ method }) =>
+const MethodTag: React.FC<{ method?: string, type: PageType }> = ({ method, type }) =>
   method ? (
     <span className="prevnext-method" style={{ color: getMethodColorVar(method) }}>
       {getShortMethod(method)}
     </span>
-  ) : null;
+  ) : type === 'script' ? (
+    <span className="prevnext-method" style={{ color: 'var(--oc-primary-text)' }}>JS</span>
+  ): null;
 
 const Card: React.FC<{ dir: 'prev' | 'next'; neighbor: SeqNeighbor; search: string }> = ({ dir, neighbor, search }) => (
   <Link
@@ -29,7 +31,7 @@ const Card: React.FC<{ dir: 'prev' | 'next'; neighbor: SeqNeighbor; search: stri
     <span className="prevnext-textcol">
       <span className="prevnext-label">{dir === 'prev' ? 'Previous' : 'Next'}</span>
       <span className="prevnext-name">
-        <MethodTag method={neighbor.method} />
+        <MethodTag method={neighbor.method} type={neighbor.type} />
         <span className="prevnext-name-text">{neighbor.name}</span>
       </span>
     </span>

--- a/packages/oc-docs/src/components/PrevNext/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/PrevNext/StyledWrapper.ts
@@ -74,7 +74,7 @@ export const StyledWrapper = styled.nav`
     max-width: 100%;
     min-width: 0;
     font-size: 0.8125rem;
-    line-height: 1;
+    line-height: 1.2;
     font-weight: 600;
     color: var(--oc-text);
   }

--- a/packages/oc-docs/src/components/TitleLabel/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/TitleLabel/StyledWrapper.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const StyledWrapper = styled.h2`
   font-family: var(--font-sans);
   font-weight: 500;
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   line-height: 1;
   letter-spacing: 0;
   color: var(--text-secondary);

--- a/packages/oc-docs/src/pages/Overview/StyledWrapper.ts
+++ b/packages/oc-docs/src/pages/Overview/StyledWrapper.ts
@@ -25,8 +25,8 @@ export const StyledWrapper = styled.div`
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     gap: 2rem;
-    margin-top: 2rem;
-    padding-top: 2rem;
+    margin-top: 1.75rem;
+    padding-top: 1.625rem;
     border-top: 1px solid var(--border-color);
   }
 

--- a/packages/oc-docs/src/ui/NoContentText/NoContentText.tsx
+++ b/packages/oc-docs/src/ui/NoContentText/NoContentText.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { StyledWrapper } from './StyledWrapper';
+
+interface NoContentTextProps {
+  className?: string;
+  text: string;
+  testId?: string
+}
+
+const NoContentText : React.FC<NoContentTextProps> = ({ 
+  className,
+  text,
+  testId = 'no-content-text' 
+}) => {
+  return (
+    <StyledWrapper className={className} data-testid={testId}>
+      {text}
+    </StyledWrapper>
+  )
+}
+
+export default NoContentText

--- a/packages/oc-docs/src/ui/NoContentText/StyledWrapper.tsx
+++ b/packages/oc-docs/src/ui/NoContentText/StyledWrapper.tsx
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.p`
+  font-style: italic;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+`;


### PR DESCRIPTION
# Description
This PR contains a UI refinements and improvements.

## Items changed

1. Empty Response headers
2. Empty Response tests
3. Change in Overview tab display for no data in request pane
4. Spacing fixes, and title change in the request page
5. Fixed the styling for Body formatter dropdown on right of Tabs in request pane
6. Remove the title and description for tab panels in the request panel
7. Fix the coloring and spacing in Environments page
8. Fix the alignment of value being displayed in the Environment's Secret table in compact view
9. Improve the pre-request view for the response pane

## Screenshots

### Sidebar

<img width="326" height="339" alt="image" src="https://github.com/user-attachments/assets/b299fb0a-ffe4-44ab-97c4-933a892d0773" />

<img width="324" height="197" alt="image" src="https://github.com/user-attachments/assets/9b8451a5-ad97-4f1c-9cbc-9faddd6f51c3" />

<img width="324" height="263" alt="image" src="https://github.com/user-attachments/assets/6f498e2d-dc2a-4498-b913-fc9ccf34ac4e" />

### Overview top spacing
<img width="607" height="186" alt="image" src="https://github.com/user-attachments/assets/e15f21a9-88f2-4fa5-a73a-67ab21d2b9fb" />

<img width="880" height="214" alt="image" src="https://github.com/user-attachments/assets/25e859d8-27bc-4fca-b643-f70b32ff3a2e" />

### No response

<img width="1226" height="300" alt="image" src="https://github.com/user-attachments/assets/fcbf8265-948f-488a-b2da-bd095991c28c" />

### No response based tests

<img width="1228" height="256" alt="image" src="https://github.com/user-attachments/assets/1766a648-da31-47b8-901c-ce0670f0c2c6" />


### Request Page headings

<img width="1228" height="256" alt="image" src="https://github.com/user-attachments/assets/49ce2022-3530-4d66-af4c-a1209ddae584" />

<img width="697" height="359" alt="image" src="https://github.com/user-attachments/assets/afe3bc99-64c8-44d1-82de-37c91b2477f2" />

### No request overview page

<img width="1244" height="688" alt="image" src="https://github.com/user-attachments/assets/17a1cd4d-965d-4b59-b3a5-fd3a59b815f4" />


### Changed icon for send

<img width="443" height="342" alt="image" src="https://github.com/user-attachments/assets/42217d6c-b5f5-47b9-9457-8b3c313341b7" />


### Environments in playground

<img width="1493" height="450" alt="image" src="https://github.com/user-attachments/assets/4d6037e8-6a34-4275-83d4-a9f7e5b6a54f" />

<img width="599" height="406" alt="image" src="https://github.com/user-attachments/assets/ba5502c4-72de-4c68-9970-bc735ebbecc5" />

### Params tab

<img width="633" height="365" alt="image" src="https://github.com/user-attachments/assets/ed181848-2814-4ac4-a102-c75dc66d0b8b" />





