### PR TITLE
feat(schema): add omitHeaders to http request settings

### DIFF
--- a/packages/oc-schema/src/opencollection.schema.json
+++ b/packages/oc-schema/src/opencollection.schema.json
@@ -1759,7 +1759,7 @@
         },
         "omitHeaders": {
           "type": "array",
-          "description": "Names of default headers to omit from the request",
+          "description": "Names of headers to omit from the request",
           "items": {
             "type": "string"
           }

--- a/packages/oc-schema/src/opencollection.schema.json
+++ b/packages/oc-schema/src/opencollection.schema.json
@@ -1756,6 +1756,13 @@
             }
           ],
           "description": "Maximum number of redirects to follow"
+        },
+        "omitHeaders": {
+          "type": "array",
+          "description": "Names of default headers to omit from the request",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/packages/oc-spec-site/src/components/sections/HttpRequest.jsx
+++ b/packages/oc-spec-site/src/components/sections/HttpRequest.jsx
@@ -85,7 +85,8 @@ settings:
   timeout: 30000
   followRedirects: true
   forwardAuthorizationHeader: true
-  maxRedirects: 5`;
+  maxRedirects: 5
+  omitHeaders: []`;
 
   return (
     <section>
@@ -161,7 +162,7 @@ settings:
         <h3 className={typography.heading.h3}>Properties</h3>
         <PropertyTable 
           properties={httpRequestSettings.properties}
-          order={['encodeUrl', 'timeout', 'followRedirects', 'forwardAuthorizationHeader', 'maxRedirects']}
+          order={['encodeUrl', 'timeout', 'followRedirects', 'forwardAuthorizationHeader', 'maxRedirects', 'omitHeaders']}
           required={httpRequestSettings.required}
         />
         

--- a/packages/oc-spec-site/src/schema.json
+++ b/packages/oc-spec-site/src/schema.json
@@ -1598,6 +1598,13 @@
             }
           ],
           "description": "Maximum number of redirects to follow"
+        },
+        "omitHeaders": {
+          "type": "array",
+          "description": "Names of default headers to omit from the request",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/packages/oc-spec-site/src/schema.json
+++ b/packages/oc-spec-site/src/schema.json
@@ -1601,7 +1601,7 @@
         },
         "omitHeaders": {
           "type": "array",
-          "description": "Names of default headers to omit from the request",
+          "description": "Names of headers to omit from the request",
           "items": {
             "type": "string"
           }

--- a/packages/oc-types/src/requests/http.ts
+++ b/packages/oc-types/src/requests/http.ts
@@ -90,6 +90,7 @@ export interface HttpRequestSettings {
   followRedirects?: boolean | 'inherit';
   forwardAuthorizationHeader?: boolean | 'inherit';
   maxRedirects?: number | 'inherit';
+  omitHeaders?: string[];
 }
 
 export interface HttpRequestExampleRequest {


### PR DESCRIPTION
add `omitHeaders` to http request settings

Required for: https://github.com/usebruno/bruno/pull/8990

<img width="910" height="472" alt="image" src="https://github.com/user-attachments/assets/a39e11b2-6dab-4fda-ae7b-4ada166fd711" />

<img width="1175" height="630" alt="image" src="https://github.com/user-attachments/assets/de2ae64e-ed2e-456d-873e-0ee98016d0ba" />
