### PR TITLE
feat(oc-docs): match playground method dropdown and url bar to Bruno app

### DIFF
--- a/packages/oc-docs/src/components/MethodBadge/MethodBadge.spec.tsx
+++ b/packages/oc-docs/src/components/MethodBadge/MethodBadge.spec.tsx
@@ -3,6 +3,12 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
 import { MethodBadge } from './MethodBadge';
 
+const badgeText = (element: React.ReactElement): string =>
+  renderToStaticMarkup(element)
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/g, '')
+    .replace(/<[^>]*>/g, '')
+    .trim();
+
 describe('MethodBadge', () => {
   it('renders the method uppercased', () => {
     expect(renderToStaticMarkup(<MethodBadge method="post" />)).toContain('POST');
@@ -13,12 +19,10 @@ describe('MethodBadge', () => {
   });
 
   it('renders the abbreviated method when short is set', () => {
-    const html = renderToStaticMarkup(<MethodBadge method="DELETE" short />);
-    expect(html).toContain('>DEL<');
-    expect(html).not.toContain('DELETE');
+    expect(badgeText(<MethodBadge method="DELETE" short />)).toBe('DEL');
   });
 
   it('keeps short methods intact when short is set', () => {
-    expect(renderToStaticMarkup(<MethodBadge method="GET" short />)).toContain('>GET<');
+    expect(badgeText(<MethodBadge method="GET" short />)).toBe('GET');
   });
 });

--- a/packages/oc-docs/src/components/MethodBadge/MethodBadge.spec.tsx
+++ b/packages/oc-docs/src/components/MethodBadge/MethodBadge.spec.tsx
@@ -11,4 +11,14 @@ describe('MethodBadge', () => {
   it('defaults to GET when no method is given', () => {
     expect(renderToStaticMarkup(<MethodBadge method="" />)).toContain('GET');
   });
+
+  it('renders the abbreviated method when short is set', () => {
+    const html = renderToStaticMarkup(<MethodBadge method="DELETE" short />);
+    expect(html).toContain('>DEL<');
+    expect(html).not.toContain('DELETE');
+  });
+
+  it('keeps short methods intact when short is set', () => {
+    expect(renderToStaticMarkup(<MethodBadge method="GET" short />)).toContain('>GET<');
+  });
 });

--- a/packages/oc-docs/src/components/MethodBadge/MethodBadge.tsx
+++ b/packages/oc-docs/src/components/MethodBadge/MethodBadge.tsx
@@ -1,19 +1,25 @@
 import React from 'react';
 import { getMethodColorVar } from '../../theme/methodColors';
+import { getShortMethod } from '../../utils/request';
 import { StyledWrapper } from './StyledWrapper';
 
 interface MethodBadgeProps {
   method: string;
   className?: string;
+  /** Render the abbreviated method (DELETE -> DEL, OPTIONS -> OPT) for tight spaces like the query bar. */
+  short?: boolean;
 }
 
-export const MethodBadge: React.FC<MethodBadgeProps> = ({ method, className }) => (
-  <StyledWrapper
-    className={['method-badge', className].filter(Boolean).join(' ')}
-    style={{ color: getMethodColorVar(method) }}
-  >
-    {(method || 'GET').toUpperCase()}
-  </StyledWrapper>
-);
+export const MethodBadge: React.FC<MethodBadgeProps> = ({ method, className, short = false }) => {
+  const resolvedMethod = method || 'GET';
+  return (
+    <StyledWrapper
+      className={['method-badge', className].filter(Boolean).join(' ')}
+      style={{ color: getMethodColorVar(method) }}
+    >
+      {short ? getShortMethod(resolvedMethod) : resolvedMethod.toUpperCase()}
+    </StyledWrapper>
+  );
+};
 
 export default MethodBadge;

--- a/packages/oc-docs/src/components/MethodBadge/MethodBadge.tsx
+++ b/packages/oc-docs/src/components/MethodBadge/MethodBadge.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from '../../utils/cx';
 import { getMethodColorVar } from '../../theme/methodColors';
 import { getShortMethod } from '../../utils/request';
 import { StyledWrapper } from './StyledWrapper';
@@ -14,7 +15,7 @@ export const MethodBadge: React.FC<MethodBadgeProps> = ({ method, className, sho
   const resolvedMethod = method || 'GET';
   return (
     <StyledWrapper
-      className={['method-badge', className].filter(Boolean).join(' ')}
+      className={cx('method-badge', className)}
       style={{ color: getMethodColorVar(method) }}
     >
       {short ? getShortMethod(resolvedMethod) : resolvedMethod.toUpperCase()}

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -4,7 +4,7 @@ import { StyledWrapper } from './StyledWrapper';
 import MenuDropdown from '../../../../../../ui/MenuDropdown';
 import { getHttpMethod, getRequestUrl, getHttpParams } from '../../../../../../utils/schemaHelpers';
 import { syncPathParams, syncQueryParams } from '../../../../../../utils/pathParams';
-import { availableMethods, getMethodColorVar } from '../../../../../../theme/methodColors';
+import { availableMethods } from '../../../../../../theme/methodColors';
 import { MethodBadge } from '../../../../../MethodBadge/MethodBadge';
 import { CopyButton } from '../../../../../../ui/CopyButton/CopyButton';
 
@@ -59,17 +59,19 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
         <MenuDropdown
           selectedItemId={method}
           placement="bottom-start"
+          offset={[-9, 13]}
           testId="method-select"
           role="listbox"
+          className="method-menu-dropdown"
           items={availableMethods.map((m) => ({
             id: m,
-            label: <span style={{ color: getMethodColorVar(m) }}>{m}</span>,
+            label: <MethodBadge method={m} />,
             ariaLabel: m,
             onClick: () => handleMethodChange(m)
           }))}
         >
           <button type="button" className="method-select" aria-label="HTTP method">
-            <MethodBadge method={method} />
+            <MethodBadge method={method} short />
           </button>
         </MenuDropdown>
       </div>
@@ -79,7 +81,7 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
         value={url}
         onChange={(e) => handleUrlChange(e.target.value)}
         placeholder="Enter request URL"
-        className="flex-1 px-3 text-xs font-normal"
+        className="flex-1 pr-3 text-xs font-normal"
         style={{
           fontFamily: 'var(--font-mono)',
           fontSize: '12px',

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
+import { Global } from '@emotion/react';
 import type { HttpRequest } from '@opencollection/types/requests/http';
-import { StyledWrapper } from './StyledWrapper';
+import { StyledWrapper, methodDropdownStyles } from './StyledWrapper';
 import MenuDropdown from '../../../../../../ui/MenuDropdown';
 import { getHttpMethod, getRequestUrl, getHttpParams } from '../../../../../../utils/schemaHelpers';
 import { syncPathParams, syncQueryParams } from '../../../../../../utils/pathParams';
@@ -55,6 +56,7 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
 
   return (
     <StyledWrapper className="flex items-center">
+      <Global styles={methodDropdownStyles} />
       <div className="method-select-wrapper">
         <MenuDropdown
           selectedItemId={method}

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Global } from '@emotion/react';
 import type { HttpRequest } from '@opencollection/types/requests/http';
-import { StyledWrapper, methodDropdownStyles } from './StyledWrapper';
+import { StyledWrapper } from './StyledWrapper';
 import MenuDropdown from '../../../../../../ui/MenuDropdown';
 import { getHttpMethod, getRequestUrl, getHttpParams } from '../../../../../../utils/schemaHelpers';
 import { syncPathParams, syncQueryParams } from '../../../../../../utils/pathParams';
@@ -57,27 +56,23 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
 
   return (
     <StyledWrapper>
-      <Global styles={methodDropdownStyles} />
-      <div className="method-select-wrapper">
-        <MenuDropdown
-          selectedItemId={method}
-          placement="bottom-start"
-          offset={[-9, 11]}
-          testId="method-select"
-          role="listbox"
-          className="method-menu-dropdown"
-          items={availableMethods.map((m) => ({
-            id: m,
-            label: <MethodBadge method={m} />,
-            ariaLabel: m,
-            onClick: () => handleMethodChange(m)
-          }))}
-        >
-          <button type="button" className="method-select" aria-label="HTTP method">
-            <MethodBadge method={method} short />
-          </button>
-        </MenuDropdown>
-      </div>
+      <MenuDropdown
+        selectedItemId={method}
+        placement="bottom-start"
+        testId="method-select"
+        role="listbox"
+        size="sm"
+        items={availableMethods.map((m) => ({
+          id: m,
+          label: <MethodBadge method={m} />,
+          ariaLabel: m,
+          onClick: () => handleMethodChange(m)
+        }))}
+      >
+        <button type="button" className="method-select" aria-label="HTTP method">
+          <MethodBadge method={method} short />
+        </button>
+      </MenuDropdown>
 
       <input
         type="text"

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -104,7 +104,7 @@ export const methodDropdownStyles = css`
     border-color: var(--border-color);
   }
 
-  .method-menu-dropdown .dropdown-item {
+  .dropdown.method-menu-dropdown .dropdown-item {
     padding: 0.25rem 0.6rem 0.25rem 0.25rem;
     margin: 1px 0;
     line-height: 1;

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 
 export const StyledWrapper = styled.div`
   display: flex;
@@ -29,12 +28,6 @@ export const StyledWrapper = styled.div`
     }
   }
 
-  .method-select-wrapper {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-  }
-
   .method-select {
     appearance: none;
     display: inline-flex;
@@ -45,6 +38,8 @@ export const StyledWrapper = styled.div`
     border: none;
     outline: none;
     cursor: pointer;
+    padding-left: 0.5rem;
+    margin-left: -0.5rem;
   }
 
   .method-select .method-badge {
@@ -92,21 +87,5 @@ export const StyledWrapper = styled.div`
       opacity: 0.5;
       cursor: not-allowed;
     }
-  }
-`;
-
-export const methodDropdownStyles = css`
-  .dropdown.method-menu-dropdown {
-    min-width: 6.875rem;
-    max-width: 9.375rem !important;
-    padding: 0.125rem;
-    background-color: var(--oc-background-base);
-    border-color: var(--border-color);
-  }
-
-  .dropdown.method-menu-dropdown .dropdown-item {
-    padding: 0.25rem 0.6rem 0.25rem 0.25rem;
-    margin: 1px 0;
-    line-height: 1;
   }
 `;

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 export const StyledWrapper = styled.div`
   gap: 0.25rem;
@@ -86,5 +87,21 @@ export const StyledWrapper = styled.div`
       opacity: 0.5;
       cursor: not-allowed;
     }
+  }
+`;
+
+export const methodDropdownStyles = css`
+  .dropdown.method-menu-dropdown {
+    min-width: 6.875rem;
+    max-width: 9.375rem !important;
+    padding: 0.125rem;
+    background-color: var(--oc-background-base);
+    border-color: var(--border-color);
+  }
+
+  .method-menu-dropdown .dropdown-item {
+    padding: 0.25rem 0.6rem 0.25rem 0.25rem;
+    margin: 1px 0;
+    line-height: 1;
   }
 `;

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const StyledWrapper = styled.div`
-  gap: 0.5rem;
+  gap: 0.25rem;
   padding: 0.25rem 0.375rem;
   border: 1px solid var(--border-color);
   border-radius: var(--oc-radius);
@@ -42,7 +42,7 @@ export const StyledWrapper = styled.div`
     position: relative;
     display: flex;
     align-items: center;
-    padding-left: 0.375rem;
+    padding-left: 0.125rem;
   }
 
   .method-select {

--- a/packages/oc-docs/src/ui/MenuDropdown/MenuDropdown.tsx
+++ b/packages/oc-docs/src/ui/MenuDropdown/MenuDropdown.tsx
@@ -15,6 +15,7 @@ import type {
   MenuGroupStyle,
   MenuItemExtraProps
 } from './types';
+import cx from '../../utils/cx';
 
 const NAVIGATION_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Escape'];
 const ACTION_KEYS = ['Enter', ' '];
@@ -48,6 +49,8 @@ export interface MenuDropdownProps extends Omit<
   placement?: Placement;
   /** Optional className for the dropdown surface. */
   className?: string;
+  /** Surface size variant: `'lg'` (default) or `'sm'` (compact, e.g. the method picker). */
+  size?: 'sm' | 'lg';
   /** ID of the selected/active item to focus on open and mark active. */
   selectedItemId?: MenuItemId | null;
   /** ARIA role family: 'menu' (default) for action menus; 'listbox' for single-select value pickers. */
@@ -93,6 +96,7 @@ const MenuDropdown = forwardRef<MenuDropdownHandle, MenuDropdownProps>(
       children,
       placement = 'bottom-end',
       className,
+      size = 'lg',
       selectedItemId,
       role = 'menu',
       opened,
@@ -556,7 +560,7 @@ const MenuDropdown = forwardRef<MenuDropdownHandle, MenuDropdownProps>(
         onCreate={onDropdownCreate}
         icon={triggerElement}
         placement={placement}
-        className={className}
+        className={cx(className,  { 'menu-dropdown-sm': size === 'sm' })}
         visible={isOpen}
         onClickOutside={handleClickOutside}
         {...dropdownProps}

--- a/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
@@ -24,20 +24,6 @@ export const StyledWrapper = styled.div`
   max-width: unset !important;
   padding: 0.25rem;
 
-  &.method-menu-dropdown {
-    min-width: 6.875rem;
-    max-width: 9.375rem !important;
-    padding: 0.125rem;
-    background-color: var(--oc-background-base);
-    border-color: var(--border-color);
-
-    .dropdown-item {
-      padding: 0.25rem 0.6rem 0.25rem 0.25rem;
-      margin: 1px 0;
-      line-height: 1;
-    }
-  }
-
   .menu-dropdown-list {
     outline: none;
     &:focus {

--- a/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
@@ -24,6 +24,20 @@ export const StyledWrapper = styled.div`
   max-width: unset !important;
   padding: 0.25rem;
 
+  &.method-menu-dropdown {
+    min-width: 6.875rem;
+    max-width: 9.375rem !important;
+    padding: 0.125rem;
+    background-color: var(--oc-background-base);
+    border-color: var(--border-color);
+
+    .dropdown-item {
+      padding: 0.25rem 0.6rem 0.25rem 0.25rem;
+      margin: 1px 0;
+      line-height: 1;
+    }
+  }
+
   .menu-dropdown-list {
     outline: none;
     &:focus {

--- a/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
@@ -24,6 +24,20 @@ export const StyledWrapper = styled.div`
   max-width: unset !important;
   padding: 0.25rem;
 
+  &.menu-dropdown-sm {
+    min-width: 6.875rem;
+    max-width: 9.375rem !important;
+    padding: 0.125rem;
+    background-color: var(--oc-background-base);
+    border-color: var(--border-color);
+
+    .dropdown-item {
+      padding: 0.25rem 0.6rem 0.25rem 0.25rem;
+      margin: 1px 0;
+      line-height: 1;
+    }
+  }
+
   .menu-dropdown-list {
     outline: none;
     &:focus {

--- a/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/MenuDropdown/StyledWrapper.ts
@@ -30,6 +30,7 @@ export const StyledWrapper = styled.div`
     padding: 0.125rem;
     background-color: var(--oc-background-base);
     border-color: var(--border-color);
+    margin-top: 2px;
 
     .dropdown-item {
       padding: 0.25rem 0.6rem 0.25rem 0.25rem;


### PR DESCRIPTION
JIRA : BRU-3753

## Summary

Brings the playground query bar's HTTP method control (the method dropdown and the url bar trigger) in line with the Bruno app for visual parity.

## Changes

### Method dropdown
- Dropdown items now render as `MethodBadge` (bold, monospace, uppercase, method-coloured), matching the trigger badge, instead of plain coloured text.
- Constrained the dropdown surface width to 110-150px (Bruno parity) and tightened item spacing (`line-height: 1`, padding, `1px` margin) and surface padding.
- Dropdown surface background now uses the app base background so it blends with the overall dark background instead of sitting on a lighter surface; border matches the query bar's `--border-color`.
- Dropdown is left-aligned to the url box's left border with a `1px` gap below it (via Tippy `offset`).

### Url bar (method trigger)
- Long methods are abbreviated in the trigger for tight spaces (`DELETE -> DEL`, `OPTIONS -> OPT`) through a new `short` prop on `MethodBadge`; the dropdown list keeps the full names.
- Reduced the method trigger's left/right padding to match the docs url bar.

## Implementation notes
- `MethodBadge` gained an optional `short` prop that renders `getShortMethod(...)` while keeping the colour derived from the full method. Default behaviour (full, uppercased) is unchanged, so the sidebar, example cards and docs url bar are unaffected.
- Dropdown-specific styling is scoped under a `method-menu-dropdown` class on the shared `MenuDropdown` surface, so other dropdowns are untouched.
