### PR TITLE
UI fix for heading, breadcrumb truncation and removed try button from the examples

### DIFF
--- a/packages/oc-docs/e2e/components/request/examples.component.ts
+++ b/packages/oc-docs/e2e/components/request/examples.component.ts
@@ -29,10 +29,6 @@ export class ExamplesComponent extends BaseComponent {
     await this.example(name).getByTestId('example-toggle').click();
   }
 
-  async try(name: string): Promise<void> {
-    await this.example(name).getByTestId('example-try').click();
-  }
-
   async selectRequestTab(name: string, tab: string): Promise<void> {
     await this.example(name).getByTestId(`example-request-pane-tab-${tab}`).click();
   }

--- a/packages/oc-docs/e2e/tests/sidebar/sidebar-examples.spec.ts
+++ b/packages/oc-docs/e2e/tests/sidebar/sidebar-examples.spec.ts
@@ -84,11 +84,4 @@ test.describe('Sidebar - Examples (docs)', () => {
     await expect(requestPage.examples.activeCard).toHaveCount(0);
   });
 
-  test('Try on an example opens the playground on that example, deep-linked', async ({ requestPage, playground, page }) => {
-    await requestPage.examples.try(OK_EXAMPLE);
-
-    await expect(playground.exampleView).toBeVisible();
-    await expect(page).toHaveURL(new RegExp(`[?&]pgEx=${OK_EXAMPLE_SLUG}(?:&|$)`));
-    await expect(playground.exampleViewControls).toHaveCount(0);
-  });
 });

--- a/packages/oc-docs/src/components/AppShell/AppShell.tsx
+++ b/packages/oc-docs/src/components/AppShell/AppShell.tsx
@@ -16,8 +16,6 @@ import { useAppSelector } from '../../store/hooks';
 import { selectDocsCollection } from '../../store/slices/docs';
 import { selectGitCollectionUrl } from '../../store/slices/app';
 import { useActiveResolution } from '../../routing/hooks';
-import { exampleSlugForIndex } from '../../routing/slug';
-import type { HttpRequest } from '@opencollection/types/requests/http';
 import { layoutModeForWidth } from '../../hooks/useTopbarLayout';
 import { buildFetchInBrunoUrl } from '../../utils/buildFetchInBrunoUrl';
 import { StyledWrapper } from './StyledWrapper';
@@ -58,7 +56,7 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   const { pathname } = useLocation();
 
-  const { open: playgroundOpen, dock: playgroundDock, openPlayground, setRequestExample } = usePlaygroundUrlState();
+  const { open: playgroundOpen, dock: playgroundDock, openPlayground } = usePlaygroundUrlState();
   // Bumped on every Try click so the bottom sheet re-expands from collapsed even
   // when the requested slug is unchanged (a slug change alone wouldn't signal it).
   const [playgroundOpenNonce, setPlaygroundOpenNonce] = useState(0);
@@ -88,15 +86,6 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
     openPlayground(resolution?.entry.slug);
     setPlaygroundOpenNonce((nonce) => nonce + 1);
   }, [openPlayground, resolution]);
-
-  // Open the playground on a specific example of the current request (its Try
-  // action): pgReq keeps the request, pgEx the example, so a share/reload lands
-  // on the same read-only example view.
-  const handleTryExample = (index: number) => {
-    const entry = resolution?.entry;
-    if (!entry) return;
-    setRequestExample(entry.slug, exampleSlugForIndex(entry.item as HttpRequest | null, index));
-  };
 
   return (
     <StyledWrapper
@@ -161,7 +150,7 @@ const AppShell: React.FC<AppShellProps> = ({ logo, testId = 'app-shell' }) => {
               </IconButton>
             )}
             <main className="appshell-content" ref={contentRef}>
-              <PageRouter onOpenPlayground={handleOpenPlayground} onTryExample={handleTryExample} />
+              <PageRouter onOpenPlayground={handleOpenPlayground} />
             </main>
           </div>
         </div>

