### PR TITLE
fix(oc-docs): polish playground example heading and add empty request state

### DIFF
--- a/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.spec.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.spec.tsx
@@ -33,4 +33,16 @@ describe('ExampleView', () => {
     expect(root.querySelector('input')).toBeNull();
     expect(root.querySelector('textarea')).toBeNull();
   });
+
+  it('renders the example-name suffix after a named example', () => {
+    const root = useRenderToDom(<ExampleView request={request} example={example} />);
+    expect(query(root, '.example-view-name-suffix').text).toContain('/ Example');
+  });
+
+  it('shows an empty message when the request has no params, headers or body', () => {
+    const root = useRenderToDom(<ExampleView request={request} example={{ ...example, request: {} }} />);
+    const empty = root.querySelector('[data-testid="example-view-request-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toContain('No headers, body, auth, variables, or scripts configured for this request.');
+  });
 });

--- a/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.tsx
@@ -111,7 +111,7 @@ export const ExampleView: React.FC<ExampleViewProps> = ({ request, example, orie
           )}
           {!hasRequestData && (
             <div className="example-view-empty" data-testid="example-view-request-empty">
-              No headers, body, auth, variables, or scripts configured for this request.
+              No header, body, params, or auth configured for the request.
             </div>
           )}
         </div>

--- a/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.tsx
+++ b/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/ExampleView.tsx
@@ -54,6 +54,8 @@ export const ExampleView: React.FC<ExampleViewProps> = ({ request, example, orie
     resHeaderRows, resBody, hasResBody
   } = model;
 
+  const hasRequestData = hasParams || reqHeaderRows.length > 0 || hasReqBody;
+
   const { size: paneSize, isResizing, containerRef, startResize } = useSplitPane(orientation);
   const paneStyle = orientation === 'vertical' ? { height: `${paneSize}%` } : { width: `${paneSize}%` };
   const statusBadge = status ? (
@@ -68,7 +70,10 @@ export const ExampleView: React.FC<ExampleViewProps> = ({ request, example, orie
   return (
     <StyledWrapper data-testid="example-view">
       <div className="example-view-head">
-        <span className="example-view-name">{example.name || 'Example'}</span>
+        <span className="example-view-name">
+          {example.name || 'Example'}
+          {example.name && <span className="example-view-name-suffix">/ Example</span>}
+        </span>
         {description && <span className="example-view-desc">{description}</span>}
       </div>
 
@@ -102,6 +107,11 @@ export const ExampleView: React.FC<ExampleViewProps> = ({ request, example, orie
             <div className="example-view-section">
               <div className="example-view-section-label">BODY</div>
               <RequestBody body={reqBody} showContentType={false} />
+            </div>
+          )}
+          {!hasRequestData && (
+            <div className="example-view-empty" data-testid="example-view-request-empty">
+              No headers, body, auth, variables, or scripts configured for this request.
             </div>
           )}
         </div>

--- a/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Playground/Content/Views/ExampleView/StyledWrapper.ts
@@ -17,12 +17,23 @@ export const StyledWrapper = styled.div`
     margin-bottom: 0.75rem;
   }
   .example-view-name {
+    font-size: 0.8125rem;
     font-weight: 600;
     color: var(--text-primary);
+  }
+  .example-view-name-suffix {
+    margin-left: 0.375rem;
+    font-weight: 400;
+    color: var(--text-tertiary);
   }
   .example-view-desc {
     color: var(--text-secondary);
     font-size: 0.8125rem;
+  }
+  .example-view-empty {
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    line-height: 1.4;
   }
   .example-view-urlbar {
     flex: 0 0 auto;

--- a/packages/oc-docs/src/components/Request/RequestParams/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Request/RequestParams/StyledWrapper.ts
@@ -3,6 +3,5 @@ import styled from '@emotion/styled';
 export const StyledWrapper = styled.div`
   .request-params-heading {
     margin-top: 0.75rem;
-    margin-left: 0.875rem;
   }
 `;

--- a/packages/oc-docs/src/components/SplitDivider/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/SplitDivider/StyledWrapper.ts
@@ -6,6 +6,7 @@ export const StyledWrapper = styled.div`
   align-self: stretch;
   touch-action: none;
   background: transparent;
+  padding: 0 1rem;
 
   &::after {
     content: '';

--- a/packages/oc-docs/src/components/SplitDivider/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/SplitDivider/StyledWrapper.ts
@@ -6,7 +6,7 @@ export const StyledWrapper = styled.div`
   align-self: stretch;
   touch-action: none;
   background: transparent;
-  padding: 0 1rem;
+  margin: 0 1rem;
 
   &::after {
     content: '';


### PR DESCRIPTION
Issue : The example heading previously rendered only the name with no `/ Example` context, and a request with no configured sections left the Request pane blank with just the "Request" title.

JIRA : BRU-3753

Polished the playground example view and add an empty-state message.

- **Heading**: render the example name followed by a muted ` / Example` suffix (e.g. `Successful login / Example`), matching the Figma design. Name size reduced to 13px (`0.8125rem`).
- **Empty state**: when an example's request has no params, headers or body, the Request pane now shows `No headers, body, auth, variables, or scripts configured for this request.` instead of an empty pane.