### PR TITLE
feat(size/M):UI improvements and fixes.

### DIFF
--- a/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.css
+++ b/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.css
@@ -221,16 +221,29 @@
   padding: 0.625rem;
 }
 
+.key-value-table .col-value .secret-value .secret-value-input {
+  font-size: 0.8125rem;
+}
+
 .key-value-table .value-cell-trailing {
   flex: none;
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: 0.5rem;
   padding-left: 0.625rem;
 }
 
 .key-value-table .value-cell-trailing .delete-button {
   margin-right: 1.25rem;
+}
+
+.key-value-table .value-cell:has(.secret-value) .value-cell-trailing {
+  gap: 0.625rem;
+  padding-left: 0;
+}
+
+.key-value-table .value-cell:has(.secret-value) .value-cell-trailing .delete-button {
+  margin-right: 0.625rem;
 }
 
 .key-value-table .delete-button {

--- a/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.tsx
+++ b/packages/oc-docs/src/components/KeyValueTable/KeyValueTable.tsx
@@ -45,6 +45,7 @@ interface KeyValueTableProps {
   valueHeader?: React.ReactNode;
   inlineActions?: boolean;
   multilineValues?: boolean;
+  secretEditByDefault?: boolean;
   testId?: string;
 }
 
@@ -73,6 +74,7 @@ const KeyValueTable: React.FC<KeyValueTableProps> = ({
   valueHeader,
   inlineActions = false,
   multilineValues = false,
+  secretEditByDefault = false,
   testId = 'key-value-table'
 }) => {
   const { isFound, names } = useResolvedVariables();
@@ -149,6 +151,8 @@ const KeyValueTable: React.FC<KeyValueTableProps> = ({
                 <SecretValue
                   value={row.value}
                   placeholder={valuePlaceholder}
+                  editByDefault={secretEditByDefault}
+                  multiline={multilineValues}
                   onChange={(v) => updateField(index, 'value', v)}
                 />
               ) : (

--- a/packages/oc-docs/src/components/Playground/Content/Views/Common/AssertsTab/AssertsTab.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/Common/AssertsTab/AssertsTab.tsx
@@ -140,10 +140,12 @@ export const AssertsTab: React.FC<AssertsTabProps> = ({
 
   return (
     <StyledWrapper className="space-y-3">
-      <div className="flex items-center justify-between mb-2">
-        <span className="asserts-title text-sm font-semibold">{title}</span>
-        {description && <span className="asserts-description text-xs leading-tight">{description}</span>}
-      </div>
+      {(Boolean(title) || Boolean(description)) && (
+        <div className="flex items-center justify-between mb-2">
+          {Boolean(title) && <span className="asserts-title text-sm font-semibold">{title}</span>}
+          {description && <span className="asserts-description text-xs leading-tight">{description}</span>}
+        </div>
+      )}
       <KeyValueTable
         data={assertionsData}
         onChange={handleAssertionsChange}

--- a/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvVarCards/EnvVarCards.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvVarCards/EnvVarCards.tsx
@@ -14,6 +14,7 @@ interface EnvVarCardsProps {
   makeNewRow?: () => Partial<KeyValueRow>;
   disableNewRow?: boolean;
   editableDataType?: boolean;
+  secretEditByDefault?: boolean;
   addWhenComplete?: boolean;
   testId?: string;
 }
@@ -24,6 +25,7 @@ const EnvVarCards: React.FC<EnvVarCardsProps> = ({
   makeNewRow,
   disableNewRow = false,
   editableDataType = false,
+  secretEditByDefault = false,
   addWhenComplete = false,
   testId
 }) => {
@@ -45,26 +47,40 @@ const EnvVarCards: React.FC<EnvVarCardsProps> = ({
               />
             )}
             <div className="body">
-              <input
-                className="name"
-                data-testid={testId ? `${testId}-name-${index}` : undefined}
-                placeholder="Name"
-                value={row.name}
-                onChange={(e) => updateRow(index, { name: e.target.value })}
-              />
+              <div className="name-row">
+                <input
+                  className="name"
+                  data-testid={testId ? `${testId}-name-${index}` : undefined}
+                  placeholder="Name"
+                  value={row.name}
+                  onChange={(e) => updateRow(index, { name: e.target.value })}
+                />
+                {!isBlankRow && (
+                  <button
+                    type="button"
+                    className="delete"
+                    aria-label="Delete variable"
+                    title="Delete"
+                    onClick={() => removeRow(index)}
+                  >
+                    <TrashIcon />
+                  </button>
+                )}
+              </div>
               <div className="value">
                 {row.secret ? (
-                  <SecretValue value={row.value} placeholder="Value" onChange={(v) => updateRow(index, { value: v })} className="value-secret" />
+                  <SecretValue value={row.value} placeholder="Value" editByDefault={secretEditByDefault} multiline={editableDataType} onChange={(v) => updateRow(index, { value: v })} className="value-secret" />
                 ) : (
-                  <input
+                  <textarea
                     className="value-input"
                     data-testid={testId ? `${testId}-value-${index}` : undefined}
                     placeholder="Value"
+                    rows={1}
                     value={row.value}
                     onChange={(e) => updateRow(index, { value: e.target.value })}
                   />
                 )}
-                {editableDataType && !row.secret && !isBlankRow ? (
+                {editableDataType && !isBlankRow ? (
                   <VariableTypeControl
                     dataType={toDataType(row.dataType)}
                     value={row.value}
@@ -74,17 +90,6 @@ const EnvVarCards: React.FC<EnvVarCardsProps> = ({
                 ) : null}
               </div>
             </div>
-            {!isBlankRow && (
-              <button
-                type="button"
-                className="delete"
-                aria-label="Delete variable"
-                title="Delete"
-                onClick={() => removeRow(index)}
-              >
-                <TrashIcon />
-              </button>
-            )}
           </div>
         );
       })}

--- a/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvVarCards/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvVarCards/StyledWrapper.ts
@@ -33,7 +33,15 @@ export const StyledWrapper = styled.div`
     gap: 4px;
   }
 
+  .env-card .name-row {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+  }
+
   .env-card .name {
+    flex: 1;
+    min-width: 0;
     border: none;
     outline: none;
     background: transparent;
@@ -53,7 +61,10 @@ export const StyledWrapper = styled.div`
 
   .env-card .value .value-secret {
     flex: 1;
-    padding: 0 0.5rem;
+  }
+
+  .env-card .value .value-secret .secret-value-input {
+    font-size: var(--oc-font-size-sm);
   }
 
   .env-card .value-input {
@@ -68,6 +79,11 @@ export const StyledWrapper = styled.div`
     font-family: var(--font-mono);
     font-size: var(--oc-font-size-sm);
     color: var(--oc-text);
+    resize: none;
+    overflow: hidden;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    line-height: 1.5;
   }
 
   .env-card .name::placeholder,
@@ -82,7 +98,6 @@ export const StyledWrapper = styled.div`
   }
 
   .env-card .delete {
-    margin-top: 2px;
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;

--- a/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvironmentsView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/EnvironmentsView/EnvironmentsView.tsx
@@ -147,6 +147,7 @@ const EnvironmentsView: React.FC<EnvironmentsViewProps> = ({ collection, compact
         makeNewRow={makeNewRow}
         disableNewRow={disableNewRow}
         editableDataType={editableDataType}
+        secretEditByDefault
         addWhenComplete
         testId="env-var-cards"
       />
@@ -163,6 +164,7 @@ const EnvironmentsView: React.FC<EnvironmentsViewProps> = ({ collection, compact
         makeNewRow={makeNewRow}
         addWhenComplete
         disableDelete={false}
+        secretEditByDefault
         additionalColumns={editableDataType ? [variableTypeColumn] : []}
       />
     );
@@ -174,7 +176,7 @@ const EnvironmentsView: React.FC<EnvironmentsViewProps> = ({ collection, compact
     },
     secrets: {
       contentIndicator: secretRows.length,
-      content: renderVars(secretRows, (rows) => commit(plainRows, rows), { makeNewRow: () => ({ secret: true }) })
+      content: renderVars(secretRows, (rows) => commit(plainRows, rows), { makeNewRow: () => ({ secret: true }), editableDataType: true })
     },
     external: {
       contentIndicator: externalRows.length,

--- a/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.tsx
@@ -106,7 +106,7 @@ export const ExampleView: React.FC<ExampleViewProps> = ({ request, example, orie
           )}
         </div>
 
-        <SplitDivider orientation={orientation} onPointerDown={startResize} testId="example-view-divider" />
+        <SplitDivider orientation={orientation} onPointerDown={startResize} active={isResizing} testId="example-view-divider" />
 
         <div className="example-view-pane example-view-pane-response" data-testid="example-view-response">
           <div className="example-view-pane-title">

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/PlaygroundView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/PlaygroundView.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { HttpRequest } from '@opencollection/types/requests/http';
 import type { OpenCollection as OpenCollectionCollection } from '@opencollection/types';
+import type { Item } from '@opencollection/types/collection/item';
 import { requestRunner } from '../../../../../runner';
+import { getAncestorsByUuid } from '../../../../../utils/fileUtils';
+import { ItemVariableResolverProvider } from '../../../../../hooks';
 import TitleLabel from '../../../../TitleLabel/TitleLabel';
 import QueryBar from './QueryBar/QueryBar';
 import RequestPane from './RequestPane/RequestPane';
@@ -32,6 +35,10 @@ const HttpRequestPlaygroundView: React.FC<PlaygroundViewProps> = ({ item, collec
   // orientation: horizontal layout resizes width, vertical layout resizes height.
   const { size: paneSize, isResizing, containerRef, startResize } = useSplitPane(orientation);
   const runner = useMemo(() => requestRunner, []);
+  const ancestry = useMemo(
+    () => (collection && itemUuid ? getAncestorsByUuid(collection, itemUuid) : []),
+    [collection, itemUuid]
+  );
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const pendingSaveRef = useRef<{ uuid: string; item: HttpRequest } | null>(null);
 
@@ -96,6 +103,7 @@ const HttpRequestPlaygroundView: React.FC<PlaygroundViewProps> = ({ item, collec
   }, [collection, editableItem, runner, selectedEnvironment, itemUuid]);
 
   return (
+    <ItemVariableResolverProvider collection={collection} ancestry={ancestry} item={editableItem as unknown as Item}>
     <div className="request-runner-container h-full flex flex-col px-4" style={{ backgroundColor: 'var(--bg-primary)' }}>
       <TitleLabel className="truncate mb-2 mt-3">{itemName}</TitleLabel>
       
@@ -108,7 +116,7 @@ const HttpRequestPlaygroundView: React.FC<PlaygroundViewProps> = ({ item, collec
       
       <div
         ref={containerRef}
-        className={`flex flex-1 overflow-hidden pt-2 ${orientation === 'vertical' ? 'flex-col' : 'flex-row'}`}
+        className={`flex flex-1 overflow-hidden pt-4 ${orientation === 'vertical' ? 'flex-col' : 'flex-row'}`}
         style={{ userSelect: isResizing ? 'none' : undefined }}
       >
         <div
@@ -122,13 +130,14 @@ const HttpRequestPlaygroundView: React.FC<PlaygroundViewProps> = ({ item, collec
           <RequestPane item={editableItem} onItemChange={handleItemChange} />
         </div>
 
-        <SplitDivider orientation={orientation} onPointerDown={startResize} testId="playground-divider" />
+        <SplitDivider orientation={orientation} onPointerDown={startResize} active={isResizing} testId="playground-divider" />
 
         <div className="flex-1 overflow-hidden min-h-0">
           <ResponsePane response={response} isLoading={isLoading} />
         </div>
       </div>
     </div>
+    </ItemVariableResolverProvider>
   );
 };
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/QueryBar.tsx
@@ -7,6 +7,7 @@ import { syncPathParams, syncQueryParams } from '../../../../../../utils/pathPar
 import { availableMethods, getMethodColorVar } from '../../../../../../theme/methodColors';
 import { MethodBadge } from '../../../../../MethodBadge/MethodBadge';
 import { CopyButton } from '../../../../../../ui/CopyButton/CopyButton';
+import { SendIcon } from '../../../../../../assets/icons';
 
 interface QueryBarProps {
   item: HttpRequest;
@@ -54,7 +55,7 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
   };
 
   return (
-    <StyledWrapper className="flex items-center">
+    <StyledWrapper>
       <div className="method-select-wrapper">
         <MenuDropdown
           selectedItemId={method}
@@ -79,12 +80,6 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
         value={url}
         onChange={(e) => handleUrlChange(e.target.value)}
         placeholder="Enter request URL"
-        className="flex-1 px-3 text-xs font-normal"
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: '12px',
-          fontWeight: 400
-        }}
         onKeyPress={(e) => {
           if (e.key === 'Enter' && url.trim() && !isLoading) {
             onSendRequest();
@@ -98,10 +93,12 @@ const QueryBar: React.FC<QueryBarProps> = ({ item, onSendRequest, isLoading, onI
           type="button"
           onClick={onSendRequest}
           disabled={isLoading || !url.trim()}
-          className="send font-semibold text-white disabled:cursor-not-allowed flex items-center gap-2 transition-all"
+          className="send"
         >
-          {isLoading && (
-            <div className="w-2.5 h-2.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+          {isLoading ? (
+            <div className="w-2.5 h-2.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+          ) : (
+            <SendIcon />
           )}
           {isLoading ? 'Sending' : 'Send'}
         </button>

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/QueryBar/StyledWrapper.ts
@@ -1,48 +1,37 @@
 import styled from '@emotion/styled';
 
 export const StyledWrapper = styled.div`
-  gap: 0.5rem;
-  padding: 0.25rem 0.375rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.5rem;
   border: 1px solid var(--border-color);
   border-radius: var(--oc-radius);
-  transition: border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-              box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   background-color: var(--bg-primary);
 
-  &:focus-within {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--oc-brand) 10%, transparent),
-                0 1px 2px color-mix(in srgb, var(--oc-text) 5%, transparent);
-  }
-
   input {
+    flex: 1;
+    min-width: 0;
     outline: none;
-    background-color: transparent;
-    color: var(--text-primary);
-    border-radius: 0;
     border: none;
-    transition: background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    border-radius: 0;
+    background-color: transparent;
+    font-family: var(--font-mono);
+    font-weight: 400;
+    font-size: 0.75rem;
+    line-height: 1.125rem;
+    color: var(--text-primary);
 
     &::placeholder {
       color: var(--text-secondary);
       opacity: 0.6;
-      transition: opacity 0.2s ease;
-    }
-
-    &:focus::placeholder {
-      opacity: 0.45;
-    }
-
-    &:focus {
-      background-color: color-mix(in srgb, var(--oc-text) 1%, transparent);
     }
   }
 
   .method-select-wrapper {
-    position: relative;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
-    padding-left: 0.375rem;
   }
 
   .method-select {
@@ -50,38 +39,54 @@ export const StyledWrapper = styled.div`
     display: inline-flex;
     align-items: center;
     margin: 0;
+    padding: 0;
     background-color: transparent;
     border: none;
     outline: none;
     cursor: pointer;
-    padding: 0;
   }
 
-  .method-badge {
+  .method-select .method-badge {
+    font-size: 0.75rem;
+    line-height: 1.125rem;
+    letter-spacing: 0.04em;
+    min-width: unset;
     padding: 0;
   }
 
   .actions {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 0.5rem;
     flex-shrink: 0;
   }
 
   button.send {
-    height: 1.75rem;
-    padding: 0 0.875rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3125rem;
+    height: 1.5rem;
+    padding: 0 0.5625rem;
+    border: 1px solid var(--oc-brand);
     border-radius: var(--oc-radius);
-    background-color: var(--primary-color);
-    font-size: 11px;
+    background-color: var(--oc-brand);
+    color: var(--oc-background-base);
+    font-family: var(--font-sans);
     font-weight: 600;
-    letter-spacing: 0.01em;
-    transition: background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    font-size: 0.71875rem;
+    line-height: 1;
+    letter-spacing: 0;
+    white-space: nowrap;
+    cursor: pointer;
 
     &:hover:not(:disabled) {
-      background-color: color-mix(in srgb, var(--oc-brand) 85%, black);
+      opacity: 0.92;
     }
-
+    &:focus-visible {
+      outline: 2px solid var(--primary-color);
+      outline-offset: 2px;
+    }
     &:disabled {
       opacity: 0.5;
       cursor: not-allowed;

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/RequestPane.tsx
@@ -14,6 +14,7 @@ import TestsTab from '../../Common/TestsTab/TestsTab';
 import AssertsTab from '../../Common/AssertsTab/AssertsTab';
 import VariablesTab from '../../Common/VariablesTab/VariablesTab';
 import OverviewTab from '../../Common/OverviewTab/OverviewTab';
+import { StyledWrapper } from './StyledWrapper';
 import {
   getHttpParams,
   getHttpHeaders,
@@ -146,8 +147,8 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onVariablesChange={handleRequestVariablesChange}
       postResponseVars={postResponseVars}
       onPostResponseVarsChange={handlePostResponseVarsChange}
-      title="Request Variables"
-      description="These variables will be available to this request"
+      title=""
+      description="These variables will be available to this request."
     />
   );
 
@@ -155,7 +156,8 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <HeadersTab
       headers={headers}
       onHeadersChange={handleHeadersChange}
-      title="Headers"
+      title=""
+      description="Headers sent with this request."
     />
   );
 
@@ -173,7 +175,8 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       onAuthChange={() => {}} // Not used for full auth
       onItemChange={onItemChange}
       item={item}
-      title="Authentication"
+      title=""
+      description="Configures authentication for this request."
       showFullAuth={true}
     />
   );
@@ -182,7 +185,8 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <ScriptsTab
       scripts={scriptsObj}
       onScriptChange={handleScriptChange}
-      title="Scripts"
+      title=""
+      description="Pre and post-request scripts that run before and after this request is sent."
       showTests={false}
     />
   );
@@ -191,6 +195,8 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <AssertsTab
       assertions={assertions}
       onAssertionsChange={handleAssertionsChange}
+      title=""
+      description="Assertions that validate the response of this request."
     />
   );
 
@@ -198,6 +204,7 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
     <TestsTab
       scripts={scriptsObj}
       onScriptChange={handleScriptChange}
+      description="These tests run every time this request is sent."
     />
   );
 
@@ -217,73 +224,71 @@ const RequestPane: React.FC<RequestPaneProps> = ({ item, onItemChange }) => {
       id: 'overview',
       label: 'Overview',
       content: (
-        <div className="py-3">
-          <OverviewTab
-            docs={getItemDocs(item)}
-            emptyStateSubheading="This request has no docs. Add one in Bruno to introduce your API to readers: what it does, who it's for, and how to authenticate."
-          />
-        </div>
+        <OverviewTab
+          docs={getItemDocs(item)}
+          emptyStateSubheading="This request has no docs. Add one in Bruno to introduce your API to readers: what it does, who it's for, and how to authenticate."
+        />
       )
     },
     {
       id: 'params',
       label: 'Params',
       contentIndicator: params?.length || undefined, 
-      content: <div className="py-3">{renderParams()}</div> 
+      content: renderParams()
     },
     { 
       id: 'variables', 
       label: 'Variables', 
       contentIndicator: variables?.length || undefined,
-      content: <div className="py-3">{renderVariables()}</div>
+      content: renderVariables()
     },
     { 
       id: 'headers', 
       label: 'Headers', 
       contentIndicator: headers?.length || undefined, 
-      content: <div className="py-3">{renderHeaders()}</div> 
+      content: renderHeaders()
     },
     {
       id: 'body',
       label: 'Body',
       contentIndicator: hasBody ? '•' : undefined,
       rightElement: <BodyModeSelector body={body} onItemChange={onItemChange} item={item} />,
-      content: <div className="py-3">{renderBody()}</div>
+      content: renderBody()
     },
     { 
       id: 'auth', 
       label: 'Auth',
       contentIndicator: auth ? '•' : undefined,
-      content: <div className="py-3">{renderAuth()}</div> 
+      content: renderAuth()
     },
     { 
       id: 'scripts', 
       label: 'Scripts',
       contentIndicator: hasScripts ? '•' : undefined,
-      content: <div className="py-3">{renderScripts()}</div> 
+      content: renderScripts()
     },
     { 
       id: 'assertions', 
       label: 'Assertions', 
       contentIndicator: assertions?.length || undefined, 
-      content: <div className="py-3">{renderAssertions()}</div> 
+      content: renderAssertions()
     },
     { 
       id: 'tests', 
       label: 'Tests',
       contentIndicator: hasTests ? '•' : undefined,
-      content: <div className="py-3">{renderTests()}</div> 
+      content: renderTests()
     }
   ];
 
   return (
-    <div className="h-full overflow-y-auto" style={{ backgroundColor: 'var(--bg-primary)' }}>
+    <StyledWrapper>
       <Tabs
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={setActiveTab}
       />
-    </div>
+    </StyledWrapper>
   );
 };
 

--- a/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/PlaygroundView/RequestPane/StyledWrapper.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
+  height: 100%;
+  overflow-y: auto;
+  background-color: var(--bg-primary);
+
+  .description,
+  .asserts-description {
+    font-size: 0.8125rem;
+    font-weight: 400;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--text-muted);
+  }
+`;

--- a/packages/oc-docs/src/components/Playground/PlaygroundSidebar/PlaygroundSidebar.tsx
+++ b/packages/oc-docs/src/components/Playground/PlaygroundSidebar/PlaygroundSidebar.tsx
@@ -7,6 +7,7 @@ import { SettingsIcon } from '../../../assets/icons';
 import { useAutoHideScrollbar, useIsMobileDevice } from '../../../hooks';
 import type { ExampleHighlight } from '../../Docs/Sidebar/SidebarTree/SidebarTree';
 import { StyledWrapper } from './StyledWrapper';
+import Tooltip from '../../../ui/Tooltip/Tooltip';
 
 interface PlaygroundSidebarProps {
   collection: OpenCollectionCollection | null;
@@ -53,15 +54,19 @@ const PlaygroundSidebar: React.FC<PlaygroundSidebarProps> = ({
     <StyledWrapper className={isMobileDevice ? 'mobile' : undefined} data-testid={testId}>
       <div className="controls">
         <EnvSwitcher testId="playground-env-switcher" />
+        <Tooltip
+          content='Configure Environments'
+        >
         <IconButton
           className={`env-settings${environmentsActive ? ' active' : ''}`}
           label="Environment settings"
-          title="Environments"
+          aria-label='Environment settings'
           data-testid="playground-env-settings"
           onClick={onOpenEnvironments}
         >
           <SettingsIcon />
         </IconButton>
+        </Tooltip>
       </div>
 
       <div className="tree" ref={treeRef}>

--- a/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/docks/BottomSheetDock/StyledWrapper.ts
@@ -30,8 +30,8 @@ export const StyledWrapper = styled.div`
 
   .resize-handle::after {
     content: '';
-    width: 40px;
-    height: 4px;
+    width: 2.5rem;
+    height: 0.25rem;
     border-radius: 999px;
     background-color: var(--oc-border-border2);
   }

--- a/packages/oc-docs/src/components/Playground/docks/InlineDock/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/docks/InlineDock/StyledWrapper.ts
@@ -30,8 +30,8 @@ export const StyledWrapper = styled.div`
 
   .resize-handle::after {
     content: '';
-    width: 4px;
-    height: 40px;
+    width: 0.25rem;
+    height: 2.5rem;
     border-radius: 999px;
     background-color: var(--oc-border-border1);
     transition: background-color 0.15s ease;

--- a/packages/oc-docs/src/components/SplitDivider/SplitDivider.tsx
+++ b/packages/oc-docs/src/components/SplitDivider/SplitDivider.tsx
@@ -5,17 +5,20 @@ import { StyledWrapper } from './StyledWrapper';
 interface SplitDividerProps {
   orientation?: SplitOrientation;
   onPointerDown: (e: React.PointerEvent) => void;
+  active?: boolean;
   testId?: string;
 }
 
 export const SplitDivider: React.FC<SplitDividerProps> = ({
   orientation = 'horizontal',
   onPointerDown,
+  active = false,
   testId,
 }) => (
   <StyledWrapper
     className="split-divider"
     data-orientation={orientation}
+    data-active={active}
     data-testid={testId}
     onPointerDown={onPointerDown}
   />

--- a/packages/oc-docs/src/components/SplitDivider/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/SplitDivider/StyledWrapper.ts
@@ -5,11 +5,12 @@ export const StyledWrapper = styled.div`
   flex: 0 0 auto;
   align-self: stretch;
   touch-action: none;
-  background: var(--border-color);
-  transition: background-color 0.15s;
+  background: transparent;
 
-  &:hover {
-    background: var(--oc-border-border2);
+  &::after {
+    content: '';
+    position: absolute;
+    background-color: var(--oc-border-border0);
   }
 
   &::before {
@@ -18,31 +19,46 @@ export const StyledWrapper = styled.div`
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    border-radius: 0.125rem;
-    background: var(--oc-border-border2);
-    transition: background-color 0.15s;
-  }
-  &:hover::before {
-    background: var(--text-muted);
+    border-radius: 999px;
+    z-index: 1;
   }
 
   &[data-orientation='horizontal'] {
-    width: 0.3125rem;
-    margin: 0 0.625rem;
+    width: 0.75rem;
     cursor: col-resize;
+  }
+  &[data-orientation='horizontal']::after {
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0.0625rem;
   }
   &[data-orientation='horizontal']::before {
     width: 0.25rem;
-    height: 2rem;
+    height: 2.5rem;
+    background-color: var(--oc-border-border1);
   }
 
   &[data-orientation='vertical'] {
-    height: 0.3125rem;
-    margin: 0.625rem 0;
+    height: 0.75rem;
     cursor: row-resize;
   }
+  &[data-orientation='vertical']::after {
+    left: 0;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 0.0625rem;
+  }
   &[data-orientation='vertical']::before {
-    width: 2rem;
+    width: 2.5rem;
     height: 0.25rem;
+    background-color: var(--oc-border-border2);
+  }
+
+  &[data-active='true']::after,
+  &[data-active='true']::before {
+    background-color: var(--oc-border-border2);
   }
 `;

--- a/packages/oc-docs/src/components/TitleLabel/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/TitleLabel/StyledWrapper.ts
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
 
 export const StyledWrapper = styled.h2`
-  font-family: var(--font-sans);
-  font-weight: 500;
-  font-size: 0.6875rem;
-  line-height: 1;
+  font-weight: 600;
+  font-size: var(--oc-font-size-base);
   letter-spacing: 0;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 `;

--- a/packages/oc-docs/src/components/UnsupportedRequest/UnsupportedRequest.tsx
+++ b/packages/oc-docs/src/components/UnsupportedRequest/UnsupportedRequest.tsx
@@ -87,7 +87,7 @@ export const UnsupportedRequest: React.FC<UnsupportedRequestProps> = ({
         </Heading>
       )}
 
-      <RequestUrlBar className="mt-3" method={shortName} url={getRequestUrl(item)} />
+      <RequestUrlBar className={showRequestDocs ? 'mt-3' : 'mt-2'} method={shortName} url={getRequestUrl(item)} />
 
       {showRequestDocs && (
         <ViewMore collapsedHeight='4.5rem' testId="overview-markdown-view-more">

--- a/packages/oc-docs/src/hooks/useSplitPane.spec.ts
+++ b/packages/oc-docs/src/hooks/useSplitPane.spec.ts
@@ -1,23 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { computeSplitPercent } from './useSplitPane';
 
-const rect = { left: 100, top: 50, width: 400, height: 200 };
-
+// computeSplitPercent(axisSize, startPos, currentPos, startPercent)
 describe('computeSplitPercent', () => {
-  it('maps X within the container to a percentage in horizontal mode', () => {
-    expect(computeSplitPercent(rect, 300, 0, 'horizontal')).toBe(50);
-    expect(computeSplitPercent(rect, 200, 0, 'horizontal')).toBe(25);
+  it('moves the split by the pointer delta relative to the grab point', () => {
+    // 400px axis, grabbed at 50%, pointer moves +40px → +10% → 60%
+    expect(computeSplitPercent(400, 300, 340, 50)).toBe(60);
+    // pointer moves -40px → -10% → 40%
+    expect(computeSplitPercent(400, 300, 260, 50)).toBe(40);
   });
 
-  it('maps Y within the container to a percentage in vertical mode', () => {
-    expect(computeSplitPercent(rect, 0, 150, 'vertical')).toBe(50);
-    expect(computeSplitPercent(rect, 0, 100, 'vertical')).toBe(25);
+  it('keeps the split unchanged when the pointer has not moved', () => {
+    expect(computeSplitPercent(400, 300, 300, 50)).toBe(50);
   });
 
   it('clamps below 20% and above 80%', () => {
-    expect(computeSplitPercent(rect, 100, 0, 'horizontal')).toBe(20);
-    expect(computeSplitPercent(rect, 500, 0, 'horizontal')).toBe(80);
-    expect(computeSplitPercent(rect, 0, 50, 'vertical')).toBe(20);
-    expect(computeSplitPercent(rect, 0, 250, 'vertical')).toBe(80);
+    expect(computeSplitPercent(400, 300, 0, 50)).toBe(20);
+    expect(computeSplitPercent(400, 300, 800, 50)).toBe(80);
+  });
+
+  it('returns the starting percent when the axis has no size', () => {
+    expect(computeSplitPercent(0, 300, 340, 50)).toBe(50);
   });
 });

--- a/packages/oc-docs/src/hooks/useSplitPane.ts
+++ b/packages/oc-docs/src/hooks/useSplitPane.ts
@@ -4,24 +4,15 @@ const clamp = (value: number, min: number, max: number): number => Math.min(max,
 
 export type SplitOrientation = 'horizontal' | 'vertical';
 
-interface Rect {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
-
 export const computeSplitPercent = (
-  rect: Rect,
-  clientX: number,
-  clientY: number,
-  orientation: SplitOrientation
+  axisSize: number,
+  startPos: number,
+  currentPos: number,
+  startPercent: number
 ): number => {
-  const raw =
-    orientation === 'vertical'
-      ? ((clientY - rect.top) / rect.height) * 100
-      : ((clientX - rect.left) / rect.width) * 100;
-  return clamp(raw, 20, 80);
+  if (axisSize <= 0) return startPercent;
+  const delta = ((currentPos - startPos) / axisSize) * 100;
+  return clamp(startPercent + delta, 20, 80);
 };
 
 export const useSplitPane = (orientation: SplitOrientation = 'horizontal', initialSize = 50) => {
@@ -39,15 +30,20 @@ export const useSplitPane = (orientation: SplitOrientation = 'horizontal', initi
   const startResize = useCallback(
     (event: React.PointerEvent) => {
       event.preventDefault();
+      const el = containerRef.current;
+      if (!el) return;
       const handle = event.currentTarget as HTMLElement;
       const pointerId = event.pointerId;
+      const rect = el.getBoundingClientRect();
+      const axisSize = orientation === 'vertical' ? rect.height : rect.width;
+      const startPos = orientation === 'vertical' ? event.clientY : event.clientX;
+      const startPercent = sizesRef.current[orientation];
       handle.setPointerCapture?.(pointerId);
       setIsResizing(true);
 
       const onMove = (moveEvent: PointerEvent) => {
-        const el = containerRef.current;
-        if (!el) return;
-        const percent = computeSplitPercent(el.getBoundingClientRect(), moveEvent.clientX, moveEvent.clientY, orientation);
+        const currentPos = orientation === 'vertical' ? moveEvent.clientY : moveEvent.clientX;
+        const percent = computeSplitPercent(axisSize, startPos, currentPos, startPercent);
         cancelAnimationFrame(rafRef.current);
         rafRef.current = requestAnimationFrame(() => {
           sizesRef.current[orientation] = percent;

--- a/packages/oc-docs/src/runner/index.ts
+++ b/packages/oc-docs/src/runner/index.ts
@@ -6,7 +6,7 @@ import ScriptRuntime from '../scripting/runtime/script-runtime';
 import AssertRuntime, { type AssertionResult } from '../scripting/runtime/assert-runtime';
 import { getTreePathFromCollectionToItem, mergeHeaders, mergeScripts, mergeAuth, interpolateVars } from './utils';
 import { getCollectionFolderRequestVariables } from './utils/variable-merger';
-import { coerceVariableValue } from '../utils/variableDataType';
+import { coerceVariableValue, parseValueByDataType } from '../utils/variableDataType';
 import { getRequestScripts, getRequestAssertions, scriptsArrayToObject } from '../utils/schemaHelpers';
 
 export interface RunRequestOptions {
@@ -213,7 +213,11 @@ export class RequestRunner {
       const name = variable.name;
       if (name && !variable.disabled) {
         // Coerce typed values (number/boolean/object) to native, like folder/collection/request vars.
-        vars[name] = coerceVariableValue(variable.value);
+        // A secret carries its data type as a sibling `type` (value is a plain string), whereas a
+        // non-secret nests it inside the value — so coerce each from the right place.
+        vars[name] = variable.secret
+          ? parseValueByDataType(variable.value, variable.type)
+          : coerceVariableValue(variable.value);
       }
       return vars;
     }, {} as Record<string, any>);

--- a/packages/oc-docs/src/styles/index.css
+++ b/packages/oc-docs/src/styles/index.css
@@ -572,9 +572,13 @@ tr.themed-row:nth-child(even) {
 }
 
 .oc-playground ::-webkit-scrollbar-thumb {
-  background-color: var(--oc-scrollbar-color);
+  background-color: transparent;
   border: none;
   border-radius: 20px;
+}
+
+.oc-playground :hover::-webkit-scrollbar-thumb {
+  background-color: var(--oc-scrollbar-color);
 }
 
 .oc-playground ::-webkit-scrollbar-thumb:hover {

--- a/packages/oc-docs/src/ui/CodeEditor/CodeEditor.tsx
+++ b/packages/oc-docs/src/ui/CodeEditor/CodeEditor.tsx
@@ -100,7 +100,15 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
           detectIndentation: false,
           lineNumbers: 'on',
           roundedSelection: false,
-          scrollbar: { vertical: 'auto', horizontal: 'auto', verticalScrollbarSize: 5, horizontalScrollbarSize: 5 },
+          // Don't swallow the wheel when the editor has nothing (more) to scroll — let it bubble to
+          // the surrounding pane so hovering a code editor doesn't trap page/drag-select scrolling.
+          scrollbar: {
+            vertical: 'auto',
+            horizontal: 'auto',
+            verticalScrollbarSize: 5,
+            horizontalScrollbarSize: 5,
+            alwaysConsumeMouseWheel: false
+          },
           wordWrap: 'on',
           folding: true,
           showFoldingControls: 'always',

--- a/packages/oc-docs/src/ui/SecretValue/SecretValue.tsx
+++ b/packages/oc-docs/src/ui/SecretValue/SecretValue.tsx
@@ -8,6 +8,8 @@ interface SecretValueProps {
   value?: React.ReactNode;
   align?: 'between' | 'start';
   readOnly?: boolean;
+  editByDefault?: boolean;
+  multiline?: boolean;
   onChange?: (value: string) => void;
   placeholder?: string;
   className?: string;
@@ -18,6 +20,8 @@ export const SecretValue: React.FC<SecretValueProps> = ({
   value = '',
   align = 'between',
   readOnly = false,
+  editByDefault = false,
+  multiline = false,
   onChange,
   placeholder,
   className,
@@ -36,19 +40,35 @@ export const SecretValue: React.FC<SecretValueProps> = ({
       data-testid={testId}
     >
       {editable ? (
-        <input
-          className="secret-value-input"
-          type={isRevealed ? 'text' : 'password'}
-          value={typeof value === 'string' ? value : ''}
-          placeholder={placeholder}
-          readOnly={!isRevealed}
-          onChange={(e) => onChange?.(e.target.value)}
-          data-testid={testId && `${testId}-input`}
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-          spellCheck={false}
-        />
+        multiline ? (
+          <textarea
+            className={cx('secret-value-input', { 'secret-value-input--masked': !isRevealed })}
+            value={typeof value === 'string' ? value : ''}
+            placeholder={placeholder}
+            readOnly={!editByDefault && !isRevealed}
+            onChange={(e) => onChange?.(e.target.value)}
+            data-testid={testId && `${testId}-input`}
+            rows={1}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+          />
+        ) : (
+          <input
+            className="secret-value-input"
+            type={isRevealed ? 'text' : 'password'}
+            value={typeof value === 'string' ? value : ''}
+            placeholder={placeholder}
+            readOnly={!editByDefault && !isRevealed}
+            onChange={(e) => onChange?.(e.target.value)}
+            data-testid={testId && `${testId}-input`}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+          />
+        )
       ) : (
         <span className="secret-value-text" aria-hidden={!isValueVisible} data-testid={testId && `${testId}-text`}>
           {isValueVisible ? value : SECRET_MASK}

--- a/packages/oc-docs/src/ui/SecretValue/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/SecretValue/StyledWrapper.ts
@@ -29,7 +29,21 @@ export const StyledWrapper = styled.span`
     padding: 0;
   }
   .secret-value-input::placeholder {
-    color: var(--text-tertiary);
+    color: var(--oc-colors-text-subtext0);
+    opacity: 0.6;
+  }
+
+  textarea.secret-value-input {
+    resize: none;
+    field-sizing: content;
+    overflow: hidden;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.5;
+  }
+
+  .secret-value-input--masked {
+    -webkit-text-security: disc;
   }
 
   &.secret-value--readonly .secret-value-text {

--- a/packages/oc-docs/src/utils/environments.spec.ts
+++ b/packages/oc-docs/src/utils/environments.spec.ts
@@ -179,11 +179,15 @@ describe('envVariableToRow / envRowToVariable round-trip', () => {
     expect(out.value).toEqual({ type: 'number', data: '30' });
   });
 
-  it('never writes a value onto a secret with no value and keeps its type', () => {
-    const out = roundTrip({ name: 'bearer_auth_token', secret: true, type: 'string' });
-    expect(out.secret).toBe(true);
-    expect(out.type).toBe('string');
-    expect('value' in out).toBe(false);
+  it('never writes a value onto a secret with no value; normalizes string type but keeps a non-string one', () => {
+    const stringSecret = roundTrip({ name: 'bearer_auth_token', secret: true, type: 'string' });
+    expect(stringSecret.secret).toBe(true);
+    expect(stringSecret.type).toBeUndefined();
+    expect('value' in stringSecret).toBe(false);
+
+    const numberSecret = roundTrip({ name: 'retryCount', secret: true, type: 'number' });
+    expect(numberSecret.type).toBe('number');
+    expect('value' in numberSecret).toBe(false);
   });
 
   it('keeps an entered secret value so the request can resolve it on send', () => {

--- a/packages/oc-docs/src/utils/environments.ts
+++ b/packages/oc-docs/src/utils/environments.ts
@@ -3,7 +3,7 @@ import type { Variable, VariableValueType } from '@opencollection/types/common/v
 import { MANAGER_LABELS } from '../constants';
 import { getDescription, getVariableTypeLabel } from './request';
 import { isSecretVariable, unwrapVariableValue } from './variableResolution';
-import { rowToVariable } from './variableDataType';
+import { rowToVariable, toDataType } from './variableDataType';
 
 const humanizeManager = (type: string | undefined): string => {
   if (!type) return 'External';
@@ -40,7 +40,10 @@ export const envVariableToRow = (variable: Variable, index: number): EnvVarRow =
 export const envRowToVariable = (row: EnvVarRow): Variable => {
   const source = row.source ?? ({} as Variable);
   if (row.secret) {
-    const secret = { ...source, name: row.name, disabled: !row.enabled, secret: true } as Variable & { value?: string };
+    const secret = { ...source, name: row.name, disabled: !row.enabled, secret: true } as Variable & { value?: string; type?: VariableValueType };
+    const dataType = toDataType(row.dataType);
+    if (dataType !== 'string') secret.type = dataType;
+    else delete secret.type;
     if (row.value) secret.value = row.value;
     else delete secret.value;
     return secret;


### PR DESCRIPTION
* Send button text should be black
* Playground request/response pane dragbar thickness is high
* Need a little more padding above the request and response pane tabs and below the request url bar.
* Request name font size is too small - above request url
* Environments secrets right side playground  - If no value for secret, make it editable by default
* In env > secret table > Value column alignment
* Unable to scroll inside code editor of new version while able to do the same in the old version. 
* Configure environment tooltip for settings icon.

<img width="2656" height="1384" alt="image" src="https://github.com/user-attachments/assets/6afc8ddd-7a96-47ab-a9d8-04722e731ea9" />

<img width="3250" height="1564" alt="image" src="https://github.com/user-attachments/assets/c4fe04fd-cfda-46b9-82df-4276fbb273fb" />

<img width="3232" height="1544" alt="image" src="https://github.com/user-attachments/assets/cdb547f0-bf34-4580-a887-b49d8a6abf0c" />