--- a/packages/oc-docs/src/components/Examples/ExampleCard/ExampleCard.spec.tsx
+++ b/packages/oc-docs/src/components/Examples/ExampleCard/ExampleCard.spec.tsx
@@ -22,11 +22,10 @@ const example: HttpRequestExample = {
 };
 
 describe('ExampleCard', () => {
-  it('shows the name, status and a Try button when collapsed', () => {
-    const html = renderToStaticMarkup(<ExampleCard example={example} method="post" url="{{baseUrl}}/auth/login" onTry={() => {}} />);
+  it('shows the name and status when collapsed', () => {
+    const html = renderToStaticMarkup(<ExampleCard example={example} method="post" url="{{baseUrl}}/auth/login" />);
     expect(html).toContain('Successful login');
     expect(html).toContain('200');
-    expect(html).toContain('>Try<');
     expect(html).toContain('--oc-status-success-text');
     expect(html).not.toContain('REQUEST');
   });
@@ -43,11 +42,10 @@ describe('ExampleCard', () => {
     expect(html).toContain('B');
   });
 
-  it('falls back to a default name and omits Try without a handler', () => {
+  it('falls back to a default name when the example has none', () => {
     const html = renderToStaticMarkup(<ExampleCard example={{ response: { status: 500 } }} method="get" url="/x" />);
     expect(html).toContain('Example');
     expect(html).toContain('--oc-status-danger-text');
-    expect(html).not.toContain('>Try<');
   });
 
   it('colours the status badge by tone: danger for 4xx/5xx, info for 3xx redirects', () => {
@@ -171,13 +169,11 @@ describe('ExampleCard', () => {
         }}
         method="post"
         url="/x"
-        onTry={() => {}}
         defaultExpanded
       />
     );
     expect(html).toContain('A described example');
     expect(html).toContain('class="example-toggle"');
-    expect(html).toContain('class="example-try"');
     expect(html).toContain('aria-expanded="true"');
     // WAI-ARIA tabs.
     expect(html).toContain('role="tablist"');

--- a/packages/oc-docs/src/components/Examples/ExampleCard/ExampleCard.tsx
+++ b/packages/oc-docs/src/components/Examples/ExampleCard/ExampleCard.tsx
@@ -10,7 +10,6 @@ import { Description } from '../../Description/Description';
 import { RequestParams } from '../../Request/RequestParams/RequestParams';
 import { RequestBody } from '../../Request/RequestBody/RequestBody';
 import { Code } from '../../Code/Code';
-import { PlayIcon } from '../../../assets/icons';
 import { resolvePathAndQueryParams } from '../../../utils/pathParams';
 import { getBodyView, getDescription, headerRows } from '../../../utils/request';
 import { computeBodySize, formatBytes, responseBodyLanguage, responseBodyContentType, statusCodePhrase } from '../../../utils/exampleResponse';
@@ -21,7 +20,6 @@ interface ExampleCardProps {
   example: HttpRequestExample;
   method: string;
   url: string;
-  onTry?: () => void;
   defaultExpanded?: boolean;
   active?: boolean;
   testId?: string;
@@ -165,7 +163,7 @@ const Pane: React.FC<{
   );
 };
 
-export const ExampleCard: React.FC<ExampleCardProps> = ({ example, method, url, onTry, defaultExpanded, active, testId = 'example-card' }) => {
+export const ExampleCard: React.FC<ExampleCardProps> = ({ example, method, url, defaultExpanded, active, testId = 'example-card' }) => {
   const [expanded, setExpanded] = useState(Boolean(defaultExpanded));
   const [mounted, setMounted] = useState(Boolean(defaultExpanded));
   const detailId = useId();
@@ -284,12 +282,6 @@ export const ExampleCard: React.FC<ExampleCardProps> = ({ example, method, url, 
     </span>
   ) : undefined;
 
-  const handleTry = () => {
-    setMounted(true);
-    setExpanded(true);
-    onTry?.();
-  };
-
   return (
     <StyledWrapper
       ref={rootRef}
@@ -318,12 +310,6 @@ export const ExampleCard: React.FC<ExampleCardProps> = ({ example, method, url, 
           ) : null}
           <span className="example-name" data-testid="example-name">{name}</span>
         </button>
-        {onTry && (
-          <button type="button" className="example-try" data-testid="example-try" onClick={handleTry}>
-            <PlayIcon />
-            Try
-          </button>
-        )}
       </div>
 
       {/* Grid-rows 0fr→1fr animates the height open/close with no fixed max-height. */}

--- a/packages/oc-docs/src/components/Examples/ExampleCard/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Examples/ExampleCard/StyledWrapper.ts
@@ -79,28 +79,6 @@ export const StyledWrapper = styled.div`
     text-overflow: ellipsis;
   }
 
-  .example-try {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    height: 24px;
-    padding: 0 9px;
-    box-sizing: border-box;
-    background: var(--brand-soft);
-    color: var(--primary-text);
-    border: 1px solid var(--primary-color);
-    border-radius: var(--oc-radius);
-    font-family: var(--font-sans);
-    font-size: 11.5px;
-    font-weight: 600;
-    cursor: pointer;
-  }
-  .example-try:focus-visible {
-    outline: 2px solid var(--primary-color);
-    outline-offset: 2px;
-  }
-
   .example-detail {
     display: grid;
     grid-template-rows: 0fr;

--- a/packages/oc-docs/src/components/Examples/Examples.tsx
+++ b/packages/oc-docs/src/components/Examples/Examples.tsx
@@ -7,14 +7,12 @@ interface ExamplesProps {
   examples?: HttpRequestExample[];
   method: string;
   url: string;
-  // Open the playground on a given example (its Try action).
-  onTryExample?: (index: number) => void;
   highlightedIndex?: number;
   className?: string;
   testId?: string;
 }
 
-export const Examples: React.FC<ExamplesProps> = ({ examples, method, url, onTryExample, highlightedIndex, className, testId = 'request-examples' }) => {
+export const Examples: React.FC<ExamplesProps> = ({ examples, method, url, highlightedIndex, className, testId = 'request-examples' }) => {
   if (!examples || examples.length === 0) return null;
 
   // A highlight that no longer resolves (out of range) falls back to the
@@ -30,7 +28,6 @@ export const Examples: React.FC<ExamplesProps> = ({ examples, method, url, onTry
           example={example}
           method={method}
           url={url}
-          onTry={onTryExample ? () => onTryExample(index) : undefined}
           defaultExpanded={validHighlight ? highlightedIndex === index : index === 0}
           active={validHighlight && highlightedIndex === index}
         />

--- a/packages/oc-docs/src/components/PageRouter/PageRouter.tsx
+++ b/packages/oc-docs/src/components/PageRouter/PageRouter.tsx
@@ -24,11 +24,10 @@ import { useDocsNavigate } from '../../hooks';
 
 interface PageRouterProps {
   onOpenPlayground?: () => void;
-  onTryExample?: (index: number) => void;
   testId?: string;
 }
 
-const PageRouter: React.FC<PageRouterProps> = ({ onOpenPlayground, onTryExample, testId = 'page' }) => {
+const PageRouter: React.FC<PageRouterProps> = ({ onOpenPlayground, testId = 'page' }) => {
   const resolution = useActiveResolution();
   const model = useNavModel();
   const collection = useAppSelector(selectDocsCollection);
@@ -93,7 +92,6 @@ const PageRouter: React.FC<PageRouterProps> = ({ onOpenPlayground, onTryExample,
               onTryClick={onOpenPlayground}
               onBreadcrumbClick={goToUuid}
               highlightedExampleIndex={resolution.example?.index}
-              onTryExample={onTryExample}
             />
           </ItemVariableResolverProvider>
         ) : null;

--- a/packages/oc-docs/src/components/Topbar/Brand/Brand.tsx
+++ b/packages/oc-docs/src/components/Topbar/Brand/Brand.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import InitialsAvatar from '../../InitialsAvatar/InitialsAvatar';
+import TruncatedText from '../../TruncatedText/TruncatedText';
 import { StyledWrapper } from './StyledWrapper';
 
 export interface BrandProps {
@@ -49,9 +50,7 @@ const Brand: React.FC<BrandProps> = ({
         <span className="topbar-brand-name" data-testid={`${testId}-name`}>{PRODUCT_LABEL}</span>
       ) : (
         <span className="topbar-brand-text">
-          <span className="topbar-brand-name" data-testid={`${testId}-name`} title={collectionName}>
-            {collectionName}
-          </span>
+          <TruncatedText text={collectionName} className="topbar-brand-name" testId={`${testId}-name`} />
           {version && (
             <span className="topbar-brand-version" data-testid={`${testId}-version`}>
               {`Version : ${version}`}

--- a/packages/oc-docs/src/components/Topbar/StyledWrapper.ts
+++ b/packages/oc-docs/src/components/Topbar/StyledWrapper.ts
@@ -30,6 +30,11 @@ export const StyledWrapper = styled.header`
     gap: 0.5rem;
   }
 
+  &[data-mode='desktop'] .topbar-brand,
+  &[data-mode='tablet'] .topbar-brand {
+    max-width: 17.5rem;
+  }
+
   .topbar-menu {
     margin-left: -0.25rem;
   }

--- a/packages/oc-docs/src/components/Topbar/Topbar.tsx
+++ b/packages/oc-docs/src/components/Topbar/Topbar.tsx
@@ -43,12 +43,13 @@ export interface TopbarProps {
  *
  * No routing, data fetching, or store access — everything arrives via props.
  * Composes small reusable subcomponents and exposes slots (search,
- * env-switcher, and a trailing theme-toggle pinned right of the CTA) that
- * render whatever node is passed and degrade gracefully when empty.
+ * env-switcher, and a theme-toggle sitting just left of the trailing
+ * Open-in-Bruno CTA) that render whatever node is passed and degrade gracefully
+ * when empty.
  * Responsive layout:
- * - desktop (>=1024): full bar — brand · centered search · env switcher · Open-in-Bruno.
- * - tablet (768-1023): hamburger · brand · search icon · env switcher inline · Bruno glyph CTA.
- * - mobile (<768): hamburger · brand · search icon · env switcher · Bruno glyph CTA.
+ * - desktop (>=1024): full bar — brand · centered search · env switcher · theme toggle · Open-in-Bruno.
+ * - tablet (768-1023): hamburger · brand · search icon · env switcher inline · theme toggle · Bruno glyph CTA.
+ * - mobile (<768): hamburger · brand · search icon · env switcher · theme toggle · Bruno glyph CTA.
  * Below desktop the search collapses to an icon that expands a full-width row.
  *
  * Open-in-Bruno needs a device that can run the Bruno desktop app (capability
@@ -135,15 +136,15 @@ const Topbar: React.FC<TopbarProps> = ({
             breakpoint; the controls condense their own labels when narrow. */}
         {hasSecondary && <div className="topbar-secondary">{envSwitcherSlot}</div>}
 
-        {/* Open-in-Bruno: shown on any device that can run the Bruno desktop app
-            (capability check, hidden on large touch tablets like iPad Pro). It
-            condenses to the Bruno glyph only on mobile; tablet and up show the
-            full icon + label since there is room for it. */}
+        {themeToggleSlot}
+
+        {/* Open-in-Bruno: pinned to the right edge, after the theme toggle. Shown on any
+            device that can run the Bruno desktop app (capability check, hidden on large
+            touch tablets like iPad Pro). It condenses to the Bruno glyph only on mobile;
+            tablet and up show the full icon + label since there is room for it. */}
         {canRunBrunoApp && hasCta && (
           <OpenInBrunoButton href={openInBrunoHref} onClick={onOpenInBruno} iconOnly={isMobile} />
         )}
-
-        {themeToggleSlot}
       </div>
 
       {hasSearch && !isDesktop && searchOpen && (

--- a/packages/oc-docs/src/pages/Request/Request.tsx
+++ b/packages/oc-docs/src/pages/Request/Request.tsx
@@ -61,8 +61,6 @@ interface RequestProps {
   onBreadcrumbClick?: (uuid: string) => void;
   // Which example (by index) to flash/scroll to, derived from the route.
   highlightedExampleIndex?: number;
-  // Open the playground on a specific example (its Try action).
-  onTryExample?: (index: number) => void;
   testId?: string;
 }
 
@@ -77,7 +75,6 @@ const RequestContent: React.FC<RequestContentProps> = ({
   onTryClick,
   onBreadcrumbClick,
   highlightedExampleIndex,
-  onTryExample,
   testId = 'request-page'
 }) => {
   const md = useMarkdownRenderer();
@@ -217,7 +214,6 @@ const RequestContent: React.FC<RequestContentProps> = ({
               examples={examples}
               method={method}
               url={url}
-              onTryExample={onTryExample}
               highlightedIndex={highlightedExampleIndex}
             />
           </Section>
@@ -263,8 +259,7 @@ export const Request: React.FC<RequestProps> = ({
   collection,
   onTryClick,
   onBreadcrumbClick,
-  highlightedExampleIndex,
-  onTryExample
+  highlightedExampleIndex
 }) => {
   if (isUnsupportedRequest(item)) {
     return (
@@ -295,7 +290,6 @@ export const Request: React.FC<RequestProps> = ({
       onTryClick={onTryClick}
       onBreadcrumbClick={onBreadcrumbClick}
       highlightedExampleIndex={highlightedExampleIndex}
-      onTryExample={onTryExample}
     />
   );
 };

--- a/packages/oc-docs/src/ui/Breadcrumb/Breadcrumb.tsx
+++ b/packages/oc-docs/src/ui/Breadcrumb/Breadcrumb.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import { Tooltip } from '../Tooltip/Tooltip';
 import { StyledWrapper } from './StyledWrapper';
 
 export interface BreadcrumbSegment {
   name: string;
   uuid: string;
 }
+
+// Labels are capped to a max-width; reveal the tooltip only when one is actually
+// truncated (its rendered width exceeds the visible box).
+const isTruncated = (anchor: HTMLElement): boolean => anchor.scrollWidth > anchor.clientWidth + 1;
 
 interface BreadcrumbProps {
   segments: BreadcrumbSegment[];
@@ -24,20 +29,24 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ segments, current, onSeg
         {segments.map((segment, index) => (
           <li key={segment.uuid || index}>
             {index > 0 && <span className="breadcrumb-sep" aria-hidden="true">›</span>}
-            <button
-              type="button"
-              className="breadcrumb-link"
-              data-testid={testId ? `${testId}-segment` : undefined}
-              onClick={() => onSegmentClick?.(segment.uuid)}
-            >
-              {segment.name}
-            </button>
+            <Tooltip content={segment.name} shouldOpen={isTruncated}>
+              <button
+                type="button"
+                className="breadcrumb-link"
+                data-testid={testId ? `${testId}-segment` : undefined}
+                onClick={() => onSegmentClick?.(segment.uuid)}
+              >
+                {segment.name}
+              </button>
+            </Tooltip>
           </li>
         ))}
         {current && (
           <li key="current" aria-current="page">
             {hasSegments && <span className="breadcrumb-sep" aria-hidden="true">›</span>}
-            <span className="breadcrumb-current" data-testid={testId ? `${testId}-current` : undefined}>{current}</span>
+            <Tooltip content={current} shouldOpen={isTruncated}>
+              <span className="breadcrumb-current" data-testid={testId ? `${testId}-current` : undefined}>{current}</span>
+            </Tooltip>
           </li>
         )}
       </ol>

--- a/packages/oc-docs/src/ui/Breadcrumb/StyledWrapper.ts
+++ b/packages/oc-docs/src/ui/Breadcrumb/StyledWrapper.ts
@@ -12,7 +12,7 @@ export const StyledWrapper = styled.nav`
     font-family: var(--font-sans);
     font-weight: 400;
     font-size: 0.75rem;
-    line-height: 1;
+    line-height: 1.2;
     letter-spacing: 0;
   }
   li {
@@ -23,6 +23,14 @@ export const StyledWrapper = styled.nav`
   .breadcrumb-sep {
     font-size: 0.75rem;
     color: var(--oc-breadcrumb-color-segments, var(--text-muted));
+  }
+  .breadcrumb-link,
+  .breadcrumb-current {
+    display: block;
+    max-width: 18rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .breadcrumb-link {
     border: none;


### PR DESCRIPTION
Fixes:
1. UI fixes text truncation in the header and breadcrumbs.
2. Removed Try button from the example.

<img width="3312" height="1778" alt="image" src="https://github.com/user-attachments/assets/931b1461-8f2b-44d6-ae52-e2e7e85c80e9" />

<img width="3312" height="1774" alt="image" src="https://github.com/user-attachments/assets/752c4b4b-a04d-49bc-a278-89671afa6e4b" />
