### PR TITLE
feat: add gRPC lifecycle hooks to ScriptType

### DIFF
--- a/packages/oc-schema/src/opencollection.schema.json
+++ b/packages/oc-schema/src/opencollection.schema.json
@@ -2494,8 +2494,8 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["before-request", "after-response", "tests", "hooks"],
-          "description": "The lifecycle stage when this script executes"
+          "enum": ["before-request", "after-response", "tests", "hooks", "grpc:before-call-start", "grpc:after-call-end", "grpc:before-message-send", "grpc:after-message-receive"],
+          "description": "The lifecycle stage when this script executes. Stages prefixed with 'grpc:' apply only to gRPC requests"
         },
         "code": {
           "type": "string",

--- a/packages/oc-spec-site/src/schema.json
+++ b/packages/oc-spec-site/src/schema.json
@@ -2238,8 +2238,8 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["before-request", "after-response", "tests", "hooks"],
-          "description": "The lifecycle stage when this script executes"
+          "enum": ["before-request", "after-response", "tests", "hooks", "grpc:before-call-start", "grpc:after-call-end", "grpc:before-message-send", "grpc:after-message-receive"],
+          "description": "The lifecycle stage when this script executes. Stages prefixed with 'grpc:' apply only to gRPC requests"
         },
         "code": {
           "type": "string",

--- a/packages/oc-types/src/common/scripts.ts
+++ b/packages/oc-types/src/common/scripts.ts
@@ -2,7 +2,15 @@
  * Scripts executed throughout the collection lifecycle
  */
 
-export type ScriptType = 'before-request' | 'after-response' | 'tests' | 'hooks';
+export type ScriptType =
+  | 'before-request'
+  | 'after-response'
+  | 'tests'
+  | 'hooks'
+  | 'grpc:before-call-start'
+  | 'grpc:after-call-end'
+  | 'grpc:before-message-send'
+  | 'grpc:after-message-receive';
 
 export interface Script {
   type: ScriptType;


### PR DESCRIPTION
Extend ScriptType with four gRPC-only lifecycle stages: before-call-start, after-call-end, before-message-send, after-message-receive.