### PR TITLE
feat/add disabled to client certs

### DIFF
--- a/packages/oc-schema/src/opencollection.schema.json
+++ b/packages/oc-schema/src/opencollection.schema.json
@@ -262,6 +262,10 @@
         "passphrase": {
           "type": "string",
           "description": "Passphrase for the private key (optional)"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Disables this client certificate"
         }
       },
       "required": ["domain", "type", "certificateFilePath", "privateKeyFilePath"],
@@ -286,6 +290,10 @@
         "passphrase": {
           "type": "string",
           "description": "Passphrase for the PKCS#12 file (optional)"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Disables this client certificate"
         }
       },
       "required": ["domain", "type", "pkcs12FilePath"],

--- a/packages/oc-schema/src/opencollection.schema.json
+++ b/packages/oc-schema/src/opencollection.schema.json
@@ -265,7 +265,7 @@
         },
         "disabled": {
           "type": "boolean",
-          "description": "Disables this client certificate"
+          "description": "Disables this client certificate (optional)"
         }
       },
       "required": ["domain", "type", "certificateFilePath", "privateKeyFilePath"],
@@ -293,7 +293,7 @@
         },
         "disabled": {
           "type": "boolean",
-          "description": "Disables this client certificate"
+          "description": "Disables this client certificate (optional)"
         }
       },
       "required": ["domain", "type", "pkcs12FilePath"],

--- a/packages/oc-spec-site/src/schema.json
+++ b/packages/oc-spec-site/src/schema.json
@@ -267,6 +267,10 @@
         "passphrase": {
           "type": "string",
           "description": "Passphrase for the private key (optional)"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Disables this client certificate"
         }
       },
       "required": ["domain", "type", "certificateFilePath", "privateKeyFilePath"],
@@ -291,6 +295,10 @@
         "passphrase": {
           "type": "string",
           "description": "Passphrase for the PKCS#12 file (optional)"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Disables this client certificate"
         }
       },
       "required": ["domain", "type", "pkcs12FilePath"],

--- a/packages/oc-spec-site/src/schema.json
+++ b/packages/oc-spec-site/src/schema.json
@@ -270,7 +270,7 @@
         },
         "disabled": {
           "type": "boolean",
-          "description": "Disables this client certificate"
+          "description": "Disables this client certificate (optional)"
         }
       },
       "required": ["domain", "type", "certificateFilePath", "privateKeyFilePath"],
@@ -298,7 +298,7 @@
         },
         "disabled": {
           "type": "boolean",
-          "description": "Disables this client certificate"
+          "description": "Disables this client certificate (optional)"
         }
       },
       "required": ["domain", "type", "pkcs12FilePath"],

--- a/packages/oc-types/src/config/certificates.ts
+++ b/packages/oc-types/src/config/certificates.ts
@@ -8,6 +8,7 @@ export interface PemCertificate {
   certificateFilePath: string;
   privateKeyFilePath: string;
   passphrase?: string;
+  disabled?: boolean;
 }
 
 export interface Pkcs12Certificate {
@@ -15,6 +16,7 @@ export interface Pkcs12Certificate {
   type: 'pkcs12';
   pkcs12FilePath: string;
   passphrase?: string;
+  disabled?: boolean;
 }
 
 export type ClientCertificate = PemCertificate | Pkcs12Certificate;


### PR DESCRIPTION
This PR adds an optional disabled flag to ClientCertificate( PemCertificate and Pkcs12Certificate) type under CollectionConfig.